### PR TITLE
chore(deps): upgrade vue-privacy to 1.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -469,7 +469,7 @@
     "@semantic-release/git": "^10.0.1",
     "@semantic-release/github": "^12.0.3",
     "@semantic-release/npm": "^13.1.3",
-    "@structured-world/vue-privacy": "^1.6.2",
+    "@structured-world/vue-privacy": "^1.9.0",
     "@types/express": "^5.0.6",
     "@types/jest": "^30.0.0",
     "@types/node": "^24.10.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2655,7 +2655,7 @@ __metadata:
     "@semantic-release/git": "npm:^10.0.1"
     "@semantic-release/github": "npm:^12.0.3"
     "@semantic-release/npm": "npm:^13.1.3"
-    "@structured-world/vue-privacy": "npm:^1.6.2"
+    "@structured-world/vue-privacy": "npm:^1.9.0"
     "@types/express": "npm:^5.0.6"
     "@types/jest": "npm:^30.0.0"
     "@types/node": "npm:^24.10.10"
@@ -2695,9 +2695,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@structured-world/vue-privacy@npm:^1.6.2":
-  version: 1.6.2
-  resolution: "@structured-world/vue-privacy@npm:1.6.2"
+"@structured-world/vue-privacy@npm:^1.9.0":
+  version: 1.9.0
+  resolution: "@structured-world/vue-privacy@npm:1.9.0"
   peerDependencies:
     vue: ^3.3.0
     vue-router: ^4.0.0 || ^5.0.0
@@ -2706,7 +2706,7 @@ __metadata:
       optional: true
     vue-router:
       optional: true
-  checksum: 10c0/88d85355f8ef639624997d1010a95938c8e24cc81d433bcb37fa30ea3020a147c650e783ea2aa15b04b63b64e09c714b64baf744782bb32b404a0c42d23c1f82
+  checksum: 10c0/1febb4f97089fb51ea2b5760745de6a661aebe1936441e9afcf4a21b37865c11fb0ec89c6b176ee5dbb1d6c77a7fc2b5ede94a4d4a3462be9464d3c70fd368fb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Verified README.md generation works correctly (44 tools, 18 entities)
- Updated `@structured-world/vue-privacy` from ^1.6.2 to ^1.9.0 for docs consent banner

## Test plan

- [x] `yarn lint` passes
- [x] `yarn test` passes (145 suites, 4565 tests)

Closes #291