### PR TITLE
chore: add glama.json for Glama.ai MCP directory listing

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": [
+    "structured-world"
+  ]
+}


### PR DESCRIPTION
## Summary
- Add `glama.json` to repository root for [Glama.ai](https://glama.ai/mcp/servers) MCP directory integration
- Register `structured-world` as maintainer

Related: [awesome-mcp-servers PR #1777](https://github.com/punkpeye/awesome-mcp-servers/pull/1777)

## Test plan
- [ ] Verify `glama.json` validates against `https://glama.ai/mcp/schemas/server.json`

Closes #253