### PR TITLE
fix(docs): reorder MCPB download before VitePress build

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -39,28 +39,27 @@ jobs:
       - name: Install dependencies
         run: yarn install --immutable
 
+      - name: Download latest MCPB bundle
+        run: |
+          mkdir -p docs/public/downloads
+          LATEST_TAG=$(gh release view --json tagName --jq '.tagName' 2>/dev/null || echo "")
+          if [ -n "$LATEST_TAG" ]; then
+            VERSION="${LATEST_TAG#v}"
+            gh release download "$LATEST_TAG" --pattern "*.mcpb" --dir docs/public/downloads/ || true
+            MCPB_FILE="docs/public/downloads/gitlab-mcp-${VERSION}.mcpb"
+            if [ -f "$MCPB_FILE" ]; then
+              cp "$MCPB_FILE" docs/public/downloads/gitlab-mcp-latest.mcpb
+              echo "MCPB bundle included: ${VERSION}"
+            fi
+          fi
+          # If no .mcpb release exists yet, ignoreDeadLinks in config.mts handles the link checker
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build documentation
         run: yarn docs:build
         env:
           DOCS_BASE: /
-
-      - name: Download latest MCPB bundle
-        run: |
-          LATEST_TAG=$(gh release view --json tagName -q .tagName 2>/dev/null || echo "")
-          if [ -n "$LATEST_TAG" ]; then
-            VERSION="${LATEST_TAG#v}"
-            MCPB_FILE="gitlab-mcp-${VERSION}.mcpb"
-            mkdir -p docs/.vitepress/dist/downloads
-            gh release download "$LATEST_TAG" --pattern "*.mcpb" --dir docs/.vitepress/dist/downloads/ || true
-            if [ -f "docs/.vitepress/dist/downloads/${MCPB_FILE}" ]; then
-              cp "docs/.vitepress/dist/downloads/${MCPB_FILE}" "docs/.vitepress/dist/downloads/gitlab-mcp-latest.mcpb"
-              echo "MCPB bundle included: ${MCPB_FILE}"
-            fi
-          else
-            echo "No release found, skipping MCPB inclusion"
-          fi
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run tests with coverage
         run: yarn test:cov

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -7,6 +7,10 @@ export default defineConfig({
   description: "Model Context Protocol server for GitLab API",
   base,
 
+  // MCPB bundle is downloaded from GitHub releases during docs build.
+  // Until first .mcpb release exists, the link is a dead link — safe to ignore.
+  ignoreDeadLinks: [/\/downloads\/.+\.mcpb$/],
+
   head: [
     ["link", { rel: "icon", type: "image/x-icon", href: "/favicon.ico" }],
     ["link", { rel: "icon", type: "image/png", sizes: "32x32", href: "/favicon-32x32.png" }],


### PR DESCRIPTION
## Summary

- Move MCPB download step before `yarn docs:build` in docs workflow
- Download to `docs/public/downloads/` instead of `docs/.vitepress/dist/downloads/`
- Add `ignoreDeadLinks` regex for `.mcpb` files as safety net until first release

## Test plan

- [ ] Docs workflow passes (no dead link errors)
- [ ] After first .mcpb release, file is served at `/downloads/gitlab-mcp-latest.mcpb`

Fixes #175