### PR TITLE
fix(transport): add SSE keepalive and configure HTTP server timeouts for proxy chain

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -145,6 +145,25 @@ export const SSL_PASSPHRASE = process.env.SSL_PASSPHRASE;
 // Values: 'true', 'false', 'loopback', 'linklocal', 'uniquelocal', or specific IPs
 export const TRUST_PROXY = process.env.TRUST_PROXY;
 
+// SSE heartbeat interval (in milliseconds)
+// Sends `: ping\n\n` comments to keep SSE connections alive through proxies (Cloudflare, Envoy, etc.)
+// Default 30s — well under Cloudflare's ~100-125s idle timeout
+const parsedHeartbeatMs = parseInt(process.env.GITLAB_SSE_HEARTBEAT_MS ?? "30000", 10);
+export const SSE_HEARTBEAT_MS =
+  Number.isFinite(parsedHeartbeatMs) && parsedHeartbeatMs > 0 ? parsedHeartbeatMs : 30000;
+
+// HTTP server keepalive timeout (in milliseconds)
+// Must be higher than any upstream proxy timeout (Cloudflare max is 600s for Enterprise)
+// Default 620s ensures the Node.js server doesn't close connections before the proxy does
+const parsedKeepAliveTimeout = parseInt(
+  process.env.GITLAB_HTTP_KEEPALIVE_TIMEOUT_MS ?? "620000",
+  10
+);
+export const HTTP_KEEPALIVE_TIMEOUT_MS =
+  Number.isFinite(parsedKeepAliveTimeout) && parsedKeepAliveTimeout > 0
+    ? parsedKeepAliveTimeout
+    : 620000;
+
 // API timeout configuration (in milliseconds)
 // Default 10s allows time for retries within a reasonable total response time
 const parsedTimeoutMs = parseInt(process.env.GITLAB_API_TIMEOUT_MS ?? "10000", 10);


### PR DESCRIPTION
## Summary

- Add SSE heartbeat (`: ping\n\n` comments every 30s) to keep connections alive through Cloudflare/Envoy proxy chains that kill idle SSE streams after ~125s
- Configure HTTP server timeouts (`keepAliveTimeout=620s`, `headersTimeout=625s`, `timeout=0`) to prevent Node.js from closing connections before upstream proxies
- Both values configurable via `GITLAB_SSE_HEARTBEAT_MS` and `GITLAB_HTTP_KEEPALIVE_TIMEOUT_MS` environment variables
- Heartbeat applied to both legacy `/sse` and modern StreamableHTTP GET endpoints

## Changes

- `src/config.ts` — Add `SSE_HEARTBEAT_MS` and `HTTP_KEEPALIVE_TIMEOUT_MS` config with env var parsing
- `src/server.ts` — Add `startSseHeartbeat()` helper, `configureServerTimeouts()`, integrate into both SSE endpoints, use `http.createServer()` for proper timeout control
- `tests/unit/server.test.ts` — 10 new tests covering heartbeat start/stop/ping, GET SSE streams, POST non-heartbeat, HTTP timeout configuration

## Test plan

- [x] All 3685 unit tests pass
- [x] ESLint passes with 0 errors
- [x] TypeScript compilation succeeds
- [x] Build succeeds
- [ ] Deploy to staging and verify SSE connections survive >125s idle time
- [ ] Verify Envoy access logs show non-zero response body bytes (heartbeat data)
- [ ] Verify `DR` (Downstream Reset) flags no longer appear at ~125s

Closes #139