### PR TITLE
fix(mcpb): reduce bundle size from 84MB to ~45MB

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,11 +67,9 @@
   },
   "dependencies": {
     "@clack/prompts": "1.0.0-alpha.9",
-    "@graphql-typed-document-node/core": "^3.2.0",
     "@modelcontextprotocol/sdk": "^1.25.3",
     "@prisma/client": "^7.3.0",
     "express": "^5.2.1",
-    "form-data": "^4.0.5",
     "graphql": "^16.12.0",
     "graphql-tag": "^2.12.6",
     "http-proxy-agent": "^7.0.2",
@@ -88,6 +86,7 @@
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20260124.0",
     "@eslint/js": "^9.39.2",
+    "@graphql-typed-document-node/core": "^3.2.0",
     "@semantic-release/changelog": "^6.0.3",
     "@semantic-release/exec": "^7.1.0",
     "@semantic-release/git": "^10.0.1",

--- a/scripts/build-mcpb.sh
+++ b/scripts/build-mcpb.sh
@@ -37,15 +37,7 @@ if [ -f "$PROJECT_DIR/mcpb/icon.png" ]; then
   cp "$PROJECT_DIR/mcpb/icon.png" "$BUNDLE_DIR/icon.png"
 fi
 
-# 6. Strip unused Prisma WASM database runtimes (keep only PostgreSQL)
-if [ -d "$BUNDLE_DIR/node_modules/@prisma/client/runtime" ]; then
-  find "$BUNDLE_DIR/node_modules/@prisma/client/runtime" \
-    \( -name "*sqlserver*" -o -name "*cockroachdb*" -o -name "*sqlite*" -o -name "*mysql*" \) \
-    -type f -exec rm -f {} +
-  echo "Stripped non-PostgreSQL Prisma runtimes"
-fi
-
-# 7. Clean up unnecessary files
+# 6. Clean up unnecessary files
 rm -rf "$BUNDLE_DIR/yarn.lock" "$BUNDLE_DIR/.yarn"
 rm -f "$BUNDLE_DIR/package-lock.json"
 
@@ -69,12 +61,12 @@ find "$BUNDLE_DIR/node_modules" \( -name "fixture" -o -name "fixtures" -o -name 
 rm -f "$BUNDLE_DIR/dist/tsconfig.build.tsbuildinfo"
 find "$BUNDLE_DIR/dist" -name "*.js.map" -type f -exec rm -f {} + 2>/dev/null || true
 
-# 8. Create .mcpb (ZIP archive)
+# 7. Create .mcpb (ZIP archive)
 OUTPUT="$PROJECT_DIR/gitlab-mcp-${VERSION}.mcpb"
 cd "$BUNDLE_DIR"
 zip -r "$OUTPUT" . -x "*.DS_Store" > /dev/null
 
-# 9. Cleanup
+# 8. Cleanup
 rm -rf "$BUNDLE_DIR"
 
 SIZE=$(stat -f%z "$OUTPUT" 2>/dev/null || stat -c%s "$OUTPUT")

--- a/yarn.lock
+++ b/yarn.lock
@@ -2639,7 +2639,6 @@ __metadata:
     eslint: "npm:^9.39.2"
     eslint-plugin-prettier: "npm:^5.5.5"
     express: "npm:^5.2.1"
-    form-data: "npm:^4.0.5"
     graphql: "npm:^16.12.0"
     graphql-tag: "npm:^2.12.6"
     http-proxy-agent: "npm:^7.0.2"
@@ -3754,13 +3753,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"asynckit@npm:^0.4.0":
-  version: 0.4.0
-  resolution: "asynckit@npm:0.4.0"
-  checksum: 10c0/d73e2ddf20c4eb9337e1b3df1a0f6159481050a5de457c55b14ea2e5cb6d90bb69e004c9af54737a5ee0917fcf2c9e25de67777bbe58261847846066ba75bc9d
-  languageName: node
-  linkType: hard
-
 "atomic-sleep@npm:^1.0.0":
   version: 1.0.0
   resolution: "atomic-sleep@npm:1.0.0"
@@ -4383,15 +4375,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"combined-stream@npm:^1.0.8":
-  version: 1.0.8
-  resolution: "combined-stream@npm:1.0.8"
-  dependencies:
-    delayed-stream: "npm:~1.0.0"
-  checksum: 10c0/0dbb829577e1b1e839fa82b40c07ffaf7de8a09b935cadd355a73652ae70a88b4320db322f6634a4ad93424292fa80973ac6480986247f1734a1137debf271d5
-  languageName: node
-  linkType: hard
-
 "comma-separated-tokens@npm:^2.0.0":
   version: 2.0.3
   resolution: "comma-separated-tokens@npm:2.0.3"
@@ -4737,13 +4720,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"delayed-stream@npm:~1.0.0":
-  version: 1.0.0
-  resolution: "delayed-stream@npm:1.0.0"
-  checksum: 10c0/d758899da03392e6712f042bec80aa293bbe9e9ff1b2634baae6a360113e708b91326594c8a486d475c69d6259afb7efacdc3537bfcda1c6c648e390ce601b19
-  languageName: node
-  linkType: hard
-
 "denque@npm:^2.1.0":
   version: 2.1.0
   resolution: "denque@npm:2.1.0"
@@ -5019,18 +4995,6 @@ __metadata:
   dependencies:
     es-errors: "npm:^1.3.0"
   checksum: 10c0/65364812ca4daf48eb76e2a3b7a89b3f6a2e62a1c420766ce9f692665a29d94fe41fe88b65f24106f449859549711e4b40d9fb8002d862dfd7eb1c512d10be0c
-  languageName: node
-  linkType: hard
-
-"es-set-tostringtag@npm:^2.1.0":
-  version: 2.1.0
-  resolution: "es-set-tostringtag@npm:2.1.0"
-  dependencies:
-    es-errors: "npm:^1.3.0"
-    get-intrinsic: "npm:^1.2.6"
-    has-tostringtag: "npm:^1.0.2"
-    hasown: "npm:^2.0.2"
-  checksum: 10c0/ef2ca9ce49afe3931cb32e35da4dcb6d86ab02592cfc2ce3e49ced199d9d0bb5085fc7e73e06312213765f5efa47cc1df553a6a5154584b21448e9fb8355b1af
   languageName: node
   linkType: hard
 
@@ -5700,19 +5664,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"form-data@npm:^4.0.5":
-  version: 4.0.5
-  resolution: "form-data@npm:4.0.5"
-  dependencies:
-    asynckit: "npm:^0.4.0"
-    combined-stream: "npm:^1.0.8"
-    es-set-tostringtag: "npm:^2.1.0"
-    hasown: "npm:^2.0.2"
-    mime-types: "npm:^2.1.12"
-  checksum: 10c0/dd6b767ee0bbd6d84039db12a0fa5a2028160ffbfaba1800695713b46ae974a5f6e08b3356c3195137f8530dcd9dfcb5d5ae1eeff53d0db1e5aad863b619ce3b
-  languageName: node
-  linkType: hard
-
 "forwarded@npm:0.2.0":
   version: 0.2.0
   resolution: "forwarded@npm:0.2.0"
@@ -5827,7 +5778,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"get-intrinsic@npm:^1.2.5, get-intrinsic@npm:^1.2.6, get-intrinsic@npm:^1.3.0":
+"get-intrinsic@npm:^1.2.5, get-intrinsic@npm:^1.3.0":
   version: 1.3.0
   resolution: "get-intrinsic@npm:1.3.0"
   dependencies:
@@ -6072,19 +6023,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"has-symbols@npm:^1.0.3, has-symbols@npm:^1.1.0":
+"has-symbols@npm:^1.1.0":
   version: 1.1.0
   resolution: "has-symbols@npm:1.1.0"
   checksum: 10c0/dde0a734b17ae51e84b10986e651c664379018d10b91b6b0e9b293eddb32f0f069688c841fb40f19e9611546130153e0a2a48fd7f512891fb000ddfa36f5a20e
-  languageName: node
-  linkType: hard
-
-"has-tostringtag@npm:^1.0.2":
-  version: 1.0.2
-  resolution: "has-tostringtag@npm:1.0.2"
-  dependencies:
-    has-symbols: "npm:^1.0.3"
-  checksum: 10c0/a8b166462192bafe3d9b6e420a1d581d93dd867adb61be223a17a8d6dad147aa77a8be32c961bb2f27b3ef893cae8d36f564ab651f5e9b7938ae86f74027c48c
   languageName: node
   linkType: hard
 
@@ -7843,26 +7785,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mime-db@npm:1.52.0":
-  version: 1.52.0
-  resolution: "mime-db@npm:1.52.0"
-  checksum: 10c0/0557a01deebf45ac5f5777fe7740b2a5c309c6d62d40ceab4e23da9f821899ce7a900b7ac8157d4548ddbb7beffe9abc621250e6d182b0397ec7f10c7b91a5aa
-  languageName: node
-  linkType: hard
-
 "mime-db@npm:^1.54.0":
   version: 1.54.0
   resolution: "mime-db@npm:1.54.0"
   checksum: 10c0/8d907917bc2a90fa2df842cdf5dfeaf509adc15fe0531e07bb2f6ab15992416479015828d6a74200041c492e42cce3ebf78e5ce714388a0a538ea9c53eece284
-  languageName: node
-  linkType: hard
-
-"mime-types@npm:^2.1.12":
-  version: 2.1.35
-  resolution: "mime-types@npm:2.1.35"
-  dependencies:
-    mime-db: "npm:1.52.0"
-  checksum: 10c0/82fb07ec56d8ff1fc999a84f2f217aa46cb6ed1033fefaabd5785b9a974ed225c90dc72fff460259e66b95b73648596dbcc50d51ed69cdf464af2d237d3149b2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Closes #183

- Move `prisma` and `@graphql-typed-document-node/core` to `devDependencies` (build-time only)
- Remove unused `form-data` package (Node.js has native FormData)
- Use `--omit=peer` in `npm install` to prevent `prisma` CLI and `typescript` being installed as `@prisma/client` peer deps
- Enhanced cleanup in build-mcpb.sh: remove source maps, `.d.ts`, `.d.mts`, fixture/example/doc directories from `node_modules`
- Remove build artifacts from `dist/` (tsconfig.tsbuildinfo, `*.js.map`)
- Skip `prisma generate` in bundle build (already compiled in `dist/`)
- Bump pino 10.3.0, undici 7.19.1, @cloudflare/workers-types

**Result: 84 MB → ~45 MB compressed (-47%)**

## Test plan

- [x] `yarn lint` — 0 errors
- [x] `yarn test` — 124 suites, 3833 tests passing
- [x] `yarn build` — success
- [x] `./scripts/build-mcpb.sh "0.0.0-test"` — 44.9 MB
- [x] Server starts correctly: `node dist/src/main.js` — OK