### PR TITLE
feat(docs): Add Google Analytics tracking to VitePress documentation

### DIFF
--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -1,6 +1,7 @@
 import { h } from "vue";
 import DefaultTheme from "vitepress/theme";
 import type { Theme } from "vitepress";
+import googleAnalytics from "vitepress-plugin-google-analytics";
 import "./style.css";
 import BugReportWidget from "./components/BugReportWidget.vue";
 
@@ -9,6 +10,11 @@ export default {
   Layout() {
     return h(DefaultTheme.Layout, null, {
       "layout-bottom": () => h(BugReportWidget),
+    });
+  },
+  enhanceApp({ app }) {
+    googleAnalytics({
+      id: import.meta.env.VITE_GA_ID || "G-RY1XJ7LR5F",
     });
   },
 } satisfies Theme;

--- a/package.json
+++ b/package.json
@@ -112,6 +112,7 @@
     "ts-jest": "^29.4.6",
     "ts-node": "^10.9.2",
     "typescript": "^5.9.3",
-    "vitepress": "^1.6.4"
+    "vitepress": "^1.6.4",
+    "vitepress-plugin-google-analytics": "^1.0.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2657,6 +2657,7 @@ __metadata:
     typescript: "npm:^5.9.3"
     undici: "npm:^7.19.1"
     vitepress: "npm:^1.6.4"
+    vitepress-plugin-google-analytics: "npm:^1.0.2"
     yaml: "npm:^2.8.2"
     zod: "npm:^4.3.6"
   bin:
@@ -11046,6 +11047,13 @@ __metadata:
   bin:
     vite: bin/vite.js
   checksum: 10c0/468336a1409f728b464160cbf02672e72271fb688d0e605e776b74a89d27e1029509eef3a3a6c755928d8011e474dbf234824d054d07960be5f23cd176bc72de
+  languageName: node
+  linkType: hard
+
+"vitepress-plugin-google-analytics@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "vitepress-plugin-google-analytics@npm:1.0.2"
+  checksum: 10c0/17b09ff91cf7f3bdd43373386f37315e88094576834dd5256071c8f357f43b23a0cb3a059f014cabccd80aea5f685c3947451f81b79d8f82add7e263ed80ccde
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Add Google Analytics 4 tracking to VitePress documentation using `vitepress-plugin-google-analytics`
- Support `VITE_GA_ID` environment variable override (default: `G-RY1XJ7LR5F`)

## Implementation

Used **Option 1 (Plugin)** from the issue as recommended — cleaner code and proper SPA navigation handling.

## Test plan

- [x] `yarn lint` passes
- [x] `yarn test` passes (132 suites, 4178 tests)
- [ ] Verify GA tracking in deployed docs via browser DevTools Network tab

Closes #214