### PR TITLE
chore(ci): ignore @types/node major updates in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,9 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    ignore:
+      - dependency-name: "@types/node"
+        update-types: ["version-update:semver-major"]
     commit-message:
       prefix: "chore(deps)"
 


### PR DESCRIPTION
## Summary
- Ignore major version updates for @types/node in dependabot
- Node 25 support not needed yet, stick with Node 24 types

Closes #109