### PR TITLE
fix(mrs): add default per_page=20 to browse_mr_discussions

### DIFF
--- a/src/entities/mrs/registry.ts
+++ b/src/entities/mrs/registry.ts
@@ -172,7 +172,7 @@ export const mrsToolRegistry: ToolRegistry = new Map<string, EnhancedToolDefinit
     {
       name: "browse_mr_discussions",
       description:
-        'BROWSE MR discussions and draft notes. Actions: "list" shows all discussion threads, "drafts" lists unpublished draft notes, "draft" gets single draft note.',
+        'BROWSE MR discussions and draft notes. Actions: "list" shows all discussion threads (default: 20 per page), "drafts" lists unpublished draft notes, "draft" gets single draft note.',
       inputSchema: z.toJSONSchema(BrowseMrDiscussionsSchema),
       gate: { envVar: "USE_MRS", defaultValue: true },
       handler: async (args: unknown) => {

--- a/src/entities/mrs/schema-readonly.ts
+++ b/src/entities/mrs/schema-readonly.ts
@@ -255,7 +255,7 @@ const ListMrDiscussionsSchema = z.object({
   action: z.literal("list").describe("List all discussion threads on an MR"),
   project_id: projectIdField,
   merge_request_iid: mergeRequestIidField,
-  per_page: z.number().optional().describe("Number of items per page"),
+  per_page: z.number().optional().default(20).describe("Number of items per page (default: 20)"),
   page: z.number().optional().describe("Page number"),
 });
 


### PR DESCRIPTION
## Summary

- Add default `per_page=20` to `browse_mr_discussions` list action to prevent hanging on large discussion payloads
- Update tool description to document the default pagination

## Problem

`browse_mr_discussions` could hang for extended periods (80+ seconds observed) when fetching discussions without explicit `per_page` parameter, as discussion responses include full diff context, position data, and nested notes.

## Test plan

- [x] Lint passes
- [x] Build passes
- [x] Coverage > 86% for changed files

Closes #97