### PR TITLE
feat(search): add global search entity with CQRS browse_search tool

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -131,6 +131,7 @@ export const USE_INTEGRATIONS = process.env.USE_INTEGRATIONS !== "false";
 export const USE_RELEASES = process.env.USE_RELEASES !== "false";
 export const USE_REFS = process.env.USE_REFS !== "false";
 export const USE_MEMBERS = process.env.USE_MEMBERS !== "false";
+export const USE_SEARCH = process.env.USE_SEARCH !== "false";
 export const HOST = process.env.HOST ?? "0.0.0.0";
 export const PORT = process.env.PORT ?? 3002;
 

--- a/src/entities/index.ts
+++ b/src/entities/index.ts
@@ -12,5 +12,6 @@ export * from "./webhooks";
 export * from "./releases";
 export * from "./refs";
 export * from "./members";
+export * from "./search";
 
 // All entities now use the registry pattern with embedded handlers

--- a/src/entities/search/index.ts
+++ b/src/entities/search/index.ts
@@ -1,0 +1,8 @@
+// Search entity - GitLab global and scoped search
+export * from "./schema-readonly";
+export {
+  searchToolRegistry,
+  getSearchReadOnlyToolNames,
+  getSearchToolDefinitions,
+  getFilteredSearchTools,
+} from "./registry";

--- a/src/entities/search/registry.ts
+++ b/src/entities/search/registry.ts
@@ -1,0 +1,127 @@
+import * as z from "zod";
+import { BrowseSearchSchema } from "./schema-readonly";
+import { ToolRegistry, EnhancedToolDefinition } from "../../types";
+import { isActionDenied } from "../../config";
+import { gitlab, paths, toQuery } from "../../utils/gitlab-api";
+
+/**
+ * Search tools registry - 1 read-only CQRS tool
+ *
+ * browse_search (Query): global, project, group
+ *
+ * Search is read-only by design - no manage_search tool needed.
+ */
+export const searchToolRegistry: ToolRegistry = new Map<string, EnhancedToolDefinition>([
+  // ============================================================================
+  // browse_search - CQRS Query Tool (discriminated union schema)
+  // TypeScript automatically narrows types in each switch case
+  // ============================================================================
+  [
+    "browse_search",
+    {
+      name: "browse_search",
+      description:
+        'SEARCH GitLab resources. Actions: "global" searches entire instance, "project" searches within a project, "group" searches within a group. Scopes: projects, issues, merge_requests, milestones, users, groups, blobs (code), commits, wiki_blobs, notes.',
+      inputSchema: z.toJSONSchema(BrowseSearchSchema),
+      gate: { envVar: "USE_SEARCH", defaultValue: true },
+      handler: async (args: unknown): Promise<unknown> => {
+        const input = BrowseSearchSchema.parse(args);
+
+        // Runtime validation: reject denied actions even if they bypass schema filtering
+        if (isActionDenied("browse_search", input.action)) {
+          throw new Error(`Action '${input.action}' is not allowed for browse_search tool`);
+        }
+
+        switch (input.action) {
+          case "global": {
+            // TypeScript knows: input has scope, search, and optional filters
+            const { scope, ...params } = input;
+
+            // Build query params excluding action (not an API parameter)
+            const query = toQuery(params, ["action"]);
+
+            // Global search endpoint
+            const results = await gitlab.get<unknown[]>("search", {
+              query: { ...query, scope },
+            });
+
+            return {
+              scope,
+              count: results.length,
+              results,
+            };
+          }
+
+          case "project": {
+            // TypeScript knows: input has project_id, scope, search, and optional filters
+            const { project_id, scope, ref, ...params } = input;
+
+            // Build query params excluding action (project_id, scope, ref are already destructured)
+            const query = toQuery(params, ["action"]);
+
+            // Project-scoped search endpoint
+            const results = await gitlab.get<unknown[]>(`${paths.project(project_id)}/search`, {
+              query: { ...query, scope, ...(ref && { ref }) },
+            });
+
+            return {
+              project_id,
+              scope,
+              count: results.length,
+              results,
+            };
+          }
+
+          case "group": {
+            // TypeScript knows: input has group_id, scope, search, and optional filters
+            const { group_id, scope, ...params } = input;
+
+            // Build query params excluding action (group_id, scope are already destructured)
+            const query = toQuery(params, ["action"]);
+
+            // Group-scoped search endpoint
+            const results = await gitlab.get<unknown[]>(`${paths.group(group_id)}/search`, {
+              query: { ...query, scope },
+            });
+
+            return {
+              group_id,
+              scope,
+              count: results.length,
+              results,
+            };
+          }
+
+          /* istanbul ignore next -- unreachable with Zod discriminatedUnion */
+          default:
+            throw new Error(`Unknown action: ${(input as { action: string }).action}`);
+        }
+      },
+    },
+  ],
+]);
+
+/**
+ * Get read-only tool names from the registry
+ * Search is entirely read-only, so all tools are read-only
+ */
+export function getSearchReadOnlyToolNames(): string[] {
+  return ["browse_search"];
+}
+
+/**
+ * Get all tool definitions from the registry
+ */
+export function getSearchToolDefinitions(): EnhancedToolDefinition[] {
+  return Array.from(searchToolRegistry.values());
+}
+
+/**
+ * Get filtered tools based on read-only mode
+ * Since search is read-only, this always returns all tools
+ */
+export function getFilteredSearchTools(readOnlyMode: boolean = false): EnhancedToolDefinition[] {
+  // Search is always read-only, so readOnlyMode doesn't affect filtering
+  void readOnlyMode;
+  return getSearchToolDefinitions();
+}

