### PR TITLE
fix(deps): update hono from 4.11.5 to 4.11.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "resolutions": {
     "lodash": "4.17.23",
     "lodash-es": "4.17.23",
-    "hono": "4.11.5",
+    "hono": "4.11.7",
     "diff": "4.0.4",
     "esbuild": ">=0.25.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -6081,10 +6081,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hono@npm:4.11.5":
-  version: 4.11.5
-  resolution: "hono@npm:4.11.5"
-  checksum: 10c0/0473f7dde6f4d2e0d6e04cace561715560d7f884d5c7d3d7bc8e4b7f7b5ec7b826cc996ebcc2b343e1c00a95d7436a95a75c91b3b2a8666ba3b4be4b7bdb1982
+"hono@npm:4.11.7":
+  version: 4.11.7
+  resolution: "hono@npm:4.11.7"
+  checksum: 10c0/c7cde1779c9352fc6aacb242af009f280f4d89315cf95135d08df5c680f845fcfb1c3c1a650ec15e1d1c2d0af26fdc87b745bb3c471c5045d88c247a7bd2aae4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Update `hono` resolution pin from `4.11.5` to `4.11.7` to fix 4 medium-severity CVEs
- Dependabot could not auto-update due to exact version pin in `resolutions`

### CVEs Fixed

| CVE | Severity | Summary |
|-----|----------|---------|
| CVE-2026-24771 | Medium | XSS through ErrorBoundary component |
| CVE-2026-24473 | Medium | Arbitrary key read in serve-static middleware |
| CVE-2026-24472 | Medium | Cache middleware ignores `Cache-Control: private` |
| CVE-2026-24398 | Medium | IPv4 validation bypass in IP Restriction Middleware |

## Test plan

- [x] `yarn build` passes
- [x] 133 test suites, 4200 tests pass
- [ ] CI checks pass

Fixes #247