### PR TITLE
fix(docs): replace Structured World with sw.foundation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -164,7 +164,7 @@ CMD ["sse"]
 # ============================================================================
 LABEL org.opencontainers.image.title="GitLab MCP Server"
 LABEL org.opencontainers.image.description="Advanced GitLab MCP server"
-LABEL org.opencontainers.image.vendor="Structured World"
+LABEL org.opencontainers.image.vendor="sw.foundation"
 LABEL org.opencontainers.image.authors="Dmitry Prudnikov <mail@polaz.com>"
 LABEL org.opencontainers.image.url="https://github.com/structured-world/gitlab-mcp"
 LABEL org.opencontainers.image.documentation="https://github.com/structured-world/gitlab-mcp/blob/main/README.md"

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -108,8 +108,8 @@ function generateStructuredData(pageData: PageDataWithFrontmatter): object[] {
       },
       author: {
         "@type": "Organization",
-        name: "Structured World",
-        url: "https://structured.world",
+        name: "sw.foundation",
+        url: "https://sw.foundation",
       },
     });
   }


### PR DESCRIPTION
## Summary

Follow-up fix to #305. Replaces remaining "Structured World" references with "sw.foundation".

## Changes

| File | Change |
|------|--------|
| `docs/.vitepress/config.mts` | Fix `author` in SoftwareApplication JSON-LD |
| `Dockerfile` | Fix `vendor` label |

gitlab-mcp is an OSS project managed by sw.foundation, not structured.world.

## Test plan

- [x] `yarn docs:build` succeeds
- [x] `yarn lint` passes
- [x] `yarn test` passes (4593 tests)
- [x] Verified no "Structured World" in codebase

Closes #307