### PR TITLE
feat(descriptions): intent-first tool descriptions with dynamic Related resolution

### DIFF
--- a/docs/advanced/customization.md
+++ b/docs/advanced/customization.md
@@ -46,6 +46,30 @@ export GITLAB_TOOL_MANAGE_WORK_ITEM="Create and manage tickets for our sprint pl
 - Tool names in variables must be UPPERCASE
 - Invalid tool names are ignored with a debug warning
 
+## Dynamic Cross-References
+
+Tool descriptions include `Related:` sections that reference companion tools (e.g., browse→manage pairs). These references are resolved dynamically at startup — if a referenced tool is unavailable (disabled via `USE_*`, `GITLAB_DENIED_TOOLS_REGEX`, read-only mode, or tier/version gating), it is automatically stripped from the description.
+
+### How It Works
+
+```
+# Source description (in registry):
+"List labels. Related: manage_label to create/update/delete."
+
+# If manage_label is disabled (USE_LABELS_MANAGE=false or read-only mode):
+"List labels."
+
+# If manage_label is available:
+"List labels. Related: manage_label to create/update/delete."
+```
+
+### Notes
+
+- References are identified by `browse_*` or `manage_*` prefixes in the `Related:` section
+- Multiple comma-separated references are resolved individually — only unavailable ones are stripped
+- If all referenced tools are unavailable, the entire `Related:` clause is removed
+- Custom description overrides (`GITLAB_TOOL_*`) bypass resolution entirely — you control the full text
+
 ## Fine-Grained Action Filtering
 
 For CQRS tools, disable specific actions while keeping others available. This reduces AI context token usage by removing disabled actions and their exclusive parameters from the schema.

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -108,6 +108,7 @@ Optional: GITLAB_API_URL (defaults to https://gitlab.com)
 - Tool filtering: GITLAB_DENIED_TOOLS_REGEX to disable specific tools
 - Action filtering: GITLAB_DENIED_ACTIONS to block specific actions
 - Project scoping: GITLAB_ALLOWED_PROJECT_IDS to restrict access
+- Dynamic cross-references: Related tool hints auto-stripped when referenced tools are disabled
 
 # Feature Flags (USE_* environment variables)
 

--- a/src/entities/context/registry.ts
+++ b/src/entities/context/registry.ts
@@ -27,14 +27,7 @@ export const contextToolRegistry: ToolRegistry = new Map<string, EnhancedToolDef
     {
       name: "manage_context",
       description:
-        "CONTEXT: Manage runtime session context. Actions: " +
-        "'show' returns current context (host, preset, scope, mode); " +
-        "'list_presets' lists available presets with descriptions; " +
-        "'list_profiles' lists OAuth profiles (OAuth mode only); " +
-        "'switch_preset' changes active preset by name; " +
-        "'switch_profile' changes OAuth profile (OAuth mode only); " +
-        "'set_scope' restricts operations to a namespace (auto-detects group vs project); " +
-        "'reset' restores initial context from session start.",
+        "View and manage runtime session configuration. Actions: show (current host/preset/scope/mode), list_presets (available tool configurations), list_profiles (OAuth users), switch_preset (change active preset), switch_profile (change OAuth user), set_scope (restrict to namespace), reset (restore initial state).",
       inputSchema: z.toJSONSchema(ManageContextSchema),
       // No gate - context management is always available
       handler: async (args: unknown) => {

--- a/src/entities/files/registry.ts
+++ b/src/entities/files/registry.ts
@@ -23,7 +23,7 @@ export const filesToolRegistry: ToolRegistry = new Map<string, EnhancedToolDefin
     {
       name: "browse_files",
       description:
-        'BROWSE repository files. Actions: "tree" lists files/folders with pagination, "content" reads file contents. Use for exploring project structure or reading source code.',
+        "Explore project file structure and read source code. Actions: tree (list directory contents with recursive depth control), content (read file at specific ref/branch), download_attachment (get uploaded file by secret+filename). Related: manage_files to create/update files.",
       inputSchema: z.toJSONSchema(BrowseFilesSchema),
       gate: { envVar: "USE_FILES", defaultValue: true },
       handler: async (args: unknown) => {
@@ -105,7 +105,7 @@ export const filesToolRegistry: ToolRegistry = new Map<string, EnhancedToolDefin
     {
       name: "manage_files",
       description:
-        'MANAGE repository files. Actions: "single" creates/updates one file, "batch" commits multiple files atomically, "upload" adds markdown attachments.',
+        "Create, update, or upload repository files. Actions: single (create/update one file with commit message), batch (atomic multi-file commit), upload (add attachment returning markdown link). Related: browse_files to read existing files.",
       inputSchema: z.toJSONSchema(ManageFilesSchema),
       gate: { envVar: "USE_FILES", defaultValue: true },
       handler: async (args: unknown) => {

--- a/src/entities/integrations/registry.ts
+++ b/src/entities/integrations/registry.ts
@@ -22,7 +22,7 @@ export const integrationsToolRegistry: ToolRegistry = new Map<string, EnhancedTo
     {
       name: "browse_integrations",
       description:
-        'BROWSE project integrations. Actions: "list" shows all active integrations (Slack, Jira, Discord, Teams, Jenkins, etc.), "get" retrieves settings for a specific integration by type slug.',
+        "Discover active project integrations and their configuration. Actions: list (all active: Slack, Jira, Discord, Teams, Jenkins, etc.), get (specific integration settings by slug). Related: manage_integration to configure/disable.",
       inputSchema: z.toJSONSchema(BrowseIntegrationsSchema, {}),
       gate: { envVar: "USE_INTEGRATIONS", defaultValue: true },
       handler: async (args: unknown) => {
@@ -72,7 +72,7 @@ export const integrationsToolRegistry: ToolRegistry = new Map<string, EnhancedTo
     {
       name: "manage_integration",
       description:
-        'MANAGE project integrations. Actions: "update" modifies or enables integration with specific config, "disable" removes integration. Supports 50+ integrations: Slack, Jira, Discord, Teams, Jenkins, etc. Note: gitlab-slack-application cannot be created via API - requires OAuth install from UI.',
+        "Configure or disable project integrations (50+ supported). Actions: update (enable/modify with integration-specific config), disable (deactivate integration). Note: gitlab-slack-application requires OAuth install from GitLab UI. Related: browse_integrations for discovery.",
       inputSchema: z.toJSONSchema(ManageIntegrationSchema, {}),
       gate: { envVar: "USE_INTEGRATIONS", defaultValue: true },
       handler: async (args: unknown) => {

--- a/src/entities/labels/registry.ts
+++ b/src/entities/labels/registry.ts
@@ -22,7 +22,7 @@ export const labelsToolRegistry: ToolRegistry = new Map<string, EnhancedToolDefi
     {
       name: "browse_labels",
       description:
-        'BROWSE labels. Actions: "list" shows all labels in project/group with filtering, "get" retrieves single label details by ID or name.',
+        "List and inspect project or group labels. Actions: list (all labels with search filtering), get (single label by ID or name). Related: manage_label to create/update/delete.",
       inputSchema: z.toJSONSchema(BrowseLabelsSchema),
       gate: { envVar: "USE_LABELS", defaultValue: true },
       handler: async (args: unknown) => {
@@ -73,7 +73,7 @@ export const labelsToolRegistry: ToolRegistry = new Map<string, EnhancedToolDefi
     {
       name: "manage_label",
       description:
-        'MANAGE labels. Actions: "create" adds new label (requires name and color), "update" modifies existing label, "delete" removes label permanently.',
+        "Create, update, or delete project/group labels. Actions: create (name + hex color required), update (modify properties), delete (remove permanently). Related: browse_labels for discovery.",
       inputSchema: z.toJSONSchema(ManageLabelSchema),
       gate: { envVar: "USE_LABELS", defaultValue: true },
       handler: async (args: unknown) => {

--- a/src/entities/members/registry.ts
+++ b/src/entities/members/registry.ts
@@ -22,7 +22,7 @@ export const membersToolRegistry: ToolRegistry = new Map<string, EnhancedToolDef
     {
       name: "browse_members",
       description:
-        'BROWSE team members in projects and groups. Actions: "list_project" lists project members, "list_group" lists group members, "get_project" gets project member details, "get_group" gets group member details, "list_all_project" includes inherited members, "list_all_group" includes inherited members. Access levels: 0=No access, 5=Minimal, 10=Guest, 20=Reporter, 30=Developer, 40=Maintainer, 50=Owner.',
+        "View team members and access levels in projects or groups. Actions: list_project, list_group, get_project, get_group (direct members), list_all_project, list_all_group (includes inherited). Levels: Guest(10), Reporter(20), Developer(30), Maintainer(40), Owner(50). Related: manage_member to add/remove, browse_users to find users by name.",
       inputSchema: z.toJSONSchema(BrowseMembersSchema),
       handler: async (args: unknown): Promise<unknown> => {
         const input = BrowseMembersSchema.parse(args);
@@ -101,7 +101,7 @@ export const membersToolRegistry: ToolRegistry = new Map<string, EnhancedToolDef
     {
       name: "manage_member",
       description:
-        'MANAGE team members in projects and groups. Actions: "add_to_project" adds member to project, "add_to_group" adds member to group, "remove_from_project" removes from project, "remove_from_group" removes from group, "update_project" changes project member access level, "update_group" changes group member access level. Access levels: 0=No access, 5=Minimal, 10=Guest, 20=Reporter, 30=Developer, 40=Maintainer, 50=Owner.',
+        "Add, remove, or update access levels for project/group members. Actions: add_to_project, add_to_group (with access level + optional expiry), remove_from_project, remove_from_group, update_project, update_group (change access level). Related: browse_members for current membership.",
       inputSchema: z.toJSONSchema(ManageMemberSchema),
       handler: async (args: unknown): Promise<unknown> => {
         const input = ManageMemberSchema.parse(args);

--- a/src/entities/milestones/registry.ts
+++ b/src/entities/milestones/registry.ts
@@ -23,7 +23,7 @@ export const milestonesToolRegistry: ToolRegistry = new Map<string, EnhancedTool
     {
       name: "browse_milestones",
       description:
-        'BROWSE milestones. Actions: "list" shows milestones with filtering, "get" retrieves single milestone, "issues" lists issues in milestone, "merge_requests" lists MRs in milestone, "burndown" gets burndown chart data.',
+        "Track milestone progress with associated issues and MRs. Actions: list (filter by state/title/search), get (milestone details), issues (items in milestone), merge_requests (MRs targeting milestone), burndown (chart data for sprint tracking). Related: manage_milestone to create/update.",
       inputSchema: z.toJSONSchema(BrowseMilestonesSchema),
       gate: { envVar: "USE_MILESTONE", defaultValue: true },
       handler: async (args: unknown) => {
@@ -98,7 +98,7 @@ export const milestonesToolRegistry: ToolRegistry = new Map<string, EnhancedTool
     {
       name: "manage_milestone",
       description:
-        'MANAGE milestones. Actions: "create" creates new milestone, "update" modifies existing milestone, "delete" removes milestone, "promote" elevates project milestone to group level.',
+        "Create, update, or delete project/group milestones. Actions: create (title + optional dates/description), update (modify properties or close/activate), delete (remove permanently), promote (elevate project milestone to group). Related: browse_milestones for progress tracking.",
       inputSchema: z.toJSONSchema(ManageMilestoneSchema),
       gate: { envVar: "USE_MILESTONE", defaultValue: true },
       handler: async (args: unknown) => {

--- a/src/entities/mrs/registry.ts
+++ b/src/entities/mrs/registry.ts
@@ -67,7 +67,7 @@ export const mrsToolRegistry: ToolRegistry = new Map<string, EnhancedToolDefinit
     {
       name: "browse_merge_requests",
       description:
-        'BROWSE merge requests. Actions: "list" shows MRs with filtering, "get" retrieves single MR by IID or branch, "diffs" shows file changes, "compare" diffs two branches/commits.',
+        "Find and inspect merge requests. Actions: list (filter by state/author/reviewer/labels/branch), get (MR details by IID or source branch), diffs (file-level changes with inline suggestions), compare (diff between any two refs). Related: manage_merge_request to create/update/merge.",
       inputSchema: z.toJSONSchema(BrowseMergeRequestsSchema),
       gate: { envVar: "USE_MRS", defaultValue: true },
       handler: async (args: unknown) => {
@@ -172,7 +172,7 @@ export const mrsToolRegistry: ToolRegistry = new Map<string, EnhancedToolDefinit
     {
       name: "browse_mr_discussions",
       description:
-        'BROWSE MR discussions and draft notes. Actions: "list" shows all discussion threads, "drafts" lists unpublished draft notes, "draft" gets single draft note.',
+        "Read discussion threads and draft review notes on merge requests. Actions: list (all threads with resolution status), drafts (unpublished draft notes), draft (single draft details). Related: manage_mr_discussion to comment, manage_draft_notes to create drafts.",
       inputSchema: z.toJSONSchema(BrowseMrDiscussionsSchema),
       gate: { envVar: "USE_MRS", defaultValue: true },
       handler: async (args: unknown) => {
@@ -228,7 +228,7 @@ export const mrsToolRegistry: ToolRegistry = new Map<string, EnhancedToolDefinit
     {
       name: "manage_merge_request",
       description:
-        'MANAGE merge requests. Actions: "create" creates new MR, "update" modifies existing MR, "merge" merges approved MR into target branch, "approve" approves MR, "unapprove" removes approval, "get_approval_state" gets approval status.',
+        "Create, update, merge, or approve merge requests. Actions: create (new MR from source to target), update (title/description/assignees/reviewers/labels), merge (into target branch), approve/unapprove (review approval), get_approval_state (current approvals). Related: browse_merge_requests for discovery.",
       inputSchema: z.toJSONSchema(ManageMergeRequestSchema),
       gate: { envVar: "USE_MRS", defaultValue: true },
       handler: async (args: unknown) => {
@@ -338,7 +338,7 @@ export const mrsToolRegistry: ToolRegistry = new Map<string, EnhancedToolDefinit
     {
       name: "manage_mr_discussion",
       description:
-        'MANAGE MR discussions. Actions: "comment" adds comment, "thread" starts discussion, "reply" responds to thread, "update" modifies note, "apply_suggestion" applies code suggestion, "apply_suggestions" batch applies suggestions, "resolve" resolves/unresolves thread, "suggest" creates code suggestion.',
+        "Post comments, start threads, and suggest code changes on merge requests. Actions: comment (simple note), thread (line-level discussion), reply (to existing thread), update (edit note text), resolve (toggle thread resolution), suggest (code suggestion block), apply_suggestion/apply_suggestions (accept code suggestions). Related: browse_mr_discussions to read threads.",
       inputSchema: z.toJSONSchema(ManageMrDiscussionSchema),
       gate: { envVar: "USE_MRS", defaultValue: true },
       handler: async (args: unknown) => {
@@ -509,7 +509,7 @@ export const mrsToolRegistry: ToolRegistry = new Map<string, EnhancedToolDefinit
     {
       name: "manage_draft_notes",
       description:
-        'MANAGE draft notes. Actions: "create" creates draft note, "update" modifies draft, "publish" publishes single draft, "publish_all" publishes all drafts, "delete" removes draft.',
+        "Create and manage unpublished review comments on merge requests. Actions: create (new draft), update (modify text), publish (make single draft visible), publish_all (submit entire review), delete (discard draft). Related: browse_mr_discussions action 'drafts' to list existing drafts.",
       inputSchema: z.toJSONSchema(ManageDraftNotesSchema),
       gate: { envVar: "USE_MRS", defaultValue: true },
       handler: async (args: unknown) => {

--- a/src/entities/pipelines/registry.ts
+++ b/src/entities/pipelines/registry.ts
@@ -25,7 +25,7 @@ export const pipelinesToolRegistry: ToolRegistry = new Map<string, EnhancedToolD
     {
       name: "browse_pipelines",
       description:
-        'BROWSE pipelines. Actions: "list" searches pipelines with filtering, "get" retrieves single pipeline details, "jobs" lists jobs in pipeline, "triggers" lists bridge/trigger jobs, "job" gets single job details, "logs" fetches job console output.',
+        "Monitor CI/CD pipelines and read job logs. Actions: list (filter by status/ref/source/username), get (pipeline details), jobs (list pipeline jobs), triggers (bridge/trigger jobs), job (single job details), logs (job console output). Related: manage_pipeline to trigger/retry/cancel, manage_pipeline_job for individual jobs.",
       inputSchema: z.toJSONSchema(BrowsePipelinesSchema),
       gate: { envVar: "USE_PIPELINE", defaultValue: true },
       handler: async (args: unknown): Promise<unknown> => {
@@ -173,7 +173,7 @@ export const pipelinesToolRegistry: ToolRegistry = new Map<string, EnhancedToolD
     {
       name: "manage_pipeline",
       description:
-        'MANAGE pipelines. Actions: "create" triggers new pipeline on branch/tag with optional variables, "retry" re-runs failed/canceled pipeline, "cancel" stops running pipeline.',
+        "Trigger, retry, or cancel CI/CD pipelines. Actions: create (run pipeline on ref with variables), retry (re-run failed jobs), cancel (stop running pipeline). Related: browse_pipelines for monitoring.",
       inputSchema: z.toJSONSchema(ManagePipelineSchema),
       gate: { envVar: "USE_PIPELINE", defaultValue: true },
       handler: async (args: unknown): Promise<unknown> => {
@@ -291,7 +291,7 @@ export const pipelinesToolRegistry: ToolRegistry = new Map<string, EnhancedToolD
     {
       name: "manage_pipeline_job",
       description:
-        'MANAGE pipeline jobs. Actions: "play" triggers manual job with optional variables, "retry" re-runs failed/canceled job, "cancel" stops running job.',
+        "Control individual CI/CD jobs within a pipeline. Actions: play (trigger manual/delayed job with variables), retry (re-run single job), cancel (stop running job). Related: browse_pipelines actions 'job'/'logs' for job details.",
       inputSchema: z.toJSONSchema(ManagePipelineJobSchema),
       gate: { envVar: "USE_PIPELINE", defaultValue: true },
       handler: async (args: unknown): Promise<unknown> => {

--- a/src/entities/refs/registry.ts
+++ b/src/entities/refs/registry.ts
@@ -23,7 +23,7 @@ export const refsToolRegistry: ToolRegistry = new Map<string, EnhancedToolDefini
     {
       name: "browse_refs",
       description:
-        'BROWSE Git refs (branches and tags). Actions: "list_branches" lists all branches, "get_branch" gets branch details, "list_tags" lists all tags, "get_tag" gets tag details, "list_protected_branches" shows protected branches, "get_protected_branch" gets protection rules, "list_protected_tags" shows protected tags.',
+        "Inspect branches, tags, and their protection rules. Actions: list_branches, get_branch, list_tags, get_tag, list_protected_branches, get_protected_branch, list_protected_tags (protection details and access levels). Related: manage_ref to create/delete/protect, browse_commits for commit history.",
       inputSchema: z.toJSONSchema(BrowseRefsSchema),
       handler: async (args: unknown): Promise<unknown> => {
         const input = BrowseRefsSchema.parse(args);
@@ -99,7 +99,7 @@ export const refsToolRegistry: ToolRegistry = new Map<string, EnhancedToolDefini
     {
       name: "manage_ref",
       description:
-        'MANAGE Git refs (branches and tags). Actions: "create_branch" creates branch from ref, "delete_branch" removes branch, "protect_branch" adds protection, "unprotect_branch" removes protection, "update_branch_protection" modifies rules, "create_tag" creates tag, "delete_tag" removes tag, "protect_tag" adds tag protection (Premium), "unprotect_tag" removes tag protection.',
+        "Create, delete, and protect branches and tags. Actions: create_branch (from ref), delete_branch, protect_branch (set allowed roles), unprotect_branch, update_branch_protection, create_tag (annotated or lightweight), delete_tag, protect_tag, unprotect_tag. Related: browse_refs for inspection.",
       inputSchema: z.toJSONSchema(ManageRefSchema),
       handler: async (args: unknown): Promise<unknown> => {
         const input = ManageRefSchema.parse(args);

--- a/src/entities/releases/registry.ts
+++ b/src/entities/releases/registry.ts
@@ -21,7 +21,7 @@ export const releasesToolRegistry: ToolRegistry = new Map<string, EnhancedToolDe
     {
       name: "browse_releases",
       description:
-        'BROWSE GitLab project releases. Actions: "list" shows all releases sorted by date, "get" retrieves specific release by tag name, "assets" lists release asset links. Releases are versioned software distributions with changelogs, assets, and milestone associations.',
+        "View project releases and asset download links. Actions: list (releases sorted by date), get (release details by tag name), assets (download link list for release). Related: manage_release to create/publish.",
       inputSchema: z.toJSONSchema(BrowseReleasesSchema),
       handler: async (args: unknown): Promise<unknown> => {
         const input = BrowseReleasesSchema.parse(args);
@@ -78,7 +78,7 @@ export const releasesToolRegistry: ToolRegistry = new Map<string, EnhancedToolDe
     {
       name: "manage_release",
       description:
-        'MANAGE GitLab releases. Actions: "create" creates release with optional assets, "update" modifies release metadata, "delete" removes release (preserves tag), "create_link" adds asset link, "delete_link" removes asset link.',
+        "Create, update, or delete project releases with asset management. Actions: create (release from tag with notes/assets), update (modify metadata), delete (remove release, tag preserved), create_link (add asset URL), delete_link (remove asset). Related: browse_releases for discovery.",
       inputSchema: z.toJSONSchema(ManageReleaseSchema),
       handler: async (args: unknown): Promise<unknown> => {
         const input = ManageReleaseSchema.parse(args);

--- a/src/entities/search/registry.ts
+++ b/src/entities/search/registry.ts
@@ -21,7 +21,7 @@ export const searchToolRegistry: ToolRegistry = new Map<string, EnhancedToolDefi
     {
       name: "browse_search",
       description:
-        'SEARCH GitLab resources. Actions: "global" searches entire instance, "project" searches within a project, "group" searches within a group. Scopes: projects, issues, merge_requests, milestones, users, groups, blobs (code), commits, wiki_blobs, notes.',
+        "Search across GitLab resources globally or within a scope. Actions: global (entire instance), project (within specific project), group (within specific group). Searchable: projects, issues, merge_requests, milestones, users, blobs (code), commits, wiki_blobs, notes.",
       inputSchema: z.toJSONSchema(BrowseSearchSchema),
       gate: { envVar: "USE_SEARCH", defaultValue: true },
       handler: async (args: unknown): Promise<unknown> => {

--- a/src/entities/snippets/registry.ts
+++ b/src/entities/snippets/registry.ts
@@ -21,7 +21,7 @@ export const snippetsToolRegistry: ToolRegistry = new Map<string, EnhancedToolDe
     {
       name: "browse_snippets",
       description:
-        'BROWSE GitLab code snippets. Actions: "list" shows snippets by scope (personal/project/public) with filtering, "get" retrieves single snippet metadata or raw content. Snippets are reusable code blocks, configs, or text with versioning support.',
+        "Find and read code snippets with versioning support. Actions: list (personal/project/public scope with filtering), get (snippet metadata or raw file content). Related: manage_snippet to create/update.",
       inputSchema: z.toJSONSchema(BrowseSnippetsSchema),
       gate: { envVar: "USE_SNIPPETS", defaultValue: true },
       handler: async (args: unknown): Promise<unknown> => {
@@ -95,7 +95,7 @@ export const snippetsToolRegistry: ToolRegistry = new Map<string, EnhancedToolDe
     {
       name: "manage_snippet",
       description:
-        'MANAGE GitLab snippets. Actions: "create" creates new snippet with multiple files and visibility control, "update" modifies title/description/visibility/files (supports file create/update/delete/move), "delete" permanently removes snippet. Supports personal and project snippets.',
+        "Create, update, or delete code snippets with multi-file support. Actions: create (new snippet with files and visibility), update (modify content/metadata, file operations), delete (remove permanently). Related: browse_snippets for discovery.",
       inputSchema: z.toJSONSchema(ManageSnippetSchema),
       gate: { envVar: "USE_SNIPPETS", defaultValue: true },
       handler: async (args: unknown): Promise<unknown> => {

--- a/src/entities/variables/registry.ts
+++ b/src/entities/variables/registry.ts
@@ -22,7 +22,7 @@ export const variablesToolRegistry: ToolRegistry = new Map<string, EnhancedToolD
     {
       name: "browse_variables",
       description:
-        'BROWSE CI/CD variables. Actions: "list" shows all variables in project/group with pagination, "get" retrieves single variable details by key with optional environment scope filter.',
+        "List and inspect CI/CD variables for projects or groups. Actions: list (all variables with pagination), get (single variable by key with environment scope filter). Related: manage_variable to create/update/delete.",
       inputSchema: z.toJSONSchema(BrowseVariablesSchema),
       gate: { envVar: "USE_VARIABLES", defaultValue: true },
       handler: async (args: unknown) => {
@@ -74,7 +74,7 @@ export const variablesToolRegistry: ToolRegistry = new Map<string, EnhancedToolD
     {
       name: "manage_variable",
       description:
-        'MANAGE CI/CD variables. Actions: "create" adds new variable (requires key and value), "update" modifies existing variable, "delete" removes variable permanently. Supports environment scoping and protection settings.',
+        "Create, update, or delete CI/CD variables with environment scoping. Actions: create (key + value, set scope/protection/masking), update (modify value or settings), delete (remove permanently). Related: browse_variables for discovery.",
       inputSchema: z.toJSONSchema(ManageVariableSchema),
       gate: { envVar: "USE_VARIABLES", defaultValue: true },
       handler: async (args: unknown) => {

--- a/src/entities/webhooks/registry.ts
+++ b/src/entities/webhooks/registry.ts
@@ -21,7 +21,7 @@ export const webhooksToolRegistry: ToolRegistry = new Map<string, EnhancedToolDe
     {
       name: "browse_webhooks",
       description:
-        'BROWSE webhooks. Actions: "list" shows all webhooks configured for a project or group with pagination, "get" retrieves single webhook details by ID. Use to discover existing integrations, audit webhook configurations, debug delivery issues, or understand event subscriptions.',
+        "List and inspect webhook configurations for projects or groups. Actions: list (all webhooks with event types and status), get (webhook details by ID). Related: manage_webhook to create/update/delete/test.",
       inputSchema: z.toJSONSchema(BrowseWebhooksSchema),
       gate: { envVar: "USE_WEBHOOKS", defaultValue: true },
       handler: async (args: unknown) => {
@@ -81,7 +81,7 @@ export const webhooksToolRegistry: ToolRegistry = new Map<string, EnhancedToolDe
     {
       name: "manage_webhook",
       description:
-        "Manage webhooks with full CRUD operations plus testing. Actions: 'create' (add new webhook with URL and event types), 'update' (modify URL, events, or settings), 'delete' (remove webhook), 'test' (trigger test delivery for specific event type). Use for setting up CI/CD automation, configuring notifications, integrating external systems, or managing event subscriptions.",
+        "Create, update, delete, or test webhooks for event-driven automation. Actions: create (URL + event types + optional secret), update (modify settings), delete (remove), test (trigger delivery for specific event). Related: browse_webhooks for inspection.",
       inputSchema: z.toJSONSchema(ManageWebhookSchema),
       gate: { envVar: "USE_WEBHOOKS", defaultValue: true },
       handler: async (args: unknown) => {

--- a/src/entities/wiki/registry.ts
+++ b/src/entities/wiki/registry.ts
@@ -22,7 +22,7 @@ export const wikiToolRegistry: ToolRegistry = new Map<string, EnhancedToolDefini
     {
       name: "browse_wiki",
       description:
-        'BROWSE wiki pages. Actions: "list" shows all wiki pages in project/group, "get" retrieves single wiki page content by slug.',
+        "Read wiki pages in projects or groups. Actions: list (all pages with metadata), get (page content by slug). Related: manage_wiki to create/update/delete.",
       inputSchema: z.toJSONSchema(BrowseWikiSchema),
       gate: { envVar: "USE_GITLAB_WIKI", defaultValue: true },
       handler: async (args: unknown) => {
@@ -68,7 +68,7 @@ export const wikiToolRegistry: ToolRegistry = new Map<string, EnhancedToolDefini
     {
       name: "manage_wiki",
       description:
-        'MANAGE wiki pages. Actions: "create" adds new wiki page, "update" modifies existing page, "delete" removes wiki page permanently.',
+        "Create, update, or delete wiki pages. Actions: create (new page with title/content/format), update (modify content or title), delete (remove permanently). Related: browse_wiki to read pages.",
       inputSchema: z.toJSONSchema(ManageWikiSchema),
       gate: { envVar: "USE_GITLAB_WIKI", defaultValue: true },
       handler: async (args: unknown) => {

--- a/src/entities/workitems/registry.ts
+++ b/src/entities/workitems/registry.ts
@@ -224,7 +224,7 @@ export const workitemsToolRegistry: ToolRegistry = new Map<string, EnhancedToolD
     {
       name: "browse_work_items",
       description:
-        'BROWSE work items. Actions: "list" returns work items with numeric IDs (groups return epics, projects return issues/tasks), "get" retrieves single work item - use the numeric ID from list results (e.g., "5953") or namespace + iid from URL (e.g., namespace: "group/project", iid: "95" from /issues/95). Legacy GIDs like gid://gitlab/Issue/X are auto-normalized.',
+        "Find and inspect issues, epics, tasks, and other work items. Actions: list (groups return epics, projects return issues/tasks, filter by type/state/labels), get (by numeric ID or namespace+iid from URL path). Related: manage_work_item to create/update/delete.",
       inputSchema: z.toJSONSchema(BrowseWorkItemsSchema),
       gate: { envVar: "USE_WORKITEMS", defaultValue: true },
       handler: async (args: unknown): Promise<unknown> => {
@@ -371,7 +371,7 @@ export const workitemsToolRegistry: ToolRegistry = new Map<string, EnhancedToolD
     {
       name: "manage_work_item",
       description:
-        'MANAGE work items. Actions: "create" creates new work item (Epics need GROUP namespace, Issues/Tasks need PROJECT), "update" modifies properties/widgets using numeric ID, "delete" permanently removes, "add_link" creates relationship (BLOCKS/IS_BLOCKED_BY/RELATES_TO), "remove_link" removes relationship. Supports dates, time tracking, hierarchy, weight, iterations, health status, progress, color widgets. Legacy GIDs auto-normalized.',
+        "Create, update, delete, or link work items (issues, epics, tasks). Actions: create (epics need GROUP namespace, issues/tasks need PROJECT), update (widgets: dates, time tracking, weight, iterations, health, progress, hierarchy), delete (permanent), add_link/remove_link (BLOCKS/IS_BLOCKED_BY/RELATES_TO). Related: browse_work_items for discovery.",
       inputSchema: z.toJSONSchema(ManageWorkItemSchema),
       gate: { envVar: "USE_WORKITEMS", defaultValue: true },
       handler: async (args: unknown): Promise<unknown> => {

--- a/src/utils/description-utils.ts
+++ b/src/utils/description-utils.ts
@@ -1,0 +1,36 @@
+/**
+ * Description Utilities for Tool Cross-References
+ *
+ * Provides dynamic resolution of "Related:" sections in tool descriptions.
+ * References to unavailable tools (disabled via USE_*, GITLAB_DENIED_TOOLS_REGEX,
+ * tier/version gating, or all-actions-denied) are automatically stripped.
+ */
+
+/**
+ * Strip "Related:" section references to unavailable tools.
+ * If all referenced tools are unavailable, the entire "Related:" clause is removed.
+ *
+ * Format: "... Related: tool_name purpose, tool_name2 purpose."
+ * Multiple items separated by commas. Each starts with a tool name (browse_ or manage_ prefix).
+ */
+export function resolveRelatedReferences(description: string, availableTools: Set<string>): string {
+  const relatedMatch = description.match(/\s*Related:\s*(.+?)\.?\s*$/);
+  if (!relatedMatch) return description;
+
+  const matchIndex = relatedMatch.index ?? description.length;
+  const baseDescription = description.substring(0, matchIndex);
+  const relatedContent = relatedMatch[1];
+
+  // Split by comma, keep only items whose tool is available
+  const items = relatedContent.split(",").map(s => s.trim());
+  const available = items.filter(item => {
+    const toolRef = item.match(/^((?:browse|manage)_\w+)\b/);
+    return toolRef && availableTools.has(toolRef[1]);
+  });
+
+  if (available.length === 0) {
+    return baseDescription.trimEnd();
+  }
+
+  return `${baseDescription.trimEnd()} Related: ${available.join(", ")}.`;
+}

--- a/tests/unit/entities/context/registry.test.ts
+++ b/tests/unit/entities/context/registry.test.ts
@@ -20,7 +20,9 @@ describe("contextToolRegistry", () => {
     const tool = contextToolRegistry.get("manage_context");
     expect(tool).toBeDefined();
     expect(tool?.name).toBe("manage_context");
-    expect(tool?.description).toContain("CONTEXT");
+    expect(tool?.description).toContain("session configuration");
+    expect(tool?.description).toContain("show");
+    expect(tool?.description).toContain("switch_preset");
     expect(tool?.inputSchema).toBeDefined();
     expect(tool?.handler).toBeDefined();
     expect(typeof tool?.handler).toBe("function");

--- a/tests/unit/entities/files/registry.test.ts
+++ b/tests/unit/entities/files/registry.test.ts
@@ -74,7 +74,9 @@ describe("Files Registry", () => {
 
       expect(tool).toBeDefined();
       expect(tool?.name).toBe("browse_files");
-      expect(tool?.description).toContain("BROWSE");
+      expect(tool?.description).toContain("file structure");
+      expect(tool?.description).toContain("tree");
+      expect(tool?.description).toContain("content");
       expect(tool?.inputSchema).toBeDefined();
     });
 
@@ -83,7 +85,9 @@ describe("Files Registry", () => {
 
       expect(tool).toBeDefined();
       expect(tool?.name).toBe("manage_files");
-      expect(tool?.description).toContain("MANAGE");
+      expect(tool?.description).toContain("Create, update, or upload");
+      expect(tool?.description).toContain("single");
+      expect(tool?.description).toContain("batch");
       expect(tool?.inputSchema).toBeDefined();
     });
   });

--- a/tests/unit/entities/integrations/registry.test.ts
+++ b/tests/unit/entities/integrations/registry.test.ts
@@ -86,7 +86,8 @@ describe("Integrations Registry", () => {
       const tool = integrationsToolRegistry.get("browse_integrations");
       expect(tool).toBeDefined();
       expect(tool!.name).toBe("browse_integrations");
-      expect(tool!.description).toContain("BROWSE project integrations");
+      expect(tool!.description).toContain("integrations");
+      expect(tool!.description).toContain("list");
       expect(tool!.inputSchema).toBeDefined();
     });
 
@@ -94,22 +95,15 @@ describe("Integrations Registry", () => {
       const tool = integrationsToolRegistry.get("manage_integration");
       expect(tool).toBeDefined();
       expect(tool!.name).toBe("manage_integration");
-      expect(tool!.description).toContain("MANAGE project integrations");
+      expect(tool!.description).toContain("integrations");
+      expect(tool!.description).toContain("update");
       expect(tool!.inputSchema).toBeDefined();
-    });
-
-    it("should mention supported integrations in manage_integration description", () => {
-      const tool = integrationsToolRegistry.get("manage_integration");
-      expect(tool).toBeDefined();
-      expect(tool!.description).toContain("Slack");
-      expect(tool!.description).toContain("Jira");
-      expect(tool!.description).toContain("Discord");
     });
 
     it("should mention gitlab-slack-application limitation in description", () => {
       const tool = integrationsToolRegistry.get("manage_integration");
       expect(tool).toBeDefined();
-      expect(tool!.description).toContain("gitlab-slack-application cannot be created via API");
+      expect(tool!.description).toContain("gitlab-slack-application");
     });
   });
 

--- a/tests/unit/entities/labels/registry.test.ts
+++ b/tests/unit/entities/labels/registry.test.ts
@@ -74,7 +74,7 @@ describe("Labels Registry - CQRS Tools", () => {
 
       expect(tool).toBeDefined();
       expect(tool?.name).toBe("browse_labels");
-      expect(tool?.description).toContain("BROWSE labels");
+      expect(tool?.description).toContain("labels");
       expect(tool?.description).toContain("list");
       expect(tool?.description).toContain("get");
       expect(tool?.inputSchema).toBeDefined();
@@ -85,7 +85,7 @@ describe("Labels Registry - CQRS Tools", () => {
 
       expect(tool).toBeDefined();
       expect(tool?.name).toBe("manage_label");
-      expect(tool?.description).toContain("MANAGE labels");
+      expect(tool?.description).toContain("labels");
       expect(tool?.description).toContain("create");
       expect(tool?.description).toContain("update");
       expect(tool?.description).toContain("delete");

--- a/tests/unit/entities/milestones/index.test.ts
+++ b/tests/unit/entities/milestones/index.test.ts
@@ -21,13 +21,13 @@ describe("Milestone Index Exports", () => {
     it("should include browse_milestones tool", () => {
       const browseTool = allTools.find(t => t.name === "browse_milestones");
       expect(browseTool).toBeDefined();
-      expect(browseTool?.description).toContain("BROWSE");
+      expect(browseTool?.description).toContain("milestone");
     });
 
     it("should include manage_milestone tool", () => {
       const manageTool = allTools.find(t => t.name === "manage_milestone");
       expect(manageTool).toBeDefined();
-      expect(manageTool?.description).toContain("MANAGE");
+      expect(manageTool?.description).toContain("milestone");
     });
 
     it("should have valid tool definition structure", () => {

--- a/tests/unit/entities/milestones/registry.test.ts
+++ b/tests/unit/entities/milestones/registry.test.ts
@@ -88,7 +88,7 @@ describe("Milestones Registry - CQRS Tools", () => {
 
       expect(tool).toBeDefined();
       expect(tool?.name).toBe("browse_milestones");
-      expect(tool?.description).toContain("BROWSE milestones");
+      expect(tool?.description).toContain("milestone");
       expect(tool?.description).toContain("list");
       expect(tool?.description).toContain("get");
       expect(tool?.description).toContain("issues");
@@ -102,7 +102,7 @@ describe("Milestones Registry - CQRS Tools", () => {
 
       expect(tool).toBeDefined();
       expect(tool?.name).toBe("manage_milestone");
-      expect(tool?.description).toContain("MANAGE milestones");
+      expect(tool?.description).toContain("milestone");
       expect(tool?.description).toContain("create");
       expect(tool?.description).toContain("update");
       expect(tool?.description).toContain("delete");

--- a/tests/unit/entities/mrs/registry.test.ts
+++ b/tests/unit/entities/mrs/registry.test.ts
@@ -326,7 +326,7 @@ describe("MRS Registry", () => {
       const tool = mrsToolRegistry.get("browse_merge_requests");
       expect(tool).toBeDefined();
       expect(tool!.name).toBe("browse_merge_requests");
-      expect(tool!.description).toContain("BROWSE");
+      expect(tool!.description).toContain("merge requests");
       expect(tool!.description).toContain("list");
       expect(tool!.description).toContain("get");
       expect(tool!.description).toContain("diffs");
@@ -338,7 +338,7 @@ describe("MRS Registry", () => {
       const tool = mrsToolRegistry.get("browse_mr_discussions");
       expect(tool).toBeDefined();
       expect(tool!.name).toBe("browse_mr_discussions");
-      expect(tool!.description).toContain("BROWSE");
+      expect(tool!.description).toContain("discussion threads");
       expect(tool!.description).toContain("list");
       expect(tool!.description).toContain("drafts");
       expect(tool!.description).toContain("draft");
@@ -349,7 +349,7 @@ describe("MRS Registry", () => {
       const tool = mrsToolRegistry.get("manage_merge_request");
       expect(tool).toBeDefined();
       expect(tool!.name).toBe("manage_merge_request");
-      expect(tool!.description).toContain("MANAGE");
+      expect(tool!.description).toContain("merge requests");
       expect(tool!.description).toContain("create");
       expect(tool!.description).toContain("update");
       expect(tool!.description).toContain("merge");
@@ -363,7 +363,7 @@ describe("MRS Registry", () => {
       const tool = mrsToolRegistry.get("manage_mr_discussion");
       expect(tool).toBeDefined();
       expect(tool!.name).toBe("manage_mr_discussion");
-      expect(tool!.description).toContain("MANAGE");
+      expect(tool!.description).toContain("threads");
       expect(tool!.description).toContain("comment");
       expect(tool!.description).toContain("thread");
       expect(tool!.description).toContain("reply");
@@ -379,7 +379,7 @@ describe("MRS Registry", () => {
       const tool = mrsToolRegistry.get("manage_draft_notes");
       expect(tool).toBeDefined();
       expect(tool!.name).toBe("manage_draft_notes");
-      expect(tool!.description).toContain("MANAGE");
+      expect(tool!.description).toContain("draft");
       expect(tool!.description).toContain("create");
       expect(tool!.description).toContain("update");
       expect(tool!.description).toContain("publish");

--- a/tests/unit/entities/pipelines/registry.test.ts
+++ b/tests/unit/entities/pipelines/registry.test.ts
@@ -75,7 +75,7 @@ describe("Pipelines Registry - CQRS Tools", () => {
 
       expect(tool).toBeDefined();
       expect(tool?.name).toBe("browse_pipelines");
-      expect(tool?.description).toContain("BROWSE pipelines");
+      expect(tool?.description).toContain("CI/CD pipelines");
       expect(tool?.description).toContain("list");
       expect(tool?.description).toContain("get");
       expect(tool?.description).toContain("jobs");
@@ -89,7 +89,7 @@ describe("Pipelines Registry - CQRS Tools", () => {
 
       expect(tool).toBeDefined();
       expect(tool?.name).toBe("manage_pipeline");
-      expect(tool?.description).toContain("MANAGE pipelines");
+      expect(tool?.description).toContain("pipelines");
       expect(tool?.description).toContain("create");
       expect(tool?.description).toContain("retry");
       expect(tool?.description).toContain("cancel");
@@ -101,7 +101,7 @@ describe("Pipelines Registry - CQRS Tools", () => {
 
       expect(tool).toBeDefined();
       expect(tool?.name).toBe("manage_pipeline_job");
-      expect(tool?.description).toContain("MANAGE pipeline jobs");
+      expect(tool?.description).toContain("individual CI/CD jobs");
       expect(tool?.description).toContain("play");
       expect(tool?.description).toContain("retry");
       expect(tool?.description).toContain("cancel");

--- a/tests/unit/entities/releases/registry.test.ts
+++ b/tests/unit/entities/releases/registry.test.ts
@@ -81,7 +81,8 @@ describe("Releases Registry", () => {
       const tool = releasesToolRegistry.get("browse_releases");
       expect(tool).toBeDefined();
       expect(tool!.name).toBe("browse_releases");
-      expect(tool!.description).toContain("BROWSE");
+      expect(tool!.description).toContain("releases");
+      expect(tool!.description).toContain("assets");
       expect(tool!.inputSchema).toBeDefined();
     });
 
@@ -89,7 +90,8 @@ describe("Releases Registry", () => {
       const tool = releasesToolRegistry.get("manage_release");
       expect(tool).toBeDefined();
       expect(tool!.name).toBe("manage_release");
-      expect(tool!.description).toContain("MANAGE");
+      expect(tool!.description).toContain("releases");
+      expect(tool!.description).toContain("create");
       expect(tool!.inputSchema).toBeDefined();
     });
   });

--- a/tests/unit/entities/search/registry.test.ts
+++ b/tests/unit/entities/search/registry.test.ts
@@ -56,7 +56,7 @@ describe("Search Tool Registry", () => {
     });
 
     it("should have proper description", () => {
-      expect(browseSearchTool?.description).toContain("SEARCH GitLab resources");
+      expect(browseSearchTool?.description).toContain("Search across GitLab");
       expect(browseSearchTool?.description).toContain("global");
       expect(browseSearchTool?.description).toContain("project");
       expect(browseSearchTool?.description).toContain("group");

--- a/tests/unit/entities/variables/registry.test.ts
+++ b/tests/unit/entities/variables/registry.test.ts
@@ -77,7 +77,6 @@ describe("Variables Registry", () => {
 
       expect(tool).toBeDefined();
       expect(tool?.name).toBe("browse_variables");
-      expect(tool?.description).toContain("BROWSE");
       expect(tool?.description).toContain("CI/CD variables");
       expect(tool?.inputSchema).toBeDefined();
     });
@@ -87,8 +86,8 @@ describe("Variables Registry", () => {
 
       expect(tool).toBeDefined();
       expect(tool?.name).toBe("manage_variable");
-      expect(tool?.description).toContain("MANAGE");
       expect(tool?.description).toContain("CI/CD variables");
+      expect(tool?.description).toContain("environment scoping");
       expect(tool?.inputSchema).toBeDefined();
     });
   });

--- a/tests/unit/entities/webhooks/registry.test.ts
+++ b/tests/unit/entities/webhooks/registry.test.ts
@@ -81,7 +81,7 @@ describe("Webhooks Registry", () => {
       const tool = webhooksToolRegistry.get("browse_webhooks");
       expect(tool).toBeDefined();
       expect(tool!.name).toBe("browse_webhooks");
-      expect(tool!.description).toContain("BROWSE webhooks");
+      expect(tool!.description).toContain("webhook configurations");
       expect(tool!.inputSchema).toBeDefined();
     });
 
@@ -89,7 +89,9 @@ describe("Webhooks Registry", () => {
       const tool = webhooksToolRegistry.get("manage_webhook");
       expect(tool).toBeDefined();
       expect(tool!.name).toBe("manage_webhook");
-      expect(tool!.description).toContain("Manage webhooks with full CRUD");
+      expect(tool!.description).toContain("webhooks");
+      expect(tool!.description).toContain("create");
+      expect(tool!.description).toContain("test");
       expect(tool!.inputSchema).toBeDefined();
     });
   });

--- a/tests/unit/entities/wiki/registry.test.ts
+++ b/tests/unit/entities/wiki/registry.test.ts
@@ -74,7 +74,7 @@ describe("Wiki Registry - CQRS Tools", () => {
 
       expect(tool).toBeDefined();
       expect(tool?.name).toBe("browse_wiki");
-      expect(tool?.description).toContain("BROWSE wiki");
+      expect(tool?.description).toContain("wiki pages");
       expect(tool?.description).toContain("list");
       expect(tool?.description).toContain("get");
       expect(tool?.inputSchema).toBeDefined();
@@ -85,7 +85,7 @@ describe("Wiki Registry - CQRS Tools", () => {
 
       expect(tool).toBeDefined();
       expect(tool?.name).toBe("manage_wiki");
-      expect(tool?.description).toContain("MANAGE wiki");
+      expect(tool?.description).toContain("wiki pages");
       expect(tool?.description).toContain("create");
       expect(tool?.description).toContain("update");
       expect(tool?.description).toContain("delete");

--- a/tests/unit/entities/workitems/registry.test.ts
+++ b/tests/unit/entities/workitems/registry.test.ts
@@ -78,7 +78,7 @@ describe("Workitems Registry - CQRS Tools", () => {
 
       expect(tool).toBeDefined();
       expect(tool?.name).toBe("browse_work_items");
-      expect(tool?.description).toContain("BROWSE work items");
+      expect(tool?.description).toContain("work items");
       expect(tool?.description).toContain("list");
       expect(tool?.description).toContain("get");
       expect(tool?.inputSchema).toBeDefined();
@@ -89,7 +89,7 @@ describe("Workitems Registry - CQRS Tools", () => {
 
       expect(tool).toBeDefined();
       expect(tool?.name).toBe("manage_work_item");
-      expect(tool?.description).toContain("MANAGE work items");
+      expect(tool?.description).toContain("work items");
       expect(tool?.description).toContain("create");
       expect(tool?.description).toContain("update");
       expect(tool?.description).toContain("delete");

--- a/tests/unit/utils/description-utils.test.ts
+++ b/tests/unit/utils/description-utils.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Unit tests for description-utils.ts
+ * Tests dynamic resolution of "Related:" cross-references in tool descriptions
+ */
+
+import { resolveRelatedReferences } from "../../../src/utils/description-utils";
+
+describe("resolveRelatedReferences", () => {
+  it("returns description unchanged when no Related section", () => {
+    const desc = "Find projects. Actions: search, list, get.";
+    expect(resolveRelatedReferences(desc, new Set(["manage_project"]))).toBe(desc);
+  });
+
+  it("keeps Related when referenced tool is available", () => {
+    const desc = "Find projects. Related: manage_project to create.";
+    const result = resolveRelatedReferences(desc, new Set(["manage_project"]));
+    expect(result).toContain("Related: manage_project");
+  });
+
+  it("strips Related when referenced tool is unavailable", () => {
+    const desc = "Find projects. Related: manage_project to create.";
+    const result = resolveRelatedReferences(desc, new Set(["browse_labels"]));
+    expect(result).toBe("Find projects.");
+  });
+
+  it("keeps only available tools from comma-separated list", () => {
+    const desc =
+      "Read discussions. Related: manage_mr_discussion to comment, manage_draft_notes to create.";
+    const result = resolveRelatedReferences(desc, new Set(["manage_mr_discussion"]));
+    expect(result).toBe("Read discussions. Related: manage_mr_discussion to comment.");
+    expect(result).not.toContain("manage_draft_notes");
+  });
+
+  it("handles all tools unavailable in multi-reference", () => {
+    const desc = "Monitor CI/CD. Related: manage_pipeline to retry, manage_pipeline_job for jobs.";
+    const result = resolveRelatedReferences(desc, new Set(["browse_labels"]));
+    expect(result).toBe("Monitor CI/CD.");
+  });
+
+  it("handles browse_ references correctly", () => {
+    const desc = "Create refs. Related: browse_refs for inspection.";
+    const result = resolveRelatedReferences(desc, new Set(["browse_refs"]));
+    expect(result).toContain("browse_refs");
+  });
+
+  it("preserves base description with actions when Related is stripped", () => {
+    const desc =
+      "List and inspect labels. Actions: list, get. Related: manage_label to create/update/delete.";
+    const result = resolveRelatedReferences(desc, new Set(["browse_labels"]));
+    expect(result).toBe("List and inspect labels. Actions: list, get.");
+  });
+
+  it("keeps all references when all tools are available", () => {
+    const desc = "Monitor CI/CD. Related: manage_pipeline to retry, manage_pipeline_job for jobs.";
+    const result = resolveRelatedReferences(
+      desc,
+      new Set(["manage_pipeline", "manage_pipeline_job"])
+    );
+    expect(result).toBe(
+      "Monitor CI/CD. Related: manage_pipeline to retry, manage_pipeline_job for jobs."
+    );
+  });
+
+  it("handles description without trailing period on Related section", () => {
+    const desc = "Find items. Related: manage_work_item to create";
+    const result = resolveRelatedReferences(desc, new Set(["manage_work_item"]));
+    expect(result).toContain("Related: manage_work_item to create.");
+  });
+
+  it("does not match non-tool references in Related section", () => {
+    // If Related contains something that doesn't start with browse_/manage_, it's filtered
+    const desc = "Find items. Related: some_other_tool for testing.";
+    const result = resolveRelatedReferences(desc, new Set(["some_other_tool"]));
+    expect(result).toBe("Find items.");
+  });
+});


### PR DESCRIPTION
## Summary

- Rewrite all 32 remaining tool descriptions from UPPERCASE PREFIX format to intent-first agentic format with dynamic cross-references
- Add `resolveRelatedReferences()` utility that strips `Related:` references to unavailable tools (disabled via `USE_*`, `GITLAB_DENIED_TOOLS_REGEX`, read-only mode, or tier/version gating)
- Integrate dynamic resolution into `buildToolLookupCache()` and `getAllToolDefinitionsTierless()` in registry-manager

## Test plan

- [x] `yarn lint` — 0 errors
- [x] `yarn test` — 3820 tests passing (124 suites)
- [x] `yarn build` — clean
- [x] New unit tests for `description-utils` (10 cases)
- [x] New RegistryManager integration tests for Related resolution (5 scenarios: unavailable tool, available tool, read-only mode, denied regex, custom override bypass)
- [x] Updated assertions in 14 entity test files

Closes #169