### PR TITLE
fix(docs): move generated API reference to /tools/ directory

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -71,7 +71,7 @@ jobs:
 
       - name: Generate dynamic documentation
         run: |
-          yarn list-tools --export --toc > docs/TOOLS.md
+          yarn list-tools --export --toc > docs/tools/api-reference.md
           yarn inject-tool-refs
         env:
           RELEASE_VERSION: ${{ steps.mcpb.outputs.version }}

--- a/README.md.in
+++ b/README.md.in
@@ -63,10 +63,10 @@ For the complete tool reference with parameters:
 yarn list-tools --detail
 
 # Generate documentation
-yarn list-tools --export --toc > docs/TOOLS.md
+yarn list-tools --export --toc > docs/tools/api-reference.md
 ```
 
-See [docs/TOOLS.md](docs/TOOLS.md) for the auto-generated reference.
+See the [Full API Reference](https://gitlab-mcp.sw.foundation/tools/api-reference) for the auto-generated tool documentation.
 
 ## Docker
 

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -31,7 +31,7 @@ export default defineConfig({
   // MCPB bundle is downloaded from GitHub releases during docs build.
   // Links use versioned filenames (e.g., gitlab-mcp-6.43.0.mcpb) injected at build time.
   // Until first .mcpb release exists, the link is a dead link — safe to ignore.
-  ignoreDeadLinks: [/\/downloads\/gitlab-mcp-[\d.]+\.mcpb$/, /\/TOOLS$/],
+  ignoreDeadLinks: [/\/downloads\/gitlab-mcp-[\d.]+\.mcpb$/],
 
   sitemap: {
     hostname,
@@ -175,7 +175,7 @@ export default defineConfig({
           text: "Tool Reference",
           items: [
             { text: "Overview", link: "/tools/" },
-            { text: "Full API Reference", link: "/TOOLS" },
+            { text: "Full API Reference", link: "/tools/api-reference" },
           ],
         },
         {
@@ -303,7 +303,16 @@ export default defineConfig({
           "clients/claude-desktop.md",
         ];
 
+        // Files fully generated at build time - no source to edit
+        const generatedFiles = ["tools/api-reference.md"];
+
         const relativePath = filePath.replace(/^docs\//, "");
+
+        // Hide edit link for fully generated files
+        if (generatedFiles.includes(relativePath)) {
+          return "";
+        }
+
         const isTemplated = templatedFiles.includes(relativePath);
         const targetPath = isTemplated ? `${filePath}.in` : filePath;
 

--- a/docs/cli/list-tools.md
+++ b/docs/cli/list-tools.md
@@ -41,13 +41,13 @@ yarn list-tools --env
 
 ```bash
 # Generate complete markdown documentation
-yarn list-tools --export > docs/TOOLS.md
+yarn list-tools --export > docs/tools/api-reference.md
 
 # Include table of contents
-yarn list-tools --export --toc > docs/TOOLS.md
+yarn list-tools --export --toc > docs/tools/api-reference.md
 
 # Compact format (no example JSON)
-yarn list-tools --export --no-examples > docs/TOOLS.md
+yarn list-tools --export --no-examples > docs/tools/api-reference.md
 ```
 
 The `--export` mode generates:

--- a/docs/tools/index.md.in
+++ b/docs/tools/index.md.in
@@ -224,10 +224,10 @@ See [role-based prompts](/prompts/by-role/developer) for workflows tailored to e
 
 ## Detailed Documentation
 
-For complete parameter documentation, action matrices, and example requests, see the auto-generated [Full API Reference](/TOOLS).
+For complete parameter documentation, action matrices, and example requests, see the auto-generated [Full API Reference](/tools/api-reference).
 
 Generate locally:
 
 ```bash
-yarn list-tools --export --toc > docs/TOOLS.md
+yarn list-tools --export --toc > docs/tools/api-reference.md
 ```

--- a/src/cli/list-tools.ts
+++ b/src/cli/list-tools.ts
@@ -169,7 +169,7 @@ Usage: yarn list-tools [options]
 Tool Options:
   --json              Output in JSON format
   --simple            Simple list of tool names
-  --export            Generate complete TOOLS.md documentation
+  --export            Generate complete API reference documentation
   --env-gates         Show USE_* environment variable gates
   --entity <name>     Filter by entity (e.g., workitems, labels, mrs)
   --tool <name>       Show details for specific tool
@@ -193,8 +193,8 @@ General:
 Examples:
   yarn list-tools                                # List all tools in markdown
   yarn list-tools --json                         # JSON output
-  yarn list-tools --export                       # Generate TOOLS.md to stdout
-  yarn list-tools --export > docs/TOOLS.md       # Generate TOOLS.md to file
+  yarn list-tools --export                       # Generate API reference to stdout
+  yarn list-tools --export > docs/tools/api-reference.md  # Generate to file
   yarn list-tools --export --toc                 # With table of contents
   yarn list-tools --export --no-examples         # Skip example JSON blocks
   yarn list-tools --env-gates                    # Show USE_* variable gates
@@ -793,7 +793,7 @@ function getPackageVersion(): string {
 }
 
 /**
- * Generate complete TOOLS.md content
+ * Generate complete API reference markdown content
  */
 function generateExportMarkdown(
   tools: any[],


### PR DESCRIPTION
## Summary

- Move generated file from `docs/TOOLS.md` to `docs/tools/api-reference.md`
- Update sidebar link from `/TOOLS` to `/tools/api-reference`
- Remove `/TOOLS` from `ignoreDeadLinks` (no longer needed)
- Hide edit link for generated `api-reference.md` page
- Update documentation and CLI help text references

## Problem

The `/TOOLS` page was missing sidebar navigation because VitePress sidebar uses path prefix matching. The sidebar was defined for `/tools/` but the file was at `/TOOLS` (root level, uppercase).

## Solution

Move the generated file into the `/tools/` directory so it inherits the sidebar configuration.

Closes #303