### PR TITLE
Potential fix for code scanning alert no. 24: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -1,5 +1,8 @@
 name: PR Test and Validation
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches: [ main ]


### PR DESCRIPTION
Potential fix for [https://github.com/structured-world/gitlab-mcp/security/code-scanning/24](https://github.com/structured-world/gitlab-mcp/security/code-scanning/24)

In general, to fix this issue you add an explicit `permissions:` section either at the top level of the workflow (to affect all jobs) or within individual jobs (to tailor permissions per job). The permissions should be set to the minimal scopes required; for this workflow, the jobs only need to read repository contents for `actions/checkout` and for running tests/builds, so `contents: read` is sufficient.

The best fix without changing existing functionality is to introduce a single root-level `permissions:` block right after the `name:` (or before `on:`) in `.github/workflows/pr-test.yml`. This will apply to all jobs (`test`, `integration-test`, `code-quality`, `coverage`) that do not override it and will restrict the GITHUB_TOKEN to read-only access to repository contents. No steps in the provided snippet perform write operations to GitHub (such as pushing commits, updating statuses via the API, or modifying issues/PRs), so adding `contents: read` will not break existing behavior. No additional imports, methods, or definitions are needed, since this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