--- a/src/entities/search/schema-readonly.ts
+++ b/src/entities/search/schema-readonly.ts
@@ -1,0 +1,96 @@
+import { z } from "zod";
+import { PaginationOptionsSchema } from "../shared";
+import { requiredId } from "../utils";
+
+// ============================================================================
+// Search scope enum - GitLab API search scopes
+// ============================================================================
+
+export const SearchScopeSchema = z
+  .enum([
+    "projects",
+    "issues",
+    "merge_requests",
+    "milestones",
+    "snippet_titles",
+    "users",
+    "groups",
+    "blobs",
+    "commits",
+    "wiki_blobs",
+    "notes",
+  ])
+  .describe("Search scope determining what type of resources to search");
+
+// ============================================================================
+// Base search parameters shared across all scopes
+// ============================================================================
+
+const BaseSearchParams = z.object({
+  search: z.string().min(1).describe("Search query string (minimum 1 character)"),
+  state: z
+    .enum(["opened", "closed", "merged", "all"])
+    .optional()
+    .describe("Filter by state (for issues and merge_requests scopes)"),
+  confidential: z
+    .boolean()
+    .optional()
+    .describe("Filter by confidentiality (for issues scope, Premium only)"),
+  order_by: z.enum(["created_at", "updated_at"]).optional().describe("Sort results by field"),
+  sort: z.enum(["asc", "desc"]).optional().describe("Sort direction"),
+});
+
+// ============================================================================
+// browse_search - CQRS Query Tool (discriminated union schema)
+// Actions: global, project, group
+// Uses z.discriminatedUnion() for type-safe action handling.
+// ============================================================================
+
+// --- Action: global ---
+const GlobalSearchSchema = z
+  .object({
+    action: z.literal("global").describe("Search across entire GitLab instance"),
+    scope: SearchScopeSchema,
+  })
+  .merge(BaseSearchParams)
+  .merge(PaginationOptionsSchema);
+
+// --- Action: project ---
+const ProjectSearchSchema = z
+  .object({
+    action: z.literal("project").describe("Search within a specific project"),
+    project_id: requiredId.describe(
+      "Project ID or URL-encoded path (e.g., 'group/project' or '123')"
+    ),
+    scope: SearchScopeSchema,
+    ref: z.string().optional().describe("Branch/tag reference for code search (blobs, commits)"),
+  })
+  .merge(BaseSearchParams)
+  .merge(PaginationOptionsSchema);
+
+// --- Action: group ---
+const GroupSearchSchema = z
+  .object({
+    action: z.literal("group").describe("Search within a specific group and its subgroups"),
+    group_id: requiredId.describe("Group ID or URL-encoded path (e.g., 'my-group' or '123')"),
+    scope: SearchScopeSchema,
+  })
+  .merge(BaseSearchParams)
+  .merge(PaginationOptionsSchema);
+
+// --- Discriminated union combining all actions ---
+export const BrowseSearchSchema = z.discriminatedUnion("action", [
+  GlobalSearchSchema,
+  ProjectSearchSchema,
+  GroupSearchSchema,
+]);
+
+// ============================================================================
+// Type exports
+// ============================================================================
+
+export type SearchScope = z.infer<typeof SearchScopeSchema>;
+export type BrowseSearchInput = z.infer<typeof BrowseSearchSchema>;
+export type GlobalSearchInput = z.infer<typeof GlobalSearchSchema>;
+export type ProjectSearchInput = z.infer<typeof ProjectSearchSchema>;
+export type GroupSearchInput = z.infer<typeof GroupSearchSchema>;

