### PR TITLE
fix(docs): MCPB download link returns 404 due to VitePress .html suffix

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -37,7 +37,7 @@ features:
 
 ## One-Click Install
 
-[![Install in Claude Desktop](https://img.shields.io/badge/Claude_Desktop-Install_Extension-F97316?style=for-the-badge&logoColor=white)](/downloads/gitlab-mcp-latest.mcpb)
+<a href="/downloads/gitlab-mcp-latest.mcpb"><img src="https://img.shields.io/badge/Claude_Desktop-Install_Extension-F97316?style=for-the-badge&logoColor=white" alt="Install in Claude Desktop"></a>
 [![Install in VS Code](https://img.shields.io/badge/VS_Code-Install_MCP_Server-007ACC?style=for-the-badge&logo=visualstudiocode&logoColor=white)](vscode:mcp/install?%7B%22name%22%3A%22gitlab-mcp%22%2C%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22%40structured-world%2Fgitlab-mcp%22%5D%7D)
 [![Install in VS Code Insiders](https://img.shields.io/badge/VS_Code_Insiders-Install_MCP_Server-24bfa5?style=for-the-badge&logo=visualstudiocode&logoColor=white)](vscode-insiders:mcp/install?%7B%22name%22%3A%22gitlab-mcp%22%2C%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22%40structured-world%2Fgitlab-mcp%22%5D%7D)
 


### PR DESCRIPTION
## Summary

- VitePress transforms markdown links by appending `.html`, causing the "Install in Claude Desktop" badge to point to `/downloads/gitlab-mcp-latest.mcpb.html` (404)
- Replace markdown image-link with raw HTML `<a>` tag which VitePress does not transform

Closes #185

## Test plan

- [ ] Verify badge link on deployed docs points to `/downloads/gitlab-mcp-latest.mcpb` (no `.html`)
- [ ] Verify `.mcpb` file downloads correctly