### PR TITLE
fix(ci): replace heredoc with quoted strings in thread-gate job

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -136,19 +136,16 @@ jobs:
           while [ "$PAGE_COUNT" -lt "$MAX_PAGES" ]; do
             PAGE_COUNT=$((PAGE_COUNT + 1))
             if [ -z "$AFTER" ]; then
-              QUERY=$(cat <<'EOF'
-query($owner:String!, $name:String!, $number:Int!) {
-  repository(owner:$owner, name:$name) {
-    pullRequest(number:$number) {
-      reviewThreads(first:100) {
-        nodes { isResolved, isOutdated }
-        pageInfo { hasNextPage, endCursor }
-      }
-    }
-  }
-}
-EOF
-)
+              QUERY='query($owner:String!, $name:String!, $number:Int!) {
+                repository(owner:$owner, name:$name) {
+                  pullRequest(number:$number) {
+                    reviewThreads(first:100) {
+                      nodes { isResolved, isOutdated }
+                      pageInfo { hasNextPage, endCursor }
+                    }
+                  }
+                }
+              }'
               RESP=$(gh api graphql \
                 -f query="$QUERY" \
                 -f owner="$OWNER" \
@@ -160,19 +157,16 @@ EOF
                   exit 0
                 }
             else
-              QUERY_AFTER=$(cat <<'EOF'
-query($owner:String!, $name:String!, $number:Int!, $after:String) {
-  repository(owner:$owner, name:$name) {
-    pullRequest(number:$number) {
-      reviewThreads(first:100, after:$after) {
-        nodes { isResolved, isOutdated }
-        pageInfo { hasNextPage, endCursor }
-      }
-    }
-  }
-}
-EOF
-)
+              QUERY_AFTER='query($owner:String!, $name:String!, $number:Int!, $after:String) {
+                repository(owner:$owner, name:$name) {
+                  pullRequest(number:$number) {
+                    reviewThreads(first:100, after:$after) {
+                      nodes { isResolved, isOutdated }
+                      pageInfo { hasNextPage, endCursor }
+                    }
+                  }
+                }
+              }'
               RESP=$(gh api graphql \
                 -f query="$QUERY_AFTER" \
                 -f owner="$OWNER" \


### PR DESCRIPTION
## Summary

- Replace bash heredoc (`<<'EOF'`) with single-quoted strings for GraphQL queries in the `review-thread-gate` CI job
- Heredoc content starting at column 0 broke YAML literal block scalar parsing, causing all `push` events on `ci-cd.yml` to fail with "workflow file issue" since #243
- All `pull_request` events were unaffected (different GitHub Actions validation path)

## Root Cause

In YAML `run: |` blocks, all content lines must maintain indentation >= the first content line. The heredoc body (`query($owner:String!...)`) started at column 0, terminating the YAML block prematurely.

## Test plan

- [ ] Verify this PR's CI passes (ci-cd.yml triggers on `pull_request`)
- [ ] After merge, verify push-triggered ci-cd.yml run succeeds on `main`

Fixes #245