--- a/src/registry-manager.ts
+++ b/src/registry-manager.ts
@@ -29,6 +29,7 @@ import {
 import { releasesToolRegistry, getReleasesReadOnlyToolNames } from "./entities/releases/registry";
 import { refsToolRegistry, getRefsReadOnlyToolNames } from "./entities/refs/registry";
 import { membersToolRegistry, getMembersReadOnlyToolNames } from "./entities/members/registry";
+import { searchToolRegistry, getSearchReadOnlyToolNames } from "./entities/search/registry";
 import {
   GITLAB_READ_ONLY_MODE,
   GITLAB_DENIED_TOOLS_REGEX,
@@ -46,6 +47,7 @@ import {
   USE_RELEASES,
   USE_REFS,
   USE_MEMBERS,
+  USE_SEARCH,
   getToolDescriptionOverrides,
 } from "./config";
 import { ToolAvailability } from "./services/ToolAvailability";
@@ -152,6 +154,10 @@ class RegistryManager {
       this.registries.set("members", membersToolRegistry);
     }
 
+    if (USE_SEARCH) {
+      this.registries.set("search", searchToolRegistry);
+    }
+
     // All entity registries have been migrated to the new pattern!
   }
 
@@ -233,6 +239,10 @@ class RegistryManager {
 
     if (USE_MEMBERS) {
       readOnlyTools.push(...getMembersReadOnlyToolNames());
+    }
+
+    if (USE_SEARCH) {
+      readOnlyTools.push(...getSearchReadOnlyToolNames());
     }
 
     return readOnlyTools;
@@ -394,6 +404,7 @@ class RegistryManager {
     const useReleases = process.env.USE_RELEASES !== "false";
     const useRefs = process.env.USE_REFS !== "false";
     const useMembers = process.env.USE_MEMBERS !== "false";
+    const useSearch = process.env.USE_SEARCH !== "false";
 
     // Build registries map based on dynamic feature flags
     const registriesToUse = new Map<string, ToolRegistry>();
@@ -416,6 +427,7 @@ class RegistryManager {
     if (useReleases) registriesToUse.set("releases", releasesToolRegistry);
     if (useRefs) registriesToUse.set("refs", refsToolRegistry);
     if (useMembers) registriesToUse.set("members", membersToolRegistry);
+    if (useSearch) registriesToUse.set("search", searchToolRegistry);
 
     // Dynamically load description overrides
     const descOverrides = getToolDescriptionOverrides();
@@ -483,6 +495,7 @@ class RegistryManager {
       releasesToolRegistry,
       refsToolRegistry,
       membersToolRegistry,
+      searchToolRegistry,
     ];
 
     for (const registry of allRegistries) {

--- a/src/services/ToolAvailability.ts
+++ b/src/services/ToolAvailability.ts
@@ -681,6 +681,16 @@ export class ToolAvailability {
         update_group: { tier: "free", minVersion: 8.0, notes: "member_role_id requires Ultimate" },
       },
     },
+
+    // Search (read-only)
+    browse_search: {
+      default: { tier: "free", minVersion: 8.0 },
+      actions: {
+        global: { tier: "free", minVersion: 8.0, notes: "Global search across GitLab instance" },
+        project: { tier: "free", minVersion: 8.0, notes: "Project-scoped search" },
+        group: { tier: "free", minVersion: 10.5, notes: "Group-scoped search" },
+      },
+    },
   };
 
   /**

--- a/tests/unit/entities/search/registry.test.ts
+++ b/tests/unit/entities/search/registry.test.ts
@@ -1,0 +1,400 @@
+import {
+  searchToolRegistry,
+  getSearchReadOnlyToolNames,
+  getSearchToolDefinitions,
+  getFilteredSearchTools,
+} from "../../../../src/entities/search/registry";
+// Import from index.ts to cover re-exports
+import {
+  BrowseSearchSchema,
+  searchToolRegistry as indexSearchToolRegistry,
+} from "../../../../src/entities/search";
+import { gitlab } from "../../../../src/utils/gitlab-api";
+import { isActionDenied } from "../../../../src/config";
+
+// Mock the GitLab API module
+jest.mock("../../../../src/utils/gitlab-api", () => ({
+  gitlab: {
+    get: jest.fn(),
+  },
+  paths: {
+    project: (id: string | number) =>
+      `projects/${typeof id === "number" ? id : encodeURIComponent(String(id))}`,
+    group: (id: string | number) =>
+      `groups/${typeof id === "number" ? id : encodeURIComponent(String(id))}`,
+  },
+  toQuery: jest.fn((params, exclude = []) => {
+    const result: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(params)) {
+      if (value !== undefined && !exclude.includes(key)) {
+        result[key] = value;
+      }
+    }
+    return result;
+  }),
+}));
+
+// Mock config module
+jest.mock("../../../../src/config", () => ({
+  isActionDenied: jest.fn(() => false),
+}));
+
+const mockGitlab = gitlab as jest.Mocked<typeof gitlab>;
+const mockIsActionDenied = isActionDenied as jest.MockedFunction<typeof isActionDenied>;
+
+describe("Search Tool Registry", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("browse_search tool", () => {
+    const browseSearchTool = searchToolRegistry.get("browse_search");
+
+    it("should be registered in the registry", () => {
+      expect(browseSearchTool).toBeDefined();
+      expect(browseSearchTool?.name).toBe("browse_search");
+    });
+
+    it("should have proper description", () => {
+      expect(browseSearchTool?.description).toContain("SEARCH GitLab resources");
+      expect(browseSearchTool?.description).toContain("global");
+      expect(browseSearchTool?.description).toContain("project");
+      expect(browseSearchTool?.description).toContain("group");
+    });
+
+    describe("global action", () => {
+      it("should perform global search with minimal params", async () => {
+        const mockResults = [
+          { id: 1, name: "project-one" },
+          { id: 2, name: "project-two" },
+        ];
+        mockGitlab.get.mockResolvedValue(mockResults);
+
+        const result = await browseSearchTool?.handler({
+          action: "global",
+          scope: "projects",
+          search: "test",
+        });
+
+        expect(mockGitlab.get).toHaveBeenCalledWith("search", expect.any(Object));
+        expect(result).toEqual({
+          scope: "projects",
+          count: 2,
+          results: mockResults,
+        });
+      });
+
+      it("should pass state filter to API", async () => {
+        mockGitlab.get.mockResolvedValue([]);
+
+        await browseSearchTool?.handler({
+          action: "global",
+          scope: "issues",
+          search: "bug",
+          state: "opened",
+        });
+
+        expect(mockGitlab.get).toHaveBeenCalledWith(
+          "search",
+          expect.objectContaining({
+            query: expect.objectContaining({
+              scope: "issues",
+              search: "bug",
+              state: "opened",
+            }),
+          })
+        );
+      });
+
+      it("should pass order_by and sort to API", async () => {
+        mockGitlab.get.mockResolvedValue([]);
+
+        await browseSearchTool?.handler({
+          action: "global",
+          scope: "merge_requests",
+          search: "feature",
+          order_by: "updated_at",
+          sort: "desc",
+        });
+
+        expect(mockGitlab.get).toHaveBeenCalledWith(
+          "search",
+          expect.objectContaining({
+            query: expect.objectContaining({
+              order_by: "updated_at",
+              sort: "desc",
+            }),
+          })
+        );
+      });
+
+      it("should pass pagination options to API", async () => {
+        mockGitlab.get.mockResolvedValue([]);
+
+        await browseSearchTool?.handler({
+          action: "global",
+          scope: "users",
+          search: "john",
+          per_page: 50,
+          page: 2,
+        });
+
+        expect(mockGitlab.get).toHaveBeenCalledWith(
+          "search",
+          expect.objectContaining({
+            query: expect.objectContaining({
+              per_page: 50,
+              page: 2,
+            }),
+          })
+        );
+      });
+    });
+
+    describe("project action", () => {
+      it("should perform project-scoped search", async () => {
+        const mockResults = [{ id: 1, path: "src/main.ts", data: "function test()" }];
+        mockGitlab.get.mockResolvedValue(mockResults);
+
+        const result = await browseSearchTool?.handler({
+          action: "project",
+          project_id: "my-group/my-project",
+          scope: "blobs",
+          search: "function",
+        });
+
+        expect(mockGitlab.get).toHaveBeenCalledWith(
+          "projects/my-group%2Fmy-project/search",
+          expect.any(Object)
+        );
+        expect(result).toEqual({
+          project_id: "my-group/my-project",
+          scope: "blobs",
+          count: 1,
+          results: mockResults,
+        });
+      });
+
+      it("should handle numeric project_id", async () => {
+        mockGitlab.get.mockResolvedValue([]);
+
+        await browseSearchTool?.handler({
+          action: "project",
+          project_id: "123",
+          scope: "commits",
+          search: "fix",
+        });
+
+        expect(mockGitlab.get).toHaveBeenCalledWith("projects/123/search", expect.any(Object));
+      });
+
+      it("should pass ref parameter for code search", async () => {
+        mockGitlab.get.mockResolvedValue([]);
+
+        await browseSearchTool?.handler({
+          action: "project",
+          project_id: "test-project",
+          scope: "blobs",
+          search: "TODO",
+          ref: "develop",
+        });
+
+        expect(mockGitlab.get).toHaveBeenCalledWith(
+          "projects/test-project/search",
+          expect.objectContaining({
+            query: expect.objectContaining({
+              ref: "develop",
+            }),
+          })
+        );
+      });
+
+      it("should handle all search scopes", async () => {
+        const scopes = ["blobs", "commits", "issues", "merge_requests", "notes", "wiki_blobs"];
+
+        for (const scope of scopes) {
+          mockGitlab.get.mockResolvedValue([]);
+
+          await browseSearchTool?.handler({
+            action: "project",
+            project_id: "test",
+            scope,
+            search: "query",
+          });
+
+          expect(mockGitlab.get).toHaveBeenCalledWith(
+            "projects/test/search",
+            expect.objectContaining({
+              query: expect.objectContaining({ scope }),
+            })
+          );
+        }
+      });
+    });
+
+    describe("group action", () => {
+      it("should perform group-scoped search", async () => {
+        const mockResults = [{ id: 1, title: "Important Issue", iid: 42 }];
+        mockGitlab.get.mockResolvedValue(mockResults);
+
+        const result = await browseSearchTool?.handler({
+          action: "group",
+          group_id: "my-group",
+          scope: "issues",
+          search: "important",
+        });
+
+        expect(mockGitlab.get).toHaveBeenCalledWith("groups/my-group/search", expect.any(Object));
+        expect(result).toEqual({
+          group_id: "my-group",
+          scope: "issues",
+          count: 1,
+          results: mockResults,
+        });
+      });
+
+      it("should handle numeric group_id", async () => {
+        mockGitlab.get.mockResolvedValue([]);
+
+        await browseSearchTool?.handler({
+          action: "group",
+          group_id: "456",
+          scope: "merge_requests",
+          search: "refactor",
+        });
+
+        expect(mockGitlab.get).toHaveBeenCalledWith("groups/456/search", expect.any(Object));
+      });
+
+      it("should pass state filter for MR search", async () => {
+        mockGitlab.get.mockResolvedValue([]);
+
+        await browseSearchTool?.handler({
+          action: "group",
+          group_id: "test-group",
+          scope: "merge_requests",
+          search: "fix",
+          state: "merged",
+        });
+
+        expect(mockGitlab.get).toHaveBeenCalledWith(
+          "groups/test-group/search",
+          expect.objectContaining({
+            query: expect.objectContaining({
+              state: "merged",
+            }),
+          })
+        );
+      });
+
+      it("should pass pagination and sorting options", async () => {
+        mockGitlab.get.mockResolvedValue([]);
+
+        await browseSearchTool?.handler({
+          action: "group",
+          group_id: "test-group",
+          scope: "issues",
+          search: "feature",
+          order_by: "created_at",
+          sort: "asc",
+          per_page: 25,
+          page: 3,
+        });
+
+        expect(mockGitlab.get).toHaveBeenCalledWith(
+          "groups/test-group/search",
+          expect.objectContaining({
+            query: expect.objectContaining({
+              order_by: "created_at",
+              sort: "asc",
+              per_page: 25,
+              page: 3,
+            }),
+          })
+        );
+      });
+    });
+
+    describe("action denial", () => {
+      it("should throw error when action is denied", async () => {
+        mockIsActionDenied.mockReturnValue(true);
+
+        await expect(
+          browseSearchTool?.handler({
+            action: "global",
+            scope: "projects",
+            search: "test",
+          })
+        ).rejects.toThrow("Action 'global' is not allowed for browse_search tool");
+
+        expect(mockIsActionDenied).toHaveBeenCalledWith("browse_search", "global");
+      });
+
+      it("should check action denial for each action type", async () => {
+        mockIsActionDenied.mockReturnValue(false);
+        mockGitlab.get.mockResolvedValue([]);
+
+        await browseSearchTool?.handler({
+          action: "project",
+          project_id: "test",
+          scope: "blobs",
+          search: "query",
+        });
+        expect(mockIsActionDenied).toHaveBeenCalledWith("browse_search", "project");
+
+        await browseSearchTool?.handler({
+          action: "group",
+          group_id: "test",
+          scope: "issues",
+          search: "query",
+        });
+        expect(mockIsActionDenied).toHaveBeenCalledWith("browse_search", "group");
+      });
+    });
+  });
+
+  describe("Helper functions", () => {
+    describe("getSearchReadOnlyToolNames", () => {
+      it("should return browse_search as read-only", () => {
+        const readOnlyTools = getSearchReadOnlyToolNames();
+        expect(readOnlyTools).toContain("browse_search");
+        expect(readOnlyTools).toHaveLength(1);
+      });
+    });
+
+    describe("getSearchToolDefinitions", () => {
+      it("should return all tool definitions", () => {
+        const definitions = getSearchToolDefinitions();
+        expect(definitions).toHaveLength(1);
+        expect(definitions[0].name).toBe("browse_search");
+      });
+    });
+
+    describe("getFilteredSearchTools", () => {
+      it("should return all tools regardless of readOnlyMode", () => {
+        const withReadOnly = getFilteredSearchTools(true);
+        const withoutReadOnly = getFilteredSearchTools(false);
+
+        expect(withReadOnly).toHaveLength(1);
+        expect(withoutReadOnly).toHaveLength(1);
+        expect(withReadOnly[0].name).toBe("browse_search");
+        expect(withoutReadOnly[0].name).toBe("browse_search");
+      });
+
+      it("should default to non-read-only mode", () => {
+        const defaultMode = getFilteredSearchTools();
+        expect(defaultMode).toHaveLength(1);
+      });
+    });
+  });
+
+  describe("Index re-exports", () => {
+    it("should re-export searchToolRegistry from index", () => {
+      expect(indexSearchToolRegistry).toBe(searchToolRegistry);
+    });
+
+    it("should re-export BrowseSearchSchema from index", () => {
+      expect(BrowseSearchSchema).toBeDefined();
+    });
+  });
+});

--- a/tests/unit/entities/search/schema-readonly.test.ts
+++ b/tests/unit/entities/search/schema-readonly.test.ts
@@ -1,0 +1,413 @@
+import {
+  BrowseSearchSchema,
+  SearchScopeSchema,
+} from "../../../../src/entities/search/schema-readonly";
+
+describe("BrowseSearchSchema - Discriminated Union", () => {
+  describe("global action", () => {
+    describe("Valid inputs", () => {
+      it("should accept minimal valid input", () => {
+        const result = BrowseSearchSchema.safeParse({
+          action: "global",
+          scope: "projects",
+          search: "test query",
+        });
+        expect(result.success).toBe(true);
+        if (result.success && result.data.action === "global") {
+          expect(result.data.scope).toBe("projects");
+          expect(result.data.search).toBe("test query");
+        }
+      });
+
+      it("should accept all valid scope values", () => {
+        const scopes = [
+          "projects",
+          "issues",
+          "merge_requests",
+          "milestones",
+          "snippet_titles",
+          "users",
+          "groups",
+          "blobs",
+          "commits",
+          "wiki_blobs",
+          "notes",
+        ] as const;
+
+        for (const scope of scopes) {
+          const result = BrowseSearchSchema.safeParse({
+            action: "global",
+            scope,
+            search: "test",
+          });
+          expect(result.success).toBe(true);
+        }
+      });
+
+      it("should accept state filter for issues scope", () => {
+        const result = BrowseSearchSchema.safeParse({
+          action: "global",
+          scope: "issues",
+          search: "bug",
+          state: "opened",
+        });
+        expect(result.success).toBe(true);
+        if (result.success && result.data.action === "global") {
+          expect(result.data.state).toBe("opened");
+        }
+      });
+
+      it("should accept all state values", () => {
+        const states = ["opened", "closed", "merged", "all"] as const;
+        for (const state of states) {
+          const result = BrowseSearchSchema.safeParse({
+            action: "global",
+            scope: "merge_requests",
+            search: "feature",
+            state,
+          });
+          expect(result.success).toBe(true);
+        }
+      });
+
+      it("should accept confidential filter", () => {
+        const result = BrowseSearchSchema.safeParse({
+          action: "global",
+          scope: "issues",
+          search: "secret",
+          confidential: true,
+        });
+        expect(result.success).toBe(true);
+        if (result.success && result.data.action === "global") {
+          expect(result.data.confidential).toBe(true);
+        }
+      });
+
+      it("should accept order_by and sort options", () => {
+        const result = BrowseSearchSchema.safeParse({
+          action: "global",
+          scope: "issues",
+          search: "test",
+          order_by: "updated_at",
+          sort: "desc",
+        });
+        expect(result.success).toBe(true);
+        if (result.success && result.data.action === "global") {
+          expect(result.data.order_by).toBe("updated_at");
+          expect(result.data.sort).toBe("desc");
+        }
+      });
+
+      it("should accept pagination options", () => {
+        const result = BrowseSearchSchema.safeParse({
+          action: "global",
+          scope: "projects",
+          search: "test",
+          per_page: 50,
+          page: 2,
+        });
+        expect(result.success).toBe(true);
+        if (result.success && result.data.action === "global") {
+          expect(result.data.per_page).toBe(50);
+          expect(result.data.page).toBe(2);
+        }
+      });
+    });
+
+    describe("Invalid inputs", () => {
+      it("should reject missing search", () => {
+        const result = BrowseSearchSchema.safeParse({
+          action: "global",
+          scope: "projects",
+        });
+        expect(result.success).toBe(false);
+      });
+
+      it("should reject empty search", () => {
+        const result = BrowseSearchSchema.safeParse({
+          action: "global",
+          scope: "projects",
+          search: "",
+        });
+        expect(result.success).toBe(false);
+      });
+
+      it("should reject missing scope", () => {
+        const result = BrowseSearchSchema.safeParse({
+          action: "global",
+          search: "test",
+        });
+        expect(result.success).toBe(false);
+      });
+
+      it("should reject invalid scope", () => {
+        const result = BrowseSearchSchema.safeParse({
+          action: "global",
+          scope: "invalid_scope",
+          search: "test",
+        });
+        expect(result.success).toBe(false);
+      });
+
+      it("should reject invalid state value", () => {
+        const result = BrowseSearchSchema.safeParse({
+          action: "global",
+          scope: "issues",
+          search: "test",
+          state: "invalid",
+        });
+        expect(result.success).toBe(false);
+      });
+
+      it("should reject per_page over 100", () => {
+        const result = BrowseSearchSchema.safeParse({
+          action: "global",
+          scope: "projects",
+          search: "test",
+          per_page: 101,
+        });
+        expect(result.success).toBe(false);
+      });
+    });
+  });
+
+  describe("project action", () => {
+    describe("Valid inputs", () => {
+      it("should accept minimal valid input", () => {
+        const result = BrowseSearchSchema.safeParse({
+          action: "project",
+          project_id: "my-group/my-project",
+          scope: "blobs",
+          search: "function",
+        });
+        expect(result.success).toBe(true);
+        if (result.success && result.data.action === "project") {
+          expect(result.data.project_id).toBe("my-group/my-project");
+          expect(result.data.scope).toBe("blobs");
+          expect(result.data.search).toBe("function");
+        }
+      });
+
+      it("should accept numeric project_id", () => {
+        const result = BrowseSearchSchema.safeParse({
+          action: "project",
+          project_id: 123,
+          scope: "commits",
+          search: "fix",
+        });
+        expect(result.success).toBe(true);
+        if (result.success && result.data.action === "project") {
+          expect(result.data.project_id).toBe("123");
+        }
+      });
+
+      it("should accept ref parameter for code search", () => {
+        const result = BrowseSearchSchema.safeParse({
+          action: "project",
+          project_id: "test-project",
+          scope: "blobs",
+          search: "TODO",
+          ref: "develop",
+        });
+        expect(result.success).toBe(true);
+        if (result.success && result.data.action === "project") {
+          expect(result.data.ref).toBe("develop");
+        }
+      });
+
+      it("should accept all optional parameters", () => {
+        const result = BrowseSearchSchema.safeParse({
+          action: "project",
+          project_id: "test-project",
+          scope: "issues",
+          search: "bug",
+          ref: "main",
+          state: "opened",
+          confidential: false,
+          order_by: "created_at",
+          sort: "asc",
+          per_page: 25,
+          page: 1,
+        });
+        expect(result.success).toBe(true);
+      });
+    });
+
+    describe("Invalid inputs", () => {
+      it("should reject missing project_id", () => {
+        const result = BrowseSearchSchema.safeParse({
+          action: "project",
+          scope: "blobs",
+          search: "test",
+        });
+        expect(result.success).toBe(false);
+      });
+
+      it("should reject empty project_id", () => {
+        const result = BrowseSearchSchema.safeParse({
+          action: "project",
+          project_id: "",
+          scope: "blobs",
+          search: "test",
+        });
+        expect(result.success).toBe(false);
+      });
+    });
+  });
+
+  describe("group action", () => {
+    describe("Valid inputs", () => {
+      it("should accept minimal valid input", () => {
+        const result = BrowseSearchSchema.safeParse({
+          action: "group",
+          group_id: "my-group",
+          scope: "issues",
+          search: "feature",
+        });
+        expect(result.success).toBe(true);
+        if (result.success && result.data.action === "group") {
+          expect(result.data.group_id).toBe("my-group");
+          expect(result.data.scope).toBe("issues");
+          expect(result.data.search).toBe("feature");
+        }
+      });
+
+      it("should accept numeric group_id", () => {
+        const result = BrowseSearchSchema.safeParse({
+          action: "group",
+          group_id: 456,
+          scope: "merge_requests",
+          search: "refactor",
+        });
+        expect(result.success).toBe(true);
+        if (result.success && result.data.action === "group") {
+          expect(result.data.group_id).toBe("456");
+        }
+      });
+
+      it("should accept state and other filters", () => {
+        const result = BrowseSearchSchema.safeParse({
+          action: "group",
+          group_id: "test-group",
+          scope: "merge_requests",
+          search: "fix",
+          state: "merged",
+          order_by: "updated_at",
+          sort: "desc",
+        });
+        expect(result.success).toBe(true);
+        if (result.success && result.data.action === "group") {
+          expect(result.data.state).toBe("merged");
+          expect(result.data.order_by).toBe("updated_at");
+          expect(result.data.sort).toBe("desc");
+        }
+      });
+    });
+
+    describe("Invalid inputs", () => {
+      it("should reject missing group_id", () => {
+        const result = BrowseSearchSchema.safeParse({
+          action: "group",
+          scope: "issues",
+          search: "test",
+        });
+        expect(result.success).toBe(false);
+      });
+
+      it("should reject empty group_id", () => {
+        const result = BrowseSearchSchema.safeParse({
+          action: "group",
+          group_id: "",
+          scope: "issues",
+          search: "test",
+        });
+        expect(result.success).toBe(false);
+      });
+    });
+  });
+
+  describe("Discriminated Union behavior", () => {
+    it("should correctly narrow types based on action", () => {
+      const globalResult = BrowseSearchSchema.safeParse({
+        action: "global",
+        scope: "projects",
+        search: "test",
+      });
+      const projectResult = BrowseSearchSchema.safeParse({
+        action: "project",
+        project_id: "test-project",
+        scope: "blobs",
+        search: "function",
+      });
+      const groupResult = BrowseSearchSchema.safeParse({
+        action: "group",
+        group_id: "test-group",
+        scope: "issues",
+        search: "bug",
+      });
+
+      expect(globalResult.success).toBe(true);
+      expect(projectResult.success).toBe(true);
+      expect(groupResult.success).toBe(true);
+
+      if (globalResult.success) {
+        expect(globalResult.data.action).toBe("global");
+      }
+      if (projectResult.success) {
+        expect(projectResult.data.action).toBe("project");
+      }
+      if (groupResult.success) {
+        expect(groupResult.data.action).toBe("group");
+      }
+    });
+
+    it("should reject unknown action values", () => {
+      const result = BrowseSearchSchema.safeParse({
+        action: "unknown",
+        scope: "projects",
+        search: "test",
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("should reject missing action", () => {
+      const result = BrowseSearchSchema.safeParse({
+        scope: "projects",
+        search: "test",
+      });
+      expect(result.success).toBe(false);
+    });
+  });
+});
+
+describe("SearchScopeSchema", () => {
+  it("should accept all valid scopes", () => {
+    const validScopes = [
+      "projects",
+      "issues",
+      "merge_requests",
+      "milestones",
+      "snippet_titles",
+      "users",
+      "groups",
+      "blobs",
+      "commits",
+      "wiki_blobs",
+      "notes",
+    ];
+
+    for (const scope of validScopes) {
+      const result = SearchScopeSchema.safeParse(scope);
+      expect(result.success).toBe(true);
+    }
+  });
+
+  it("should reject invalid scopes", () => {
+    const invalidScopes = ["invalid", "code", "files", "repositories", ""];
+
+    for (const scope of invalidScopes) {
+      const result = SearchScopeSchema.safeParse(scope);
+      expect(result.success).toBe(false);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Implements issue #82 - global search (`browse_search`) tool
- CQRS read-only tool with 3 actions: `global`, `project`, `group`
- Supports 11 search scopes: projects, issues, merge_requests, milestones, snippet_titles, users, groups, blobs, commits, wiki_blobs, notes
- All actions available in GitLab Free tier

## Changes
- New `src/entities/search/` directory with schema and registry
- Added `USE_SEARCH` feature flag to config
- Integrated into registry-manager and ToolAvailability
- Unit tests with 100% code coverage (51 tests)

## Test plan
- [x] Unit tests pass (`yarn test:unit`)
- [x] Lint passes (`yarn lint`)
- [x] Build succeeds (`yarn build`)
- [ ] CI/CD pipeline passes
- [ ] Integration test with real GitLab instance

Closes #82