### PR TITLE
docs(pipelines): add inputs parameter documentation

### DIFF
--- a/docs/prompts/ci-cd/trigger-deploy.md
+++ b/docs/prompts/ci-cd/trigger-deploy.md
@@ -39,6 +39,42 @@ Run pipelines, trigger manual jobs, and manage deployments with GitLab MCP.
 }
 ```
 
+```json [With typed inputs]
+{
+  "action": "create",
+  "project_id": "my-org/api",
+  "ref": "main",
+  "inputs": {
+    "environment": "production",
+    "dry_run": false,
+    "replicas": 3
+  }
+}
+```
+
+:::
+
+## Trigger with Typed Inputs
+
+For pipelines using GitLab's typed inputs feature:
+
+> "Run a deploy pipeline with environment set to production and dry_run disabled"
+
+```json
+{
+  "action": "create",
+  "project_id": "my-org/api",
+  "ref": "main",
+  "inputs": {
+    "environment": "production",
+    "dry_run": false,
+    "replicas": 3
+  }
+}
+```
+
+::: info GitLab 15.5+ Required
+Pipeline inputs require GitLab 15.5 or later. Check your `.gitlab-ci.yml` for `spec.inputs` to see available inputs.
 :::
 
 ## Trigger Manual Deploy Jobs

--- a/docs/tools/ci-cd.md
+++ b/docs/tools/ci-cd.md
@@ -135,6 +135,60 @@ Trigger and control pipeline execution.
 }
 ```
 
+```json [With typed inputs]
+{
+  "action": "create",
+  "project_id": "my-org/api",
+  "ref": "main",
+  "inputs": {
+    "environment": "production",
+    "dry_run": true,
+    "replicas": 3
+  }
+}
+```
+
+:::
+
+### Pipeline Inputs (GitLab 15.5+)
+
+For pipelines with typed inputs defined in `.gitlab-ci.yml`:
+
+```yaml
+# .gitlab-ci.yml
+spec:
+  inputs:
+    environment:
+      type: string
+      options: [staging, production]
+    dry_run:
+      type: boolean
+      default: false
+    replicas:
+      type: number
+      default: 1
+```
+
+Trigger with inputs:
+
+```json
+{
+  "action": "create",
+  "project_id": "my-org/api",
+  "ref": "main",
+  "inputs": {
+    "environment": "production",
+    "dry_run": true,
+    "replicas": 3
+  }
+}
+```
+
+::: tip Variables vs Inputs
+- **`variables`**: Legacy key-value pairs, no type validation
+- **`inputs`**: Typed parameters with schema validation (requires GitLab 15.5+)
+
+You can use both in the same request if needed.
 :::
 
 ## manage_pipeline_job


### PR DESCRIPTION
## Summary

Add documentation for pipeline inputs feature introduced in #273.

- Add Pipeline Inputs section to `docs/tools/ci-cd.md` with examples
- Add typed inputs examples to `docs/prompts/ci-cd/trigger-deploy.md`
- Include variables vs inputs comparison tip

## Context

This documentation was part of the original #272 implementation but was not included in the squash merge of #273.

Related to #272