### PR TITLE
test(handlers): add concurrent setupHandlers deduplication test

### DIFF
--- a/tests/unit/handlers.test.ts
+++ b/tests/unit/handlers.test.ts
@@ -210,6 +210,19 @@ describe('handlers', () => {
       callToolHandler = getRegisteredHandler(mockServer, CallToolRequestSchema);
     });
 
+    it('should deduplicate concurrent setupHandlers calls', async () => {
+      // Call setupHandlers concurrently — the ??= guard must ensure
+      // health monitor init and state-change registration happen exactly once
+      await Promise.all([
+        setupHandlers(mockServer),
+        setupHandlers(mockServer),
+        setupHandlers(mockServer),
+      ]);
+
+      expect(mockHealthMonitor.initialize).toHaveBeenCalledTimes(1);
+      expect(mockHealthMonitor.onStateChange).toHaveBeenCalledTimes(1);
+    });
+
     it('should continue setup even if health monitor starts disconnected', async () => {
       // Simulate HealthMonitor starting in disconnected state (GitLab unreachable)
       mockHealthMonitor.getState.mockReturnValue('disconnected');


### PR DESCRIPTION
## Summary
- Add test that calls `setupHandlers()` concurrently via `Promise.all()` and asserts health monitor `initialize` and `onStateChange` are called exactly once
- Guards the `??=` deduplication pattern against regression to per-session initialization

## Test plan
- [x] New test passes (`yarn test tests/unit/handlers.test.ts` — 75/75)
- [x] Full suite passes (`yarn test:all` — 5288/5288)
- [x] Lint clean, build clean

Closes #385