### PR TITLE
fix(docs): add GA4 consent mode to enable analytics tracking

### DIFF
--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -33,6 +33,16 @@ function initGoogleAnalytics() {
   window.gtag = function (...args: unknown[]) {
     window.dataLayer!.push(args);
   };
+
+  // Set default consent - required for GA4 to send data
+  // This grants analytics by default (no ads tracking)
+  window.gtag("consent", "default", {
+    analytics_storage: "granted",
+    ad_storage: "denied",
+    ad_user_data: "denied",
+    ad_personalization: "denied",
+  });
+
   window.gtag("js", new Date());
   // Disable automatic page_view - we send manually to track SPA navigation
   window.gtag("config", GA_ID, { send_page_view: false });


### PR DESCRIPTION
## Summary

- Add default consent configuration for GA4 to enable analytics tracking
- Without consent mode, GA4 blocks all data collection by default

## Root Cause

GA4 requires explicit `gtag('consent', 'default', {...})` before config. The `analytics_storage` was implicitly denied, blocking all tracking despite gtag.js loading successfully.

## Changes

- Grant `analytics_storage` to allow page view tracking
- Deny `ad_storage`, `ad_user_data`, `ad_personalization` (privacy-focused, no ads)

Fixes #229