### PR TITLE
refactor(read-only): move read-only actions from manage_* to browse_* tools

### DIFF
--- a/src/cli/list-tools.ts
+++ b/src/cli/list-tools.ts
@@ -382,8 +382,8 @@ const ENTITY_TOOLS: Record<string, string[]> = {
   Milestones: ["browse_milestones", "manage_milestone"],
   Files: ["browse_files", "manage_files"],
   Snippets: ["browse_snippets", "manage_snippet"],
-  Webhooks: ["list_webhooks", "manage_webhook"],
-  Integrations: ["list_integrations", "manage_integration"],
+  Webhooks: ["browse_webhooks", "manage_webhook"],
+  Integrations: ["browse_integrations", "manage_integration"],
   Todos: ["list_todos", "manage_todos"],
 };
 
@@ -1024,9 +1024,9 @@ const FEATURE_TO_TOOLS: Record<string, string[]> = {
   files: ["browse_files", "manage_files"],
   variables: ["browse_variables", "manage_variable"],
   workitems: ["browse_work_items", "manage_work_item"],
-  webhooks: ["list_webhooks", "manage_webhook"],
+  webhooks: ["browse_webhooks", "manage_webhook"],
   snippets: ["browse_snippets", "manage_snippet"],
-  integrations: ["list_integrations", "manage_integration"],
+  integrations: ["browse_integrations", "manage_integration"],
 };
 
 /**

--- a/src/entities/integrations/index.ts
+++ b/src/entities/integrations/index.ts
@@ -9,25 +9,3 @@ export * from "./schema";
 
 // Export the unified registry
 export * from "./registry";
-
-// Import from the registry
-import { getFilteredIntegrationsTools, getIntegrationsReadOnlyToolNames } from "./registry";
-import type { ToolDefinition } from "../../types";
-
-// Conditional exports based on GITLAB_READONLY environment variable
-const isReadOnly = process.env.GITLAB_READONLY === "true";
-
-// Get tools from the registry
-const integrationsToolsFromRegistry = getFilteredIntegrationsTools(isReadOnly);
-
-// Convert enhanced tool definitions to regular tool definitions for backward compatibility
-export const integrationsTools: ToolDefinition[] = integrationsToolsFromRegistry.map(
-  (tool): ToolDefinition => ({
-    name: tool.name,
-    description: tool.description,
-    inputSchema: tool.inputSchema,
-  })
-);
-
-// Export read-only tool names for backward compatibility
-export const integrationsReadOnlyTools = getIntegrationsReadOnlyToolNames();

--- a/src/entities/integrations/registry.ts
+++ b/src/entities/integrations/registry.ts
@@ -1,5 +1,5 @@
 import * as z from "zod";
-import { ListIntegrationsSchema } from "./schema-readonly";
+import { BrowseIntegrationsSchema } from "./schema-readonly";
 import { ManageIntegrationSchema } from "./schema";
 import { gitlab, toQuery } from "../../utils/gitlab-api";
 import { getEffectiveProjectId, isActionDenied } from "../../config";
@@ -9,34 +9,56 @@ import { ToolRegistry, EnhancedToolDefinition } from "../../types";
  * Integrations tools registry - 2 CQRS tools for managing GitLab project integrations
  * Uses discriminated union schemas for type-safe action handling.
  *
- * list_integrations (Query): list all active integrations
- * manage_integration (Command): get, update, disable
+ * browse_integrations (Query): list, get
+ * manage_integration (Command): update, disable
  */
 export const integrationsToolRegistry: ToolRegistry = new Map<string, EnhancedToolDefinition>([
   // ============================================================================
-  // list_integrations - CQRS Query Tool
+  // browse_integrations - CQRS Query Tool (discriminated union schema)
+  // TypeScript automatically narrows types in each switch case
   // ============================================================================
   [
-    "list_integrations",
+    "browse_integrations",
     {
-      name: "list_integrations",
+      name: "browse_integrations",
       description:
-        "LIST all active integrations for a project. Returns integrations like Slack, Jira, Discord, Microsoft Teams, Jenkins, etc. Only shows enabled/configured integrations.",
-      inputSchema: z.toJSONSchema(ListIntegrationsSchema, {}),
+        'BROWSE project integrations. Actions: "list" shows all active integrations (Slack, Jira, Discord, Teams, Jenkins, etc.), "get" retrieves settings for a specific integration by type slug.',
+      inputSchema: z.toJSONSchema(BrowseIntegrationsSchema, {}),
       gate: { envVar: "USE_INTEGRATIONS", defaultValue: true },
       handler: async (args: unknown) => {
-        const input = ListIntegrationsSchema.parse(args);
+        const input = BrowseIntegrationsSchema.parse(args);
+
+        // Runtime validation: reject denied actions even if they bypass schema filtering
+        if (isActionDenied("browse_integrations", input.action)) {
+          throw new Error(`Action '${input.action}' is not allowed for browse_integrations tool`);
+        }
+
         const projectId = getEffectiveProjectId(input.project_id);
 
-        const query = toQuery(
-          {
-            per_page: input.per_page,
-            page: input.page,
-          },
-          []
-        );
+        switch (input.action) {
+          case "list": {
+            // TypeScript knows: input has project_id, per_page, page
+            const query = toQuery(
+              {
+                per_page: input.per_page,
+                page: input.page,
+              },
+              []
+            );
+            return gitlab.get(`projects/${encodeURIComponent(projectId)}/integrations`, { query });
+          }
 
-        return gitlab.get(`projects/${encodeURIComponent(projectId)}/integrations`, { query });
+          case "get": {
+            // TypeScript knows: input has project_id, integration
+            return gitlab.get(
+              `projects/${encodeURIComponent(projectId)}/integrations/${input.integration}`
+            );
+          }
+
+          /* istanbul ignore next -- unreachable with Zod discriminatedUnion */
+          default:
+            throw new Error(`Unknown action: ${(input as { action: string }).action}`);
+        }
       },
     },
   ],
@@ -50,7 +72,7 @@ export const integrationsToolRegistry: ToolRegistry = new Map<string, EnhancedTo
     {
       name: "manage_integration",
       description:
-        'MANAGE project integrations. Actions: "get" retrieves integration settings (read-only), "update" modifies or enables integration with specific config, "disable" removes integration. Supports 50+ integrations: Slack, Jira, Discord, Teams, Jenkins, etc. Note: gitlab-slack-application cannot be created via API - requires OAuth install from UI.',
+        'MANAGE project integrations. Actions: "update" modifies or enables integration with specific config, "disable" removes integration. Supports 50+ integrations: Slack, Jira, Discord, Teams, Jenkins, etc. Note: gitlab-slack-application cannot be created via API - requires OAuth install from UI.',
       inputSchema: z.toJSONSchema(ManageIntegrationSchema, {}),
       gate: { envVar: "USE_INTEGRATIONS", defaultValue: true },
       handler: async (args: unknown) => {
@@ -64,22 +86,7 @@ export const integrationsToolRegistry: ToolRegistry = new Map<string, EnhancedTo
         const projectId = getEffectiveProjectId(input.project_id);
         const integrationSlug = input.integration;
 
-        // Enforce read-only mode for write actions (check dynamically for testability)
-        const isReadOnly = process.env.GITLAB_READ_ONLY_MODE === "true";
-        if (isReadOnly && (input.action === "update" || input.action === "disable")) {
-          throw new Error(
-            `Action '${input.action}' is not allowed in read-only mode. Only 'get' action is permitted.`
-          );
-        }
-
         switch (input.action) {
-          case "get": {
-            // TypeScript knows: input has project_id, integration (required)
-            return gitlab.get(
-              `projects/${encodeURIComponent(projectId)}/integrations/${integrationSlug}`
-            );
-          }
-
           case "update": {
             // TypeScript knows: input has project_id, integration (required), plus event fields and config (optional)
             const {
@@ -123,12 +130,11 @@ export const integrationsToolRegistry: ToolRegistry = new Map<string, EnhancedTo
 ]);
 
 /**
- * Get read-only tool names from the registry
- * Note: manage_integration is included because it supports a read-only action ('get').
- * Write actions ('update', 'disable') are blocked at the handler level when GITLAB_READ_ONLY_MODE is enabled.
+ * Get read-only tool names from the registry.
+ * Only browse_integrations is read-only. manage_integration is purely write operations.
  */
 export function getIntegrationsReadOnlyToolNames(): string[] {
-  return ["list_integrations", "manage_integration"];
+  return ["browse_integrations"];
 }
 
 /**

--- a/src/entities/integrations/schema-readonly.ts
+++ b/src/entities/integrations/schema-readonly.ts
@@ -1,17 +1,43 @@
 import { z } from "zod";
 import { paginationFields } from "../utils";
+import { IntegrationTypeSchema } from "./schema";
 
 // ============================================================================
-// list_integrations - Read-only tool for listing project integrations
+// browse_integrations - CQRS Query Tool (discriminated union schema)
+// Actions: list, get
+//
+// Uses z.discriminatedUnion() on "action" for type-safe action handling.
+// - action="list": List all active integrations for a project
+// - action="get": Retrieve settings for a specific integration
 // ============================================================================
 
-export const ListIntegrationsSchema = z.object({
-  project_id: z.string().describe("Project ID or URL-encoded path"),
+// --- Shared fields ---
+const projectIdField = z.string().describe("Project ID or URL-encoded path");
+
+// --- Action: list ---
+const ListIntegrationsSchema = z.object({
+  action: z.literal("list").describe("List all active integrations for a project"),
+  project_id: projectIdField,
   ...paginationFields(),
 });
+
+// --- Action: get ---
+const GetIntegrationSchema = z.object({
+  action: z.literal("get").describe("Get integration settings (read-only)"),
+  project_id: projectIdField,
+  integration: IntegrationTypeSchema.describe(
+    "Integration type slug (e.g., slack, jira, discord). Note: gitlab-slack-application cannot be created via API - it requires OAuth installation from GitLab UI."
+  ),
+});
+
+// --- Discriminated union combining all actions ---
+export const BrowseIntegrationsSchema = z.discriminatedUnion("action", [
+  ListIntegrationsSchema,
+  GetIntegrationSchema,
+]);
 
 // ============================================================================
 // Type exports
 // ============================================================================
 
-export type ListIntegrationsInput = z.infer<typeof ListIntegrationsSchema>;
+export type BrowseIntegrationsInput = z.infer<typeof BrowseIntegrationsSchema>;

--- a/src/entities/integrations/schema.ts
+++ b/src/entities/integrations/schema.ts
@@ -68,8 +68,11 @@ export const IntegrationTypeSchema = z.enum([
 
 // ============================================================================
 // manage_integration - CQRS Command Tool (discriminated union schema)
-// Actions: get, update, disable
+// Actions: update, disable
 // Uses z.discriminatedUnion() for type-safe action handling.
+//
+// Note: The 'get' action has been moved to browse_integrations (action: 'get')
+// for clean CQRS separation (browse_* = read, manage_* = write).
 // ============================================================================
 
 // --- Shared fields ---
@@ -111,13 +114,6 @@ const eventFields = {
     ),
 };
 
-// --- Action: get ---
-const GetIntegrationSchema = z.object({
-  action: z.literal("get").describe("Get integration settings (read-only)"),
-  project_id: projectIdField,
-  integration: integrationField,
-});
-
 // --- Action: update ---
 const UpdateIntegrationSchema = z
   .object({
@@ -137,7 +133,6 @@ const DisableIntegrationSchema = z.object({
 
 // --- Discriminated union combining all actions ---
 export const ManageIntegrationSchema = z.discriminatedUnion("action", [
-  GetIntegrationSchema,
   UpdateIntegrationSchema,
   DisableIntegrationSchema,
 ]);

--- a/src/entities/webhooks/index.ts
+++ b/src/entities/webhooks/index.ts
@@ -1,33 +1,11 @@
 // Always export shared schemas
 export * from "../shared";
 
-// Always export read-only schemas (for backward compatibility)
+// Always export read-only schemas
 export * from "./schema-readonly";
 
-// Export write schemas (for backward compatibility)
+// Export write schemas
 export * from "./schema";
 
-// Export the new unified registry
+// Export the unified registry
 export * from "./registry";
-
-// Import from the new registry
-import { getFilteredWebhooksTools, getWebhooksReadOnlyToolNames } from "./registry";
-import type { ToolDefinition } from "../../types";
-
-// Conditional exports based on GITLAB_READ_ONLY_MODE environment variable
-const isReadOnly = process.env.GITLAB_READ_ONLY_MODE === "true";
-
-// Get tools from the new registry (with backward compatibility)
-const webhooksToolsFromRegistry = getFilteredWebhooksTools(isReadOnly);
-
-// Convert enhanced tool definitions to regular tool definitions for backward compatibility
-export const webhooksTools: ToolDefinition[] = webhooksToolsFromRegistry.map(
-  (tool): ToolDefinition => ({
-    name: tool.name,
-    description: tool.description,
-    inputSchema: tool.inputSchema,
-  })
-);
-
-// Export read-only tool names for backward compatibility
-export const webhooksReadOnlyTools = getWebhooksReadOnlyToolNames();

--- a/src/entities/webhooks/schema.ts
+++ b/src/entities/webhooks/schema.ts
@@ -3,7 +3,7 @@ import { flexibleBoolean, requiredId } from "../utils";
 
 // ============================================================================
 // manage_webhook - CQRS Command Tool (discriminated union schema)
-// Actions: create, read, update, delete, test
+// Actions: create, update, delete, test
 //
 // Uses z.discriminatedUnion() to define action-specific parameters.
 // Benefits:
@@ -11,6 +11,9 @@ import { flexibleBoolean, requiredId } from "../utils";
 // - TypeScript type narrowing in handlers
 // - Filtering denied actions removes their exclusive parameters from schema
 // - JSON Schema outputs oneOf which is flattened for AI clients at runtime
+//
+// Note: The 'read' action has been moved to browse_webhooks (action: 'get')
+// for clean CQRS separation (browse_* = read, manage_* = write).
 // ============================================================================
 
 // --- Shared webhook event fields used by create/update actions ---
@@ -83,15 +86,6 @@ const CreateWebhookSchema = z.object({
   ...WebhookEventFields,
 });
 
-// --- Read action: retrieves webhook details ---
-const ReadWebhookSchema = z.object({
-  action: z.literal("read"),
-  scope: scopeField,
-  projectId: z.string().optional().describe("Project ID or path (required if scope=project)"),
-  groupId: z.string().optional().describe("Group ID or path (required if scope=group)"),
-  hookId: requiredId.describe("Webhook ID (required)"),
-});
-
 // --- Update action: modifies an existing webhook ---
 const UpdateWebhookSchema = z.object({
   action: z.literal("update"),
@@ -128,7 +122,6 @@ const TestWebhookSchema = z.object({
 // --- Discriminated union combining all actions ---
 export const ManageWebhookSchema = z.discriminatedUnion("action", [
   CreateWebhookSchema,
-  ReadWebhookSchema,
   UpdateWebhookSchema,
   DeleteWebhookSchema,
   TestWebhookSchema,

--- a/src/services/ToolAvailability.ts
+++ b/src/services/ToolAvailability.ts
@@ -390,7 +390,7 @@ export class ToolAvailability {
     delete_variable: { minVersion: 9.0, requiredTier: "free" },
 
     // Webhooks - Project hooks in Free, Group hooks in Premium
-    list_webhooks: { minVersion: 8.0, requiredTier: "free", notes: "Project webhooks" },
+    browse_webhooks: { minVersion: 8.0, requiredTier: "free", notes: "Project webhooks" },
     manage_webhook: {
       minVersion: 8.0,
       requiredTier: "free",
@@ -579,7 +579,7 @@ export class ToolAvailability {
     },
 
     // Webhooks
-    list_webhooks: {
+    browse_webhooks: {
       default: { tier: "free", minVersion: 8.0, notes: "Project webhooks" },
     },
     manage_webhook: {
@@ -592,7 +592,7 @@ export class ToolAvailability {
     },
 
     // Integrations
-    list_integrations: {
+    browse_integrations: {
       default: { tier: "free", minVersion: 8.0 },
     },
     manage_integration: {

--- a/src/utils/error-handler.ts
+++ b/src/utils/error-handler.ts
@@ -452,7 +452,7 @@ function detectTierRestriction(
   }
 
   // Check for group webhooks (tool name pattern)
-  if ((tool === "list_webhooks" || tool === "manage_webhook") && toolArgs?.scope === "group") {
+  if ((tool === "browse_webhooks" || tool === "manage_webhook") && toolArgs?.scope === "group") {
     // Group webhooks require Premium - check if we have serviceDesk (Premium feature) as proxy
     if (!connectionManager.isFeatureAvailable("serviceDesk")) {
       return {

--- a/tests/unit/entities/integrations/schema-readonly.test.ts
+++ b/tests/unit/entities/integrations/schema-readonly.test.ts
@@ -1,24 +1,27 @@
 /**
- * ListIntegrationsSchema Unit Tests
- * Tests schema validation for list_integrations CQRS Query tool
+ * BrowseIntegrationsSchema Unit Tests
+ * Tests schema validation for browse_integrations CQRS Query tool
  */
 
-import { ListIntegrationsSchema } from "../../../../src/entities/integrations/schema-readonly";
+import { BrowseIntegrationsSchema } from "../../../../src/entities/integrations/schema-readonly";
 
-describe("ListIntegrationsSchema", () => {
-  describe("Valid inputs", () => {
-    it("should accept minimal valid input (project_id only)", () => {
-      const result = ListIntegrationsSchema.safeParse({
+describe("BrowseIntegrationsSchema", () => {
+  describe("Action: list - Valid inputs", () => {
+    it("should accept minimal valid input (action + project_id only)", () => {
+      const result = BrowseIntegrationsSchema.safeParse({
+        action: "list",
         project_id: "my-group/my-project",
       });
       expect(result.success).toBe(true);
       if (result.success) {
+        expect(result.data.action).toBe("list");
         expect(result.data.project_id).toBe("my-group/my-project");
       }
     });
 
     it("should accept numeric project_id", () => {
-      const result = ListIntegrationsSchema.safeParse({
+      const result = BrowseIntegrationsSchema.safeParse({
+        action: "list",
         project_id: "12345",
       });
       expect(result.success).toBe(true);
@@ -28,51 +31,57 @@ describe("ListIntegrationsSchema", () => {
     });
 
     it("should accept pagination parameters", () => {
-      const result = ListIntegrationsSchema.safeParse({
+      const result = BrowseIntegrationsSchema.safeParse({
+        action: "list",
         project_id: "test/project",
         per_page: 50,
         page: 2,
       });
       expect(result.success).toBe(true);
-      if (result.success) {
+      if (result.success && result.data.action === "list") {
         expect(result.data.per_page).toBe(50);
         expect(result.data.page).toBe(2);
       }
     });
 
     it("should accept per_page at minimum value (1)", () => {
-      const result = ListIntegrationsSchema.safeParse({
+      const result = BrowseIntegrationsSchema.safeParse({
+        action: "list",
         project_id: "test/project",
         per_page: 1,
       });
       expect(result.success).toBe(true);
-      if (result.success) {
+      if (result.success && result.data.action === "list") {
         expect(result.data.per_page).toBe(1);
       }
     });
 
     it("should accept per_page at maximum value (100)", () => {
-      const result = ListIntegrationsSchema.safeParse({
+      const result = BrowseIntegrationsSchema.safeParse({
+        action: "list",
         project_id: "test/project",
         per_page: 100,
       });
       expect(result.success).toBe(true);
-      if (result.success) {
+      if (result.success && result.data.action === "list") {
         expect(result.data.per_page).toBe(100);
       }
     });
 
     it("should accept URL-encoded project path", () => {
-      const result = ListIntegrationsSchema.safeParse({
+      const result = BrowseIntegrationsSchema.safeParse({
+        action: "list",
         project_id: "my-group%2Fmy-project",
       });
       expect(result.success).toBe(true);
     });
   });
 
-  describe("Invalid inputs", () => {
+  describe("Action: list - Invalid inputs", () => {
     it("should reject missing project_id", () => {
-      const result = ListIntegrationsSchema.safeParse({});
+      const result = BrowseIntegrationsSchema.safeParse({
+        action: "list",
+      });
       expect(result.success).toBe(false);
       if (!result.success) {
         const projectIdError = result.error.issues.find(i => i.path.includes("project_id"));
@@ -81,7 +90,8 @@ describe("ListIntegrationsSchema", () => {
     });
 
     it("should reject per_page exceeding 100", () => {
-      const result = ListIntegrationsSchema.safeParse({
+      const result = BrowseIntegrationsSchema.safeParse({
+        action: "list",
         project_id: "test/project",
         per_page: 150,
       });
@@ -89,7 +99,8 @@ describe("ListIntegrationsSchema", () => {
     });
 
     it("should reject per_page less than 1", () => {
-      const result = ListIntegrationsSchema.safeParse({
+      const result = BrowseIntegrationsSchema.safeParse({
+        action: "list",
         project_id: "test/project",
         per_page: 0,
       });
@@ -97,7 +108,8 @@ describe("ListIntegrationsSchema", () => {
     });
 
     it("should reject negative per_page", () => {
-      const result = ListIntegrationsSchema.safeParse({
+      const result = BrowseIntegrationsSchema.safeParse({
+        action: "list",
         project_id: "test/project",
         per_page: -10,
       });
@@ -105,7 +117,8 @@ describe("ListIntegrationsSchema", () => {
     });
 
     it("should reject page less than 1", () => {
-      const result = ListIntegrationsSchema.safeParse({
+      const result = BrowseIntegrationsSchema.safeParse({
+        action: "list",
         project_id: "test/project",
         page: 0,
       });
@@ -113,7 +126,8 @@ describe("ListIntegrationsSchema", () => {
     });
 
     it("should reject non-integer per_page", () => {
-      const result = ListIntegrationsSchema.safeParse({
+      const result = BrowseIntegrationsSchema.safeParse({
+        action: "list",
         project_id: "test/project",
         per_page: 10.5,
       });
@@ -121,7 +135,8 @@ describe("ListIntegrationsSchema", () => {
     });
 
     it("should reject non-integer page", () => {
-      const result = ListIntegrationsSchema.safeParse({
+      const result = BrowseIntegrationsSchema.safeParse({
+        action: "list",
         project_id: "test/project",
         page: 1.5,
       });
@@ -129,16 +144,97 @@ describe("ListIntegrationsSchema", () => {
     });
   });
 
+  describe("Action: get - Valid inputs", () => {
+    it("should accept valid get parameters", () => {
+      const result = BrowseIntegrationsSchema.safeParse({
+        action: "get",
+        project_id: "123",
+        integration: "slack",
+      });
+      expect(result.success).toBe(true);
+      if (result.success && result.data.action === "get") {
+        expect(result.data.action).toBe("get");
+        expect(result.data.integration).toBe("slack");
+      }
+    });
+
+    it("should support all integration types", () => {
+      const integrationTypes = [
+        "slack",
+        "jira",
+        "discord",
+        "microsoft-teams",
+        "jenkins",
+        "emails-on-push",
+      ];
+
+      for (const integrationType of integrationTypes) {
+        const result = BrowseIntegrationsSchema.safeParse({
+          action: "get",
+          project_id: "123",
+          integration: integrationType,
+        });
+        expect(result.success).toBe(true);
+      }
+    });
+  });
+
+  describe("Action: get - Invalid inputs", () => {
+    it("should reject invalid integration type", () => {
+      const result = BrowseIntegrationsSchema.safeParse({
+        action: "get",
+        project_id: "123",
+        integration: "invalid-integration",
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("should reject missing integration field", () => {
+      const result = BrowseIntegrationsSchema.safeParse({
+        action: "get",
+        project_id: "123",
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("should reject missing project_id", () => {
+      const result = BrowseIntegrationsSchema.safeParse({
+        action: "get",
+        integration: "slack",
+      });
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe("Action discriminator", () => {
+    it("should reject invalid action", () => {
+      const result = BrowseIntegrationsSchema.safeParse({
+        action: "invalid",
+        project_id: "123",
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("should reject missing action", () => {
+      const result = BrowseIntegrationsSchema.safeParse({
+        project_id: "123",
+      });
+      expect(result.success).toBe(false);
+    });
+  });
+
   describe("Edge cases", () => {
     it("should handle project path with special characters", () => {
-      const result = ListIntegrationsSchema.safeParse({
+      const result = BrowseIntegrationsSchema.safeParse({
+        action: "list",
         project_id: "my-group/my-project_v2.0",
       });
       expect(result.success).toBe(true);
     });
 
     it("should handle deeply nested project path", () => {
-      const result = ListIntegrationsSchema.safeParse({
+      const result = BrowseIntegrationsSchema.safeParse({
+        action: "list",
         project_id: "org/team/subteam/project",
       });
       expect(result.success).toBe(true);

--- a/tests/unit/entities/integrations/schema.test.ts
+++ b/tests/unit/entities/integrations/schema.test.ts
@@ -79,16 +79,13 @@ describe("IntegrationTypeSchema", () => {
 
 describe("ManageIntegrationSchema", () => {
   describe("action field validation", () => {
-    it("should accept 'get' action", () => {
+    it("should reject 'get' action (moved to browse_integrations)", () => {
       const result = ManageIntegrationSchema.safeParse({
         action: "get",
         project_id: "test/project",
         integration: "slack",
       });
-      expect(result.success).toBe(true);
-      if (result.success) {
-        expect(result.data.action).toBe("get");
-      }
+      expect(result.success).toBe(false);
     });
 
     it("should accept 'update' action", () => {
@@ -134,24 +131,24 @@ describe("ManageIntegrationSchema", () => {
     });
   });
 
-  describe("get action validation", () => {
-    it("should accept minimal get request", () => {
+  describe("disable action validation", () => {
+    it("should accept minimal disable request", () => {
       const result = ManageIntegrationSchema.safeParse({
-        action: "get",
+        action: "disable",
         project_id: "my-group/my-project",
         integration: "jira",
       });
       expect(result.success).toBe(true);
       if (result.success) {
-        expect(result.data.action).toBe("get");
+        expect(result.data.action).toBe("disable");
         expect(result.data.project_id).toBe("my-group/my-project");
         expect(result.data.integration).toBe("jira");
       }
     });
 
-    it("should accept get with numeric project_id", () => {
+    it("should accept disable with numeric project_id", () => {
       const result = ManageIntegrationSchema.safeParse({
-        action: "get",
+        action: "disable",
         project_id: "12345",
         integration: "discord",
       });
@@ -372,7 +369,7 @@ describe("ManageIntegrationSchema", () => {
   describe("required fields validation", () => {
     it("should reject missing project_id", () => {
       const result = ManageIntegrationSchema.safeParse({
-        action: "get",
+        action: "update",
         integration: "slack",
       });
       expect(result.success).toBe(false);
@@ -380,7 +377,7 @@ describe("ManageIntegrationSchema", () => {
 
     it("should reject missing integration", () => {
       const result = ManageIntegrationSchema.safeParse({
-        action: "get",
+        action: "disable",
         project_id: "test/project",
       });
       expect(result.success).toBe(false);
@@ -388,7 +385,7 @@ describe("ManageIntegrationSchema", () => {
 
     it("should reject invalid integration type", () => {
       const result = ManageIntegrationSchema.safeParse({
-        action: "get",
+        action: "disable",
         project_id: "test/project",
         integration: "invalid-integration-type",
       });
@@ -410,7 +407,7 @@ describe("ManageIntegrationSchema", () => {
 
       for (const integration of communicationIntegrations) {
         const result = ManageIntegrationSchema.safeParse({
-          action: "get",
+          action: "disable",
           project_id: "test/project",
           integration,
         });
@@ -430,7 +427,7 @@ describe("ManageIntegrationSchema", () => {
 
       for (const integration of cicdIntegrations) {
         const result = ManageIntegrationSchema.safeParse({
-          action: "get",
+          action: "disable",
           project_id: "test/project",
           integration,
         });
@@ -451,7 +448,7 @@ describe("ManageIntegrationSchema", () => {
 
       for (const integration of issueTrackerIntegrations) {
         const result = ManageIntegrationSchema.safeParse({
-          action: "get",
+          action: "disable",
           project_id: "test/project",
           integration,
         });

--- a/tests/unit/utils/error-handler.test.ts
+++ b/tests/unit/utils/error-handler.test.ts
@@ -87,7 +87,7 @@ describe("Error Handler", () => {
         };
 
         // Group webhooks require Premium - scope is in toolArgs
-        const result = handleGitLabError(error, "list_webhooks", "list", { scope: "group" });
+        const result = handleGitLabError(error, "browse_webhooks", "list", { scope: "group" });
 
         expect(result.error_code).toBe("TIER_RESTRICTED");
         if (result.error_code === "TIER_RESTRICTED") {


### PR DESCRIPTION
## Summary

- Move `manage_webhook` action `read` → `browse_webhooks` action `get`
- Move `manage_integration` action `get` → `browse_integrations` action `get`
- Rename `list_webhooks` → `browse_webhooks`, `list_integrations` → `browse_integrations` for consistency with existing `browse_*` naming convention
- `browse_*` tools now use discriminated union schemas (`list` + `get` actions)
- `manage_*` tools only contain write operations, simplifying read-only mode filtering
- `manage_context` kept as-is (session-only state, no GitLab writes)

Closes #134

## Test plan

- [x] All 3478 unit tests pass
- [x] Lint passes with 0 errors
- [x] TypeScript build succeeds
- [x] Integration test schemas updated for new tool names and action structure