### PR TITLE
fix(docs): inline constants removed with dead code cleanup

### DIFF
--- a/docs/.vitepress/theme/components/BugReportWidget.vue
+++ b/docs/.vitepress/theme/components/BugReportWidget.vue
@@ -1,7 +1,16 @@
 <script setup lang="ts">
 import { ref, computed, nextTick, onMounted, onUnmounted } from "vue";
 import { useRoute } from "vitepress";
-import { CATEGORIES, MIN_DESCRIPTION_LENGTH } from "../../../functions/api/utils";
+
+const MIN_DESCRIPTION_LENGTH = 10;
+
+const CATEGORIES = [
+  "Documentation is wrong/outdated",
+  "Tool not working as described",
+  "Missing information",
+  "Installation/setup issue",
+  "Other",
+];
 
 const route = useRoute();
 


### PR DESCRIPTION
## Summary

- Fix broken `Deploy Documentation` workflow on `main` caused by missing import
- `BugReportWidget.vue` imported `CATEGORIES` and `MIN_DESCRIPTION_LENGTH` from `docs/functions/api/utils.ts` which was deleted in #156
- Constants are now defined directly in the component

Fixes #157

## Test plan

- [x] `yarn docs:build` passes locally
- [ ] Deploy Documentation workflow passes in CI