### PR TITLE
fix(docs): use canonical URL for TOOLS reference in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ yarn list-tools --detail
 yarn list-tools --export --toc > docs/TOOLS.md
 ```
 
-See [Tools Reference](https://gitlab-mcp.sw.foundation/TOOLS.html) for the auto-generated reference.
+See [Tools Reference](https://gitlab-mcp.sw.foundation/TOOLS) for the auto-generated reference.
 
 ## Docker
 


### PR DESCRIPTION
## Summary
- Remove `.html` extension from TOOLS link in README to match sitemap canonical URL (`/TOOLS` instead of `/TOOLS.html`)

## Test plan
- [ ] Verify `https://gitlab-mcp.sw.foundation/TOOLS` returns 200

Closes #251