### PR TITLE
test(handlers): add regression coverage for all three bootstrap failure paths (#375)

### DIFF
--- a/tests/unit/handlers.test.ts
+++ b/tests/unit/handlers.test.ts
@@ -531,10 +531,10 @@ describe('handlers', () => {
       mockConnectionManager.initialize.mockResolvedValue(undefined);
     });
 
-    it('should return CONNECTION_FAILED when getClient throws after initialize succeeds', async () => {
-      // isConnected returns true so initialize() is skipped, but getClient() throws.
-      // bootstrapComplete is still false → must return structured CONNECTION_FAILED,
-      // not a generic "Bad Request: Server not initialized" string.
+    it('should return CONNECTION_FAILED on connected fast-path when getClient throws before bootstrap completes', async () => {
+      // isConnected() returns true, so initialize() is intentionally skipped here.
+      // getClient() then throws while bootstrapComplete is still false, which should
+      // produce a structured CONNECTION_FAILED response rather than a generic error string.
       mockConnectionManager.isConnected.mockReturnValue(true);
       mockConnectionManager.getClient.mockImplementationOnce(() => {
         throw new Error('Connection not initialized. Call initialize() first.');

--- a/tests/unit/handlers.test.ts
+++ b/tests/unit/handlers.test.ts
@@ -531,6 +531,38 @@ describe('handlers', () => {
       mockConnectionManager.initialize.mockResolvedValue(undefined);
     });
 
+    it('should return CONNECTION_FAILED when getClient throws after initialize succeeds', async () => {
+      // isConnected returns true so initialize() is skipped, but getClient() throws.
+      // bootstrapComplete is still false → must return structured CONNECTION_FAILED,
+      // not a generic "Bad Request: Server not initialized" string.
+      mockConnectionManager.isConnected.mockReturnValue(true);
+      mockConnectionManager.getClient.mockImplementationOnce(() => {
+        throw new Error('Connection not initialized. Call initialize() first.');
+      });
+
+      const result = await callToolHandler({
+        params: {
+          name: 'test_tool',
+          arguments: { action: 'list' },
+        },
+      });
+
+      expect(result.isError).toBe(true);
+      const parsed = JSON.parse(result.content![0].text);
+      expect(parsed.error_code).toBe('CONNECTION_FAILED');
+      expect(parsed.tool).toBe('test_tool');
+      expect(parsed.action).toBe('list');
+      expect(parsed.instance_url).toBe('https://gitlab.example.com');
+      // Error is reported to HealthMonitor
+      expect(mockHealthMonitor.reportError).toHaveBeenCalledWith(
+        'https://gitlab.example.com',
+        expect.any(Error),
+      );
+
+      // Restore
+      mockConnectionManager.getClient.mockReturnValue({});
+    });
+
     it('should return error if tool is not available', async () => {
       mockRegistryManager.hasToolHandler.mockReturnValue(false);
 


### PR DESCRIPTION
## Summary

- The structured `CONNECTION_FAILED` bootstrap error path was already implemented in main (PR #387, health monitor)
- Issue #375 identified three failure points: `initialize`, `getClient`, `ensureIntrospected`
- Tests existed for `initialize` and `ensureIntrospected` failures, but `getClient` was uncovered
- Add regression test: `isConnected()=true` → `initialize()` skipped → `getClient()` throws → `bootstrapComplete=false` → structured `CONNECTION_FAILED` returned (not re-thrown as "Bad Request: Server not initialized")

## Test Plan

- `yarn test tests/unit/handlers.test.ts` — 76 tests pass (was 75)
- New test: `should return CONNECTION_FAILED when getClient throws after initialize succeeds`

Closes #375