### PR TITLE
fix(docs): Replace hardcoded 'latest' MCPB link with versioned URL in README

### DIFF
--- a/README.md.in
+++ b/README.md.in
@@ -4,7 +4,7 @@
 
 A [Model Context Protocol](https://modelcontextprotocol.io) server that connects AI agents to the GitLab API — __TOOL_COUNT__ tools across __ENTITY_COUNT__ entity types with CQRS architecture, OAuth 2.1, and multiple transport modes.
 
-[![Install in Claude Desktop](https://img.shields.io/badge/Claude_Desktop-Install_Extension-F97316?style=for-the-badge)](https://gitlab-mcp.sw.foundation/downloads/gitlab-mcp-latest.mcpb)
+[![Install in Claude Desktop](https://img.shields.io/badge/Claude_Desktop-Install_Extension-F97316?style=for-the-badge)](https://gitlab-mcp.sw.foundation/downloads/gitlab-mcp-__VERSION__.mcpb)
 [![Install in VS Code](https://img.shields.io/badge/VS_Code-Install_MCP_Server-007ACC?style=for-the-badge&logo=visualstudiocode&logoColor=white)](vscode:mcp/install?%7B%22name%22%3A%22gitlab-mcp%22%2C%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22%40structured-world%2Fgitlab-mcp%22%5D%7D)
 [![Install in VS Code Insiders](https://img.shields.io/badge/VS_Code_Insiders-Install_MCP_Server-24bfa5?style=for-the-badge&logo=visualstudiocode&logoColor=white)](vscode-insiders:mcp/install?%7B%22name%22%3A%22gitlab-mcp%22%2C%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22%40structured-world%2Fgitlab-mcp%22%5D%7D)
 

--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -46,6 +46,7 @@ fi
 sed -e "s/__TOOL_COUNT__/${TOOL_COUNT}/g" \
     -e "s/__ENTITY_COUNT__/${ENTITY_COUNT}/g" \
     -e "s/__READONLY_TOOL_COUNT__/${READONLY_TOOL_COUNT}/g" \
+    -e "s/__VERSION__/${VERSION}/g" \
     README.md.in > README.md
 
 # Write version file for CI


### PR DESCRIPTION
## Summary
- Update README.md.in to use `__VERSION__` placeholder for MCPB download link
- Extend prepare-release.sh to replace `__VERSION__` with actual version during release

## Problem
The MCPB download link in README was pointing to non-existent `gitlab-mcp-latest.mcpb`. Now uses versioned format `gitlab-mcp-6.44.0.mcpb` matching the docs site.

## Test plan
- [x] Run `./scripts/prepare-release.sh 6.44.0`
- [x] Verify `grep "mcpb" README.md` shows versioned link
- [x] All tests pass (4071 tests)
- [x] Lint passes

Fixes #204