### PR TITLE
fix(mrs): Pre-check mergeability before calling merge API to avoid 405 errors

### DIFF
--- a/src/entities/mrs/registry.ts
+++ b/src/entities/mrs/registry.ts
@@ -86,7 +86,8 @@ export function getMergeStatusHint(status: string): string {
     need_rebase: "Rebase the source branch before merging",
 
     // Status related
-    draft_status: "Remove draft status before merging (use update action with draft: false)",
+    draft_status:
+      "Remove draft status before merging by updating the title to remove any 'Draft:' or 'WIP:' prefix",
     discussions_not_resolved: "Resolve all blocking discussions before merging",
     blocked_status: "MR is blocked by another MR or issue",
 
@@ -105,11 +106,7 @@ export function getMergeStatusHint(status: string): string {
 /**
  * Build suggested action message based on merge status.
  */
-export function getSuggestedAction(
-  status: string,
-  isRetryable: boolean,
-  canAutoMerge: boolean
-): string {
+export function getSuggestedAction(isRetryable: boolean, canAutoMerge: boolean): string {
   if (canAutoMerge) {
     return "Consider using merge_when_pipeline_succeeds: true to auto-merge when pipeline passes";
   }
@@ -441,7 +438,7 @@ export const mrsToolRegistry: ToolRegistry = new Map<string, EnhancedToolDefinit
               hint: getMergeStatusHint(detailedStatus),
               is_retryable: isRetryable,
               can_auto_merge: canAutoMerge,
-              suggested_action: getSuggestedAction(detailedStatus, isRetryable, canAutoMerge),
+              suggested_action: getSuggestedAction(isRetryable, canAutoMerge),
             };
 
             return blockedResponse;

--- a/tests/unit/entities/mrs/registry.test.ts
+++ b/tests/unit/entities/mrs/registry.test.ts
@@ -351,18 +351,18 @@ describe("getMergeStatusHint", () => {
 
 describe("getSuggestedAction", () => {
   it("should suggest auto-merge when canAutoMerge is true", () => {
-    const action = getSuggestedAction("ci_still_running", true, true);
+    const action = getSuggestedAction(true, true);
     expect(action).toContain("merge_when_pipeline_succeeds");
   });
 
   it("should suggest wait when retryable but not auto-merge", () => {
-    const action = getSuggestedAction("checking", true, false);
+    const action = getSuggestedAction(true, false);
     expect(action).toContain("Wait");
     expect(action).toContain("retry");
   });
 
   it("should suggest resolving blocking condition when not retryable", () => {
-    const action = getSuggestedAction("conflict", false, false);
+    const action = getSuggestedAction(false, false);
     expect(action).toContain("Resolve");
     expect(action).toContain("blocking");
   });


### PR DESCRIPTION
## Summary

- Pre-check `detailed_merge_status` before attempting merge to avoid confusing 405 errors
- Return structured error response with actionable guidance for AI agents
- Support auto-merge via `merge_when_pipeline_succeeds` parameter (skips pre-check)
- Add `is_retryable` and `can_auto_merge` flags to help agents decide next action

## Changes

### New exports in `src/entities/mrs/registry.ts`
- `MergeBlockedResponse` interface for structured error responses
- `RETRYABLE_MERGE_STATUSES` - statuses that may resolve on their own
- `AUTO_MERGE_ELIGIBLE_STATUSES` - statuses where auto-merge is applicable
- `getMergeStatusHint()` - actionable hints for each status
- `getSuggestedAction()` - suggested next step based on status

### Merge action behavior
1. If `merge_when_pipeline_succeeds: true` → call merge API directly with auto-merge
2. Otherwise → pre-check `detailed_merge_status`:
   - If `mergeable` → proceed with merge
   - Otherwise → return structured response (not 405 error)

### Example response when blocked
```json
{
  "error": true,
  "message": "MR cannot be merged: ci_still_running",
  "detailed_merge_status": "ci_still_running",
  "merge_status": "can_be_merged",
  "has_conflicts": false,
  "blocking_discussions_resolved": true,
  "hint": "Pipeline is running. Use merge_when_pipeline_succeeds: true for auto-merge, or wait for completion",
  "is_retryable": true,
  "can_auto_merge": true,
  "suggested_action": "Consider using merge_when_pipeline_succeeds: true to auto-merge when pipeline passes"
}
```

## Test plan

- [x] Unit tests for `getMergeStatusHint()` with all status types
- [x] Unit tests for `getSuggestedAction()` with all flag combinations
- [x] Unit tests for merge action with mergeable status
- [x] Unit tests for merge action with `merge_when_pipeline_succeeds`
- [x] Unit tests for merge action with blocking statuses (ci_still_running, not_approved, conflict, checking)
- [x] All 3954 tests passing
- [x] Lint clean
- [x] Build successful

Closes #197