### PR TITLE
Gate heavy CI jobs on unresolved review threads

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -237,8 +237,10 @@ EOF
           echo "allow_heavy=true" >> "$GITHUB_OUTPUT"
           echo "Unresolved review threads: 0" >> "$GITHUB_STEP_SUMMARY"
 
+  # Legacy required status check - reports quality-checks result for branch protection
+  # Added to support migration from old "Lint, Test & Build" ruleset requirement
   expected-status:
-    name: Lint, Test & BuildExpected
+    name: Lint, Test & Build
     runs-on: ubuntu-latest
     needs: [quality-checks]
     if: always()


### PR DESCRIPTION
Adds a review-thread gate to skip heavy jobs on PRs when review threads are unresolved.

- New review-thread-gate job checks unresolved threads via GraphQL.
- docker-build runs only if gate allows (PRs with unresolved threads skip heavy jobs).
- Non-PR events bypass gate and proceed normally.
- Added expected-status job as legacy required status check (migrates from old ruleset requirement).