### PR TITLE
fix(ci): use GitHub App token for semantic-release

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -130,11 +130,18 @@ jobs:
       new-release-version: ${{ steps.semantic.outputs.new-release-version }}
 
     steps:
+      - name: Generate release token
+        uses: tibdex/github-app-token@v2
+        id: app-token
+        with:
+          app_id: ${{ secrets.RELEASER_APP_ID }}
+          private_key: ${{ secrets.RELEASER_APP_PRIVATE_KEY }}
+
       - name: Checkout code
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -159,7 +166,7 @@ jobs:
       - name: Run semantic-release
         id: semantic
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           npx semantic-release


### PR DESCRIPTION
## Summary
- Use SW Release Bot app token instead of GITHUB_TOKEN for semantic-release
- Allows pushing version commits to main despite required status checks
- App is configured in ruleset bypass list

## Changes
- Add `tibdex/github-app-token@v2` step to generate app token
- Use app token for checkout (sets git identity)
- Use app token as GITHUB_TOKEN for semantic-release

## Requirements
Org secrets must be configured:
- `RELEASER_APP_ID` - SW Release Bot app ID
- `RELEASER_APP_PRIVATE_KEY` - App private key

## Test plan
- [ ] Merge PR and verify semantic-release can push to main
- [ ] Verify CHANGELOG.md and package.json are updated
- [ ] Verify npm package is published with correct version