### PR TITLE
fix(ci): prevent transitive skip propagation in release pipeline

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -482,6 +482,8 @@ jobs:
     name: Pipeline Summary
     runs-on: ubuntu-latest
     permissions: {}
+    # All jobs listed so summary can read their outputs/results.
+    # if: always() ensures this runs even when needs jobs are skipped/failed.
     needs: [quality-checks, docker-build, semantic-release, mcpb-bundle, docker-publish, mcp-registry-publish]
     if: always()
 


### PR DESCRIPTION
## Summary

Follow-up to #264. The `!cancelled()` approach was insufficient — GitHub Actions propagates skipped status transitively through the entire `needs` chain, blocking `semantic-release` even when `docker-build` succeeded.

**Root cause:** `review-thread-gate` was a separate job with `if: github.event_name == 'pull_request'`. On push to main it was skipped, causing ALL downstream jobs in the `needs` chain to be skipped too (`docker-build` -> `semantic-release` -> publish jobs).

**Solution:** Delete the standalone gate job entirely. Move the gate check into `docker-build` as its first step with `if: github.event_name == 'pull_request'`. On push to main, the step is simply skipped — no separate job, no `needs` chain issues, no wasted runner.

Changes:
- Remove `review-thread-gate` job (was ~110 lines + separate runner)
- Add gate check as first step of `docker-build` (PR-only via step-level `if`)
- `docker-build` now depends only on `quality-checks`
- Simplify `summary` job — remove gate-specific status branches

## Test plan

- [ ] CI passes on this PR (docker-build runs after quality-checks, no skip)
- [ ] After merge to main, verify full pipeline: docker-build, semantic-release, docker-publish all run
- [ ] Verify pending releases since v6.50.0 are published

Fixes #265