### PR TITLE
fix(ci): unblock release pipeline on push to main

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -256,7 +256,12 @@ jobs:
     needs: [quality-checks, review-thread-gate]
     # For PRs, only run heavy jobs if the gate succeeded and explicitly allowed them.
     # Non-PR events (push/workflow_dispatch) run unconditionally.
-    if: github.event_name != 'pull_request' || (needs.review-thread-gate.result == 'success' && needs.review-thread-gate.outputs.allow_heavy == 'true')
+    # Note: !cancelled() is required because review-thread-gate is skipped on non-PR events,
+    # and GitHub Actions skips dependent jobs by default when any needs job is skipped.
+    if: |
+      !cancelled() &&
+      needs.quality-checks.result == 'success' &&
+      (github.event_name != 'pull_request' || (needs.review-thread-gate.result == 'success' && needs.review-thread-gate.outputs.allow_heavy == 'true'))
 
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

- Add `!cancelled()` to `docker-build` job `if` condition to prevent cascading skip when PR-only gate job is skipped on push events
- Add explicit `needs.quality-checks.result == 'success'` check for safety
- Release pipeline was blocked since v6.50.0 due to regression in 54c6358

## Root Cause

The `docker-build` job depends on a PR-only gate job via `needs`. On push to main, the gate is skipped, and GitHub Actions default behavior skips all dependent jobs without evaluating their `if` conditions. This cascaded to skip `semantic-release`, preventing all releases after v6.50.0.

## Test plan

- [ ] CI passes on this PR (docker-build should NOT be skipped)
- [ ] After merge, verify semantic-release runs and publishes pending versions

Fixes #263