### PR TITLE
refactor(session): per-session instance URL tracking for session-aware ListTools

### DIFF
--- a/src/dashboard/metrics.ts
+++ b/src/dashboard/metrics.ts
@@ -233,9 +233,8 @@ export function collectMetrics(): DashboardMetrics {
   const uptimeSeconds = Math.floor((Date.now() - serverStartTime) / 1000);
 
   // Session counts by instance (anonymized - just counts, no user info)
-  // Note: Current SessionManager doesn't track per-instance sessions
-  // This would require extending the architecture to track which instance each session uses
-  const sessionsByInstance: Record<string, number> = {};
+  const sessionsByInstanceMap = sessionManager.getSessionsByInstance();
+  const sessionsByInstance: Record<string, number> = Object.fromEntries(sessionsByInstanceMap);
 
   return {
     server: {

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -501,6 +501,12 @@ export async function setupHandlers(server: Server): Promise<void> {
     // current instance URL → GITLAB_BASE_URL. Substituting GITLAB_BASE_URL explicitly
     // would short-circuit that chain and return the wrong tool list for OAuth requests
     // with a real context URL or after an instance switch (#398).
+    //
+    // NOTE: tools/list is NOT wrapped in runWithTokenContext(), so getGitLabApiUrlFromContext()
+    // returns undefined here regardless. Passing the tracked session URL is therefore
+    // correct — for static-token multi-instance it routes to the right instance, and
+    // for OAuth mode the session URL is kept in sync by the CallTool handler so it
+    // reflects the most-recently resolved OAuth context URL.
     const sessionInstanceUrl =
       listToolsSessionId !== undefined
         ? sessionMgr.getSessionInstanceUrl(listToolsSessionId)
@@ -622,7 +628,9 @@ export async function setupHandlers(server: Server): Promise<void> {
     // In static-token mode, prefer the actively selected instance URL so
     // requests continue routing to the current instance.
     const oauthEnabled = isOAuthEnabled();
-    const oauthContextUrl = oauthEnabled ? getUrlFromCtx() : null;
+    // getGitLabApiUrlFromContext() returns string | undefined; use undefined (not null)
+    // so that strict equality checks below correctly detect "no OAuth context".
+    const oauthContextUrl = oauthEnabled ? getUrlFromCtx() : undefined;
     const rawInstanceUrl = oauthEnabled
       ? (oauthContextUrl ?? GITLAB_BASE_URL)
       : (ConnectionManager.getInstance().getCurrentInstanceUrl() ?? GITLAB_BASE_URL);
@@ -636,7 +644,7 @@ export async function setupHandlers(server: Server): Promise<void> {
     // transport; persisting the fallback would reset multi-tenant tool filtering).
     // In static-token mode always track the active instance URL.
     const callSessionId = extra?.sessionId;
-    if (callSessionId && (!oauthEnabled || oauthContextUrl !== null)) {
+    if (callSessionId && (!oauthEnabled || oauthContextUrl !== undefined)) {
       const { getSessionManager: getSessionMgrForCall } = await import('./session-manager');
       getSessionMgrForCall().setSessionInstanceUrl(callSessionId, requestInstanceUrl);
     }

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -612,18 +612,22 @@ export async function setupHandlers(server: Server): Promise<void> {
     // fallback is safe because GITLAB_BASE_URL is always configured.
     // In static-token mode, prefer the actively selected instance URL so
     // requests continue routing to the current instance.
-    const rawInstanceUrl = isOAuthEnabled()
-      ? (getUrlFromCtx() ?? GITLAB_BASE_URL)
+    const oauthEnabled = isOAuthEnabled();
+    const oauthContextUrl = oauthEnabled ? getUrlFromCtx() : null;
+    const rawInstanceUrl = oauthEnabled
+      ? (oauthContextUrl ?? GITLAB_BASE_URL)
       : (ConnectionManager.getInstance().getCurrentInstanceUrl() ?? GITLAB_BASE_URL);
     // Normalize so CONNECTION_FAILED instance_url and HealthMonitor keys are consistent
     const requestInstanceUrl = normalizeInstanceUrl(rawInstanceUrl);
 
     // Keep per-session instance URL in sync so ListTools requests reflect the correct
-    // instance. In OAuth mode this resolves the actual instance from the token context
-    // (replacing the GITLAB_BASE_URL default set at session creation). In static-token
-    // mode this is the actively selected instance URL at the time of the call.
+    // instance. In OAuth mode only update when we have a real OAuth context URL —
+    // the GITLAB_BASE_URL fallback must NOT overwrite a session already pinned to a
+    // specific instance (contextless calls occur during health checks / non-OAuth
+    // transport; persisting the fallback would reset multi-tenant tool filtering).
+    // In static-token mode always track the active instance URL.
     const callSessionId = extra?.sessionId;
-    if (callSessionId) {
+    if (callSessionId && (!oauthEnabled || oauthContextUrl !== null)) {
       const { getSessionManager: getSessionMgrForCall } = await import('./session-manager');
       getSessionMgrForCall().setSessionInstanceUrl(callSessionId, requestInstanceUrl);
     }
@@ -782,6 +786,15 @@ export async function setupHandlers(server: Server): Promise<void> {
           request.params.arguments,
           effectiveInstanceUrl,
         );
+
+        // Guard against TOCTOU cache miss: hasToolHandler returned true but a
+        // concurrent refreshCache swapped the lookup table before executeTool ran.
+        // Re-throw so the outer catch converts it to a McpError, consistent with
+        // the explicit hasToolHandler check above. Never return JSON.stringify(undefined)
+        // which would produce an invalid MCP payload ("text: undefined").
+        if (result === undefined) {
+          throw new Error(`Tool '${toolName}' is not available or has been filtered out`);
+        }
 
         // Report success — skip if handler already timed out (late completion
         // must not overwrite the timeout error already sent to HealthMonitor)

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -401,10 +401,11 @@ export async function setupHandlers(server: Server): Promise<void> {
     // Keep per-session instance URL in sync so ListTools requests reflect the correct
     // instance. In OAuth mode this resolves the actual instance from the token context
     // (replacing the GITLAB_BASE_URL default set at session creation). In static-token
-    // mode this tracks switch_instance changes across requests.
-    if (extra?.sessionId) {
+    // mode this is the pre-dispatch URL; switch_instance is corrected post-dispatch below.
+    const callSessionId = extra?.sessionId;
+    if (callSessionId) {
       const { getSessionManager: getSessionMgrForCall } = await import('./session-manager');
-      getSessionMgrForCall().setSessionInstanceUrl(extra.sessionId, requestInstanceUrl);
+      getSessionMgrForCall().setSessionInstanceUrl(callSessionId, requestInstanceUrl);
     }
 
     // Flag to prevent late reportSuccess/reportError from a timed-out handlerWork()
@@ -716,6 +717,26 @@ export async function setupHandlers(server: Server): Promise<void> {
           request.params.arguments,
           effectiveInstanceUrl,
         );
+
+        // For switch_instance in static-token mode: requestInstanceUrl was captured
+        // before the tool ran and holds the old instance URL. Re-read
+        // getCurrentInstanceUrl() post-dispatch so the session immediately reflects
+        // the new instance, ensuring a tools/list_changed notification triggers
+        // ListTools with the correct catalog for the switched instance.
+        if (
+          !oauthMode &&
+          callSessionId &&
+          toolName === 'manage_context' &&
+          action === 'switch_instance'
+        ) {
+          const { getSessionManager: getPostSwitchSessionMgr } = await import('./session-manager');
+          getPostSwitchSessionMgr().setSessionInstanceUrl(
+            callSessionId,
+            normalizeInstanceUrl(
+              ConnectionManager.getInstance().getCurrentInstanceUrl() ?? GITLAB_BASE_URL,
+            ),
+          );
+        }
 
         // Report success — skip if handler already timed out (late completion
         // must not overwrite the timeout error already sent to HealthMonitor)

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -271,6 +271,10 @@ async function tryManageContextFastPath(
  * introspection step), or undefined on success. All errors are handled internally
  * and surfaced as a CONNECTION_FAILED payload — none are rethrown to the caller.
  */
+// Cognitive complexity is elevated but justified: bootstrapState mutations, error
+// classification, HealthMonitor reporting, and derived-state computation are tightly
+// coupled. Further extraction would add indirection without reducing conceptual complexity.
+// eslint-disable-next-line sonarjs/cognitive-complexity
 async function ensureBootstrapped(
   ctx: BootstrapContext,
 ): Promise<{ content: Array<{ type: string; text: string }>; isError: true } | undefined> {

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -178,6 +178,14 @@ export function resetHandlersState(): void {
   stateChangeRegistered = false;
 }
 
+/**
+ * Register all MCP request handlers on a Server instance.
+ *
+ * Called once per session by SessionManager. Handlers are idempotent across
+ * sessions — the same logic is registered on each per-session Server instance.
+ * One-shot initialisation guards (HealthMonitor startup, state-change callback)
+ * are protected by module-level flags so they run exactly once across all sessions.
+ */
 export async function setupHandlers(server: Server): Promise<void> {
   // Check if authentication is configured before trying to initialize connection
   const { isAuthenticationConfigured } = await import('./oauth/index');

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -253,6 +253,11 @@ async function tryManageContextFastPath(
   // bootstrap path below. A full atomic getTool() refactor is tracked separately.
   if (registryManager.hasToolHandler(toolName, effectiveInstanceUrl)) {
     const result = await registryManager.executeTool(toolName, toolArguments, effectiveInstanceUrl);
+    // If executeTool returns undefined (TOCTOU: cache was refreshed between hasToolHandler and
+    // executeTool), fall through to the bootstrap path instead of returning {text: "undefined"}.
+    if (result === undefined) {
+      return null;
+    }
     return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
   }
   return null; // tool not yet cached — fall through to bootstrap

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -267,10 +267,9 @@ async function tryManageContextFastPath(
  * Initialize the connection, verify the client, and rebuild the per-URL tool cache.
  *
  * Mutates bootstrapState to track progress for the handler-level timeout path.
- * Returns a CONNECTION_FAILED response if bootstrap fails before the connection is
- * established, or undefined on success. When initialization succeeds but a later
- * step fails (getClient / ensureIntrospected), the error is rethrown so the caller
- * can surface it as a generic tool error rather than a false CONNECTION_FAILED.
+ * Returns a CONNECTION_FAILED response when bootstrap fails (connection, client, or
+ * introspection step), or undefined on success. All errors are handled internally
+ * and surfaced as a CONNECTION_FAILED payload — none are rethrown to the caller.
  */
 async function ensureBootstrapped(
   ctx: BootstrapContext,
@@ -496,11 +495,12 @@ export async function setupHandlers(server: Server): Promise<void> {
     const { getSessionManager: getSessionMgr } = await import('./session-manager');
     const sessionMgr = getSessionMgr();
     const listToolsSessionId = extra?.sessionId;
-    // Always pass the tracked URL (or undefined) so getAllToolDefinitions can resolve via
-    // its built-in chain: OAuth request context → current instance URL → GITLAB_BASE_URL.
-    // Passing GITLAB_BASE_URL explicitly (either for unknown sessions or absent sessionId)
-    // would short-circuit this chain and return the wrong tool list for OAuth requests
-    // that have a real context URL or after an instance switch (#398).
+    // SessionManager always initialises instanceUrl on createSession(), so undefined here
+    // means the sessionId is unknown/expired (or absent). Pass it through so
+    // getAllToolDefinitions can resolve via its built-in chain: OAuth request context →
+    // current instance URL → GITLAB_BASE_URL. Substituting GITLAB_BASE_URL explicitly
+    // would short-circuit that chain and return the wrong tool list for OAuth requests
+    // with a real context URL or after an instance switch (#398).
     const sessionInstanceUrl =
       listToolsSessionId !== undefined
         ? sessionMgr.getSessionInstanceUrl(listToolsSessionId)

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -285,9 +285,16 @@ async function ensureBootstrapped(
     // so tier/version/widget availability are all populated.
     // Cache is keyed by normalized URL — concurrent multi-instance requests
     // each get their own cache entry and cannot interfere (#379).
-    {
+    // Isolated try/catch: cache rebuild is best-effort; a failure must NOT abort
+    // the tool call — the connection is already established at this point.
+    try {
       const { RegistryManager } = await import('./registry-manager');
       RegistryManager.getInstance().refreshCache(effectiveInstanceUrl);
+    } catch (cacheError) {
+      logWarn('Failed to refresh registry cache after bootstrap', {
+        instanceUrl: effectiveInstanceUrl,
+        err: cacheError as Error,
+      });
     }
     if (LOG_FORMAT === 'verbose') {
       try {
@@ -301,60 +308,53 @@ async function ensureBootstrapped(
     }
     return undefined;
   } catch (initError) {
-    // Use bootstrapComplete (not isConnected) — isConnected flips after
-    // initialize() but getClient/ensureIntrospected can still fail before
-    // bootstrapComplete is set, and those failures should return CONNECTION_FAILED.
-    if (!bootstrapState.complete) {
-      const errorCategory = initError instanceof Error ? classifyError(initError) : 'permanent';
-      // Report bootstrap failure to HealthMonitor. When the handler has already
-      // timed out, we still forward auth/permanent errors so the instance
-      // converges to `failed` instead of staying in `reconnecting` indefinitely.
-      if (initError instanceof Error) {
-        if (!isTimedOut() || errorCategory === 'auth' || errorCategory === 'permanent') {
-          healthMonitor.reportError(effectiveInstanceUrl, initError);
-        }
+    // bootstrapState.complete is always false here: refreshCache is isolated above,
+    // so the only way to reach this catch is initialize()/getClient()/ensureIntrospected()
+    // failing before bootstrapState.complete was set.
+    const errorCategory = initError instanceof Error ? classifyError(initError) : 'permanent';
+    // Report bootstrap failure to HealthMonitor. When the handler has already
+    // timed out, we still forward auth/permanent errors so the instance
+    // converges to `failed` instead of staying in `reconnecting` indefinitely.
+    if (initError instanceof Error) {
+      if (!isTimedOut() || errorCategory === 'auth' || errorCategory === 'permanent') {
+        healthMonitor.reportError(effectiveInstanceUrl, initError);
       }
-      logError(
-        `Connection initialization failed: ${initError instanceof Error ? initError.message : String(initError)}`,
-        { instanceUrl: effectiveInstanceUrl },
-      );
-      const action =
-        toolArguments && typeof toolArguments.action === 'string'
-          ? toolArguments.action
-          : 'unknown';
-      // Use error classification together with HealthMonitor state to determine
-      // the derived connection state. For untracked URLs, getState() falls back
-      // to 'disconnected', so we must not rely on that alone — otherwise
-      // permanent/auth failures would incorrectly appear retriable.
-      const monitorState = healthMonitor.getState(effectiveInstanceUrl);
-      // Prefer explicit monitor states when available; otherwise derive from the
-      // error category: auth/permanent → failed (no auto-retry),
-      // transient/other → disconnected (retriable)
-      let derivedState: 'connecting' | 'disconnected' | 'failed';
-      if (monitorState === 'connecting' || monitorState === 'failed') {
-        derivedState = monitorState;
-      } else if (errorCategory === 'auth' || errorCategory === 'permanent') {
-        derivedState = 'failed';
-      } else {
-        derivedState = 'disconnected';
-      }
-      const connError = createConnectionFailedError(
-        toolName,
-        action,
-        effectiveInstanceUrl,
-        derivedState,
-      );
-      if (!isTimedOut()) {
-        recordEarlyReturnError(toolName, action, connError.message);
-      }
-      return {
-        content: [{ type: 'text', text: JSON.stringify(connError, null, 2) }],
-        isError: true,
-      };
     }
-    // Connected but getClient()/ensureIntrospected() failed — rethrow as
-    // generic tool error. These are NOT connection failures (initialize succeeded).
-    throw initError;
+    logError(
+      `Connection initialization failed: ${initError instanceof Error ? initError.message : String(initError)}`,
+      { instanceUrl: effectiveInstanceUrl },
+    );
+    const action =
+      toolArguments && typeof toolArguments.action === 'string' ? toolArguments.action : 'unknown';
+    // Use error classification together with HealthMonitor state to determine
+    // the derived connection state. For untracked URLs, getState() falls back
+    // to 'disconnected', so we must not rely on that alone — otherwise
+    // permanent/auth failures would incorrectly appear retriable.
+    const monitorState = healthMonitor.getState(effectiveInstanceUrl);
+    // Prefer explicit monitor states when available; otherwise derive from the
+    // error category: auth/permanent → failed (no auto-retry),
+    // transient/other → disconnected (retriable)
+    let derivedState: 'connecting' | 'disconnected' | 'failed';
+    if (monitorState === 'connecting' || monitorState === 'failed') {
+      derivedState = monitorState;
+    } else if (errorCategory === 'auth' || errorCategory === 'permanent') {
+      derivedState = 'failed';
+    } else {
+      derivedState = 'disconnected';
+    }
+    const connError = createConnectionFailedError(
+      toolName,
+      action,
+      effectiveInstanceUrl,
+      derivedState,
+    );
+    if (!isTimedOut()) {
+      recordEarlyReturnError(toolName, action, connError.message);
+    }
+    return {
+      content: [{ type: 'text', text: JSON.stringify(connError, null, 2) }],
+      isError: true,
+    };
   }
 }
 

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -342,7 +342,10 @@ async function ensureBootstrapped(
     }
     logError(
       `Connection initialization failed: ${initError instanceof Error ? initError.message : String(initError)}`,
-      { instanceUrl: effectiveInstanceUrl },
+      {
+        instanceUrl: effectiveInstanceUrl,
+        err: initError instanceof Error ? initError : new Error(String(initError)),
+      },
     );
     const action =
       toolArguments && typeof toolArguments.action === 'string' ? toolArguments.action : 'unknown';
@@ -493,8 +496,13 @@ export async function setupHandlers(server: Server): Promise<void> {
     const { getSessionManager: getSessionMgr } = await import('./session-manager');
     const sessionMgr = getSessionMgr();
     const listToolsSessionId = extra?.sessionId;
+    // When sessionId is present, pass the tracked URL directly (may be undefined for a
+    // newly created session whose CallTool hasn't run yet). getAllToolDefinitions resolves
+    // undefined via its built-in chain: OAuth request context → current instance URL →
+    // GITLAB_BASE_URL. Passing GITLAB_BASE_URL explicitly would short-circuit this chain
+    // and return the wrong tool list for OAuth requests that have a real context URL.
     const sessionInstanceUrl = listToolsSessionId
-      ? (sessionMgr.getSessionInstanceUrl(listToolsSessionId) ?? GITLAB_BASE_URL)
+      ? sessionMgr.getSessionInstanceUrl(listToolsSessionId)
       : GITLAB_BASE_URL;
 
     // Get tools from registry manager (already filtered by tier/version/scopes)

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -496,14 +496,15 @@ export async function setupHandlers(server: Server): Promise<void> {
     const { getSessionManager: getSessionMgr } = await import('./session-manager');
     const sessionMgr = getSessionMgr();
     const listToolsSessionId = extra?.sessionId;
-    // When sessionId is present, pass the tracked URL directly (may be undefined for a
-    // newly created session whose CallTool hasn't run yet). getAllToolDefinitions resolves
-    // undefined via its built-in chain: OAuth request context → current instance URL →
-    // GITLAB_BASE_URL. Passing GITLAB_BASE_URL explicitly would short-circuit this chain
-    // and return the wrong tool list for OAuth requests that have a real context URL.
-    const sessionInstanceUrl = listToolsSessionId
-      ? sessionMgr.getSessionInstanceUrl(listToolsSessionId)
-      : GITLAB_BASE_URL;
+    // Always pass the tracked URL (or undefined) so getAllToolDefinitions can resolve via
+    // its built-in chain: OAuth request context → current instance URL → GITLAB_BASE_URL.
+    // Passing GITLAB_BASE_URL explicitly (either for unknown sessions or absent sessionId)
+    // would short-circuit this chain and return the wrong tool list for OAuth requests
+    // that have a real context URL or after an instance switch (#398).
+    const sessionInstanceUrl =
+      listToolsSessionId !== undefined
+        ? sessionMgr.getSessionInstanceUrl(listToolsSessionId)
+        : undefined;
 
     // Get tools from registry manager (already filtered by tier/version/scopes)
     const { RegistryManager } = await import('./registry-manager');

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -203,7 +203,9 @@ export async function setupHandlers(server: Server): Promise<void> {
             RegistryManager.getInstance().refreshCache(instanceUrl);
 
             const { getSessionManager } = await import('./session-manager');
-            await getSessionManager().broadcastToolsListChanged();
+            // Pass instanceUrl so only sessions targeting the changed instance are notified.
+            // Sessions on other instances have no tool list changes from this state transition.
+            await getSessionManager().broadcastToolsListChanged(instanceUrl);
 
             logInfo('Tool list updated after connection state change', {
               instanceUrl,
@@ -259,18 +261,26 @@ export async function setupHandlers(server: Server): Promise<void> {
     logInfo('Skipping connection initialization - no authentication configured');
   }
   // List tools handler
-  // getAllToolDefinitions() resolves the effective instance URL from OAuth token
-  // context when called without arguments, so authenticated multi-instance sessions
-  // already receive instance-specific tool lists. Remaining limitation:
-  // unauthenticated tools/list requests fall back to default/global instance
-  // because there is no per-session token context to infer an instance from (#398).
-  server.setRequestHandler(ListToolsRequestSchema, async () => {
+  // Uses per-session instance URL tracking so each session receives the tool list
+  // filtered for its target GitLab instance (#398). The sessionId from RequestHandlerExtra
+  // resolves to the instance URL stored in SessionManager (set on session creation and
+  // kept in sync by the CallToolRequestSchema handler on every tool call).
+  server.setRequestHandler(ListToolsRequestSchema, async (_request, extra) => {
     logInfo('ListToolsRequest received');
 
-    // Get tools from registry manager (already filtered)
+    // Resolve the instance URL for this session so the tool list reflects the
+    // correct tier/version/scope restrictions for the session's target instance.
+    const { getSessionManager: getSessionMgr } = await import('./session-manager');
+    const sessionMgr = getSessionMgr();
+    const listToolsSessionId = extra?.sessionId;
+    const sessionInstanceUrl = listToolsSessionId
+      ? (sessionMgr.getSessionInstanceUrl(listToolsSessionId) ?? GITLAB_BASE_URL)
+      : GITLAB_BASE_URL;
+
+    // Get tools from registry manager (already filtered by tier/version/scopes)
     const { RegistryManager } = await import('./registry-manager');
     const registryManager = RegistryManager.getInstance();
-    const tools = registryManager.getAllToolDefinitions();
+    const tools = registryManager.getAllToolDefinitions(sessionInstanceUrl);
 
     logInfo('Returning tools list', { toolCount: tools.length });
 
@@ -367,7 +377,7 @@ export async function setupHandlers(server: Server): Promise<void> {
   // using Promise.race() so the client gets a response early on hang. The underlying
   // work may continue running after the timeout fires, but late results are guarded
   // by the timedOut flag to prevent overwriting the timeout error response.
-  server.setRequestHandler(CallToolRequestSchema, async (request) => {
+  server.setRequestHandler(CallToolRequestSchema, async (request, extra) => {
     // Capture instance URL early — used for both handlerWork and timeout reporting.
     // Must be resolved before Promise.race so timeout branch doesn't re-derive a
     // potentially different URL after a concurrent switch_instance.
@@ -387,6 +397,15 @@ export async function setupHandlers(server: Server): Promise<void> {
       : (ConnectionManager.getInstance().getCurrentInstanceUrl() ?? GITLAB_BASE_URL);
     // Normalize so CONNECTION_FAILED instance_url and HealthMonitor keys are consistent
     const requestInstanceUrl = normalizeInstanceUrl(rawInstanceUrl);
+
+    // Keep per-session instance URL in sync so ListTools requests reflect the correct
+    // instance. In OAuth mode this resolves the actual instance from the token context
+    // (replacing the GITLAB_BASE_URL default set at session creation). In static-token
+    // mode this tracks switch_instance changes across requests.
+    if (extra?.sessionId) {
+      const { getSessionManager: getSessionMgrForCall } = await import('./session-manager');
+      getSessionMgrForCall().setSessionInstanceUrl(extra.sessionId, requestInstanceUrl);
+    }
 
     // Flag to prevent late reportSuccess/reportError from a timed-out handlerWork()
     // overwriting the timeout signal already sent to HealthMonitor.

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -172,6 +172,18 @@ interface BootstrapState {
   complete: boolean;
 }
 
+/** Dependencies and per-call values passed to ensureBootstrapped. */
+interface BootstrapContext {
+  toolName: string;
+  toolArguments: Record<string, unknown> | undefined;
+  effectiveInstanceUrl: string;
+  oauthMode: boolean;
+  connectionManager: ConnectionManager;
+  healthMonitor: HealthMonitor;
+  isTimedOut: () => boolean;
+  bootstrapState: BootstrapState;
+}
+
 /**
  * Return a CONNECTION_FAILED response if the target instance is unreachable for
  * non-context tools, or null to proceed normally.
@@ -256,15 +268,18 @@ async function tryManageContextFastPath(
  * can surface it as a generic tool error rather than a false CONNECTION_FAILED.
  */
 async function ensureBootstrapped(
-  toolName: string,
-  toolArguments: Record<string, unknown> | undefined,
-  effectiveInstanceUrl: string,
-  oauthMode: boolean,
-  connectionManager: ConnectionManager,
-  healthMonitor: HealthMonitor,
-  isTimedOut: () => boolean,
-  bootstrapState: BootstrapState,
+  ctx: BootstrapContext,
 ): Promise<{ content: Array<{ type: string; text: string }>; isError: true } | undefined> {
+  const {
+    toolName,
+    toolArguments,
+    effectiveInstanceUrl,
+    oauthMode,
+    connectionManager,
+    healthMonitor,
+    isTimedOut,
+    bootstrapState,
+  } = ctx;
   bootstrapState.started = true;
   try {
     if (!connectionManager.isConnected(effectiveInstanceUrl)) {
@@ -684,16 +699,16 @@ export async function setupHandlers(server: Server): Promise<void> {
 
       // Initialize connection, verify client, and rebuild the per-URL tool cache
       const oauthMode = isOAuthEnabled();
-      const bootstrapFailure = await ensureBootstrapped(
+      const bootstrapFailure = await ensureBootstrapped({
         toolName,
         toolArguments,
         effectiveInstanceUrl,
         oauthMode,
         connectionManager,
         healthMonitor,
-        () => timedOut,
+        isTimedOut: () => timedOut,
         bootstrapState,
-      );
+      });
       if (bootstrapFailure) return bootstrapFailure;
 
       // Dynamic tool dispatch using the new registry manager

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -166,6 +166,198 @@ function toStructuredError(
   );
 }
 
+/** Tracks connection bootstrap progress; shared with the handler-level timeout path. */
+interface BootstrapState {
+  started: boolean;
+  complete: boolean;
+}
+
+/**
+ * Return a CONNECTION_FAILED response if the target instance is unreachable for
+ * non-context tools, or null to proceed normally.
+ *
+ * manage_context always passes through — it operates on local state and can
+ * surface the disconnected status to the caller.
+ */
+function checkUnreachableInstance(
+  toolName: string,
+  toolArguments: Record<string, unknown> | undefined,
+  effectiveInstanceUrl: string,
+  healthMonitor: HealthMonitor,
+): { content: Array<{ type: string; text: string }>; isError: true } | null {
+  if (healthMonitor.isInstanceReachable(effectiveInstanceUrl) || toolName === 'manage_context') {
+    return null;
+  }
+  const action =
+    toolArguments && typeof toolArguments.action === 'string' ? toolArguments.action : 'unknown';
+  const rawState = healthMonitor.getState(effectiveInstanceUrl);
+  let connectionState: 'connecting' | 'disconnected' | 'failed';
+  if (rawState === 'failed') {
+    connectionState = 'failed';
+  } else if (rawState === 'connecting') {
+    connectionState = 'connecting';
+  } else {
+    connectionState = 'disconnected';
+  }
+  const connError = createConnectionFailedError(
+    toolName,
+    action,
+    effectiveInstanceUrl,
+    connectionState,
+  );
+  recordEarlyReturnError(toolName, action, connError.message);
+  return { content: [{ type: 'text', text: JSON.stringify(connError, null, 2) }], isError: true };
+}
+
+/**
+ * Fast-path for manage_context when the instance is unreachable: bypass connection
+ * bootstrap and health reporting. Returns a tool response if handled, or null to
+ * fall through to the normal bootstrap path.
+ *
+ * Bypasses bootstrap intentionally — context tools mostly operate on local state
+ * (cached scopes, config, instance registry). Health reporting is skipped because
+ * the fast-path bypasses bootstrap — there is no connection lifecycle to report on.
+ */
+async function tryManageContextFastPath(
+  toolName: string,
+  toolArguments: Record<string, unknown> | undefined,
+  effectiveInstanceUrl: string,
+  healthMonitor: HealthMonitor,
+): Promise<{ content: Array<{ type: string; text: string }> } | null> {
+  if (toolName !== 'manage_context' || healthMonitor.isInstanceReachable(effectiveInstanceUrl)) {
+    return null;
+  }
+  if (LOG_FORMAT === 'condensed') {
+    const action =
+      toolArguments && typeof toolArguments.action === 'string' ? toolArguments.action : undefined;
+    const requestTracker = getRequestTracker();
+    requestTracker.setToolForCurrentRequest(toolName, action);
+  }
+  const { RegistryManager } = await import('./registry-manager');
+  const registryManager = RegistryManager.getInstance();
+  // hasToolHandler + executeTool are not a single atomic operation — a concurrent
+  // refreshCache() could swap the lookup cache between the two calls. In practice
+  // this is benign: executeTool() falls through with undefined and we re-enter the
+  // bootstrap path below. A full atomic getTool() refactor is tracked separately.
+  if (registryManager.hasToolHandler(toolName, effectiveInstanceUrl)) {
+    const result = await registryManager.executeTool(toolName, toolArguments, effectiveInstanceUrl);
+    return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+  }
+  return null; // tool not yet cached — fall through to bootstrap
+}
+
+/**
+ * Initialize the connection, verify the client, and rebuild the per-URL tool cache.
+ *
+ * Mutates bootstrapState to track progress for the handler-level timeout path.
+ * Returns a CONNECTION_FAILED response if bootstrap fails before the connection is
+ * established, or undefined on success. When initialization succeeds but a later
+ * step fails (getClient / ensureIntrospected), the error is rethrown so the caller
+ * can surface it as a generic tool error rather than a false CONNECTION_FAILED.
+ */
+async function ensureBootstrapped(
+  toolName: string,
+  toolArguments: Record<string, unknown> | undefined,
+  effectiveInstanceUrl: string,
+  oauthMode: boolean,
+  connectionManager: ConnectionManager,
+  healthMonitor: HealthMonitor,
+  isTimedOut: () => boolean,
+  bootstrapState: BootstrapState,
+): Promise<{ content: Array<{ type: string; text: string }>; isError: true } | undefined> {
+  bootstrapState.started = true;
+  try {
+    if (!connectionManager.isConnected(effectiveInstanceUrl)) {
+      if (LOG_FORMAT === 'verbose') {
+        logInfo('Connection not initialized, attempting to initialize...');
+      }
+      await connectionManager.initialize(effectiveInstanceUrl);
+    }
+    connectionManager.getClient(effectiveInstanceUrl);
+    if (oauthMode) {
+      await connectionManager.ensureIntrospected(effectiveInstanceUrl);
+    }
+    // Mark bootstrap complete BEFORE cache rebuild — refreshCache is local
+    // bookkeeping, not a connectivity step. If it fails, the tool call should
+    // still proceed (not return CONNECTION_FAILED for a successful connection).
+    bootstrapState.complete = true;
+    // Rebuild per-URL registry cache AFTER full bootstrap (initialize + introspection)
+    // so tier/version/widget availability are all populated.
+    // Cache is keyed by normalized URL — concurrent multi-instance requests
+    // each get their own cache entry and cannot interfere (#379).
+    {
+      const { RegistryManager } = await import('./registry-manager');
+      RegistryManager.getInstance().refreshCache(effectiveInstanceUrl);
+    }
+    if (LOG_FORMAT === 'verbose') {
+      try {
+        const instanceInfo = connectionManager.getInstanceInfo(effectiveInstanceUrl);
+        logInfo(`Connection verified: ${instanceInfo.version} ${instanceInfo.tier}`);
+      } catch {
+        logDebug('Connection verified but instance info not yet available', {
+          instanceUrl: effectiveInstanceUrl,
+        });
+      }
+    }
+    return undefined;
+  } catch (initError) {
+    // Use bootstrapComplete (not isConnected) — isConnected flips after
+    // initialize() but getClient/ensureIntrospected can still fail before
+    // bootstrapComplete is set, and those failures should return CONNECTION_FAILED.
+    if (!bootstrapState.complete) {
+      const errorCategory = initError instanceof Error ? classifyError(initError) : 'permanent';
+      // Report bootstrap failure to HealthMonitor. When the handler has already
+      // timed out, we still forward auth/permanent errors so the instance
+      // converges to `failed` instead of staying in `reconnecting` indefinitely.
+      if (initError instanceof Error) {
+        if (!isTimedOut() || errorCategory === 'auth' || errorCategory === 'permanent') {
+          healthMonitor.reportError(effectiveInstanceUrl, initError);
+        }
+      }
+      logError(
+        `Connection initialization failed: ${initError instanceof Error ? initError.message : String(initError)}`,
+        { instanceUrl: effectiveInstanceUrl },
+      );
+      const action =
+        toolArguments && typeof toolArguments.action === 'string'
+          ? toolArguments.action
+          : 'unknown';
+      // Use error classification together with HealthMonitor state to determine
+      // the derived connection state. For untracked URLs, getState() falls back
+      // to 'disconnected', so we must not rely on that alone — otherwise
+      // permanent/auth failures would incorrectly appear retriable.
+      const monitorState = healthMonitor.getState(effectiveInstanceUrl);
+      // Prefer explicit monitor states when available; otherwise derive from the
+      // error category: auth/permanent → failed (no auto-retry),
+      // transient/other → disconnected (retriable)
+      let derivedState: 'connecting' | 'disconnected' | 'failed';
+      if (monitorState === 'connecting' || monitorState === 'failed') {
+        derivedState = monitorState;
+      } else if (errorCategory === 'auth' || errorCategory === 'permanent') {
+        derivedState = 'failed';
+      } else {
+        derivedState = 'disconnected';
+      }
+      const connError = createConnectionFailedError(
+        toolName,
+        action,
+        effectiveInstanceUrl,
+        derivedState,
+      );
+      if (!isTimedOut()) {
+        recordEarlyReturnError(toolName, action, connError.message);
+      }
+      return {
+        content: [{ type: 'text', text: JSON.stringify(connError, null, 2) }],
+        isError: true,
+      };
+    }
+    // Connected but getClient()/ensureIntrospected() failed — rethrow as
+    // generic tool error. These are NOT connection failures (initialize succeeded).
+    throw initError;
+  }
+}
+
 /** One-shot startup promise: health monitor init + registry refresh.
  *  Concurrent setupHandlers() calls await the same promise instead of racing. */
 let healthMonitorStartup: Promise<void> | null = null;
@@ -420,11 +612,10 @@ export async function setupHandlers(server: Server): Promise<void> {
     // overwriting the timeout signal already sent to HealthMonitor.
     let timedOut = false;
     // Tracks whether bootstrap was entered and whether it completed.
-    // bootstrapStarted: true once we enter the init/introspection path (not set
-    //   for disconnected manage_context bypass which does no GitLab I/O)
-    // bootstrapComplete: true after init + introspection succeed (before cache rebuild)
-    let bootstrapStarted = false;
-    let bootstrapComplete = false;
+    // started: true once we enter the init/introspection path (not set for the
+    //   disconnected manage_context bypass which does no GitLab I/O)
+    // complete: true after init + introspection succeed (before cache rebuild)
+    const bootstrapState: BootstrapState = { started: false, complete: false };
 
     // Create a timeout promise that rejects after HANDLER_TIMEOUT_MS
     const HANDLER_TIMEOUT_SYMBOL = Symbol('handler_timeout');
@@ -468,195 +659,42 @@ export async function setupHandlers(server: Server): Promise<void> {
       // to ensure the entire dispatch path uses the same URL.
       const effectiveInstanceUrl = requestInstanceUrl;
       const connectionManager = ConnectionManager.getInstance();
-
-      // Check connection health — if disconnected, return structured error for non-context tools.
-      // Context tools (manage_context) are allowed through for diagnostic/context management
-      // actions (e.g., whoami, show_scope, set_scope).
       const healthMonitor = HealthMonitor.getInstance();
       const toolName = request.params.name;
-      // isInstanceReachable treats untracked URLs as reachable (first call before
-      // HealthMonitor.initialize) and healthy/degraded as reachable.
-      if (
-        !healthMonitor.isInstanceReachable(effectiveInstanceUrl) &&
-        toolName !== 'manage_context'
-      ) {
-        const action =
-          request.params.arguments && typeof request.params.arguments.action === 'string'
-            ? request.params.arguments.action
-            : 'unknown';
+      const toolArguments = request.params.arguments;
 
-        // Read state for CONNECTION_FAILED payload
-        const rawState = healthMonitor.getState(effectiveInstanceUrl);
-        let connectionState: 'connecting' | 'disconnected' | 'failed';
-        if (rawState === 'failed') {
-          connectionState = 'failed';
-        } else if (rawState === 'connecting') {
-          connectionState = 'connecting';
-        } else {
-          connectionState = 'disconnected';
-        }
-        const connError = createConnectionFailedError(
-          toolName,
-          action,
-          effectiveInstanceUrl,
-          connectionState,
-        );
+      // Early return: instance unreachable for non-context tools
+      // (isInstanceReachable treats untracked URLs as reachable before HealthMonitor.initialize)
+      const unreachableResult = checkUnreachableInstance(
+        toolName,
+        toolArguments,
+        effectiveInstanceUrl,
+        healthMonitor,
+      );
+      if (unreachableResult) return unreachableResult;
 
-        recordEarlyReturnError(toolName, action, connError.message);
+      // manage_context fast-path when disconnected: bypass bootstrap and health reporting
+      const fastPathResult = await tryManageContextFastPath(
+        toolName,
+        toolArguments,
+        effectiveInstanceUrl,
+        healthMonitor,
+      );
+      if (fastPathResult) return fastPathResult;
 
-        return {
-          content: [{ type: 'text', text: JSON.stringify(connError, null, 2) }],
-          isError: true,
-        };
-      }
-
-      // Disconnected/failed fast-path for manage_context: skip connection bootstrap
-      // and health reporting. Most context actions operate on local state (cached
-      // scopes, config, instance registry). Some actions (e.g. whoami) may attempt
-      // GitLab API calls that fail gracefully. Health reporting is skipped because
-      // the fast-path bypasses bootstrap — there's no connection lifecycle to report on.
-      if (
-        toolName === 'manage_context' &&
-        !healthMonitor.isInstanceReachable(effectiveInstanceUrl)
-      ) {
-        // Track in condensed mode so disconnected context calls appear in access logs
-        if (LOG_FORMAT === 'condensed') {
-          const action =
-            request.params.arguments && typeof request.params.arguments.action === 'string'
-              ? request.params.arguments.action
-              : undefined;
-          const requestTracker = getRequestTracker();
-          requestTracker.setToolForCurrentRequest(toolName, action);
-        }
-
-        const { RegistryManager } = await import('./registry-manager');
-        const registryManager = RegistryManager.getInstance();
-        // hasToolHandler + executeTool are not a single atomic operation — a concurrent
-        // refreshCache() could swap the lookup cache between the two calls. In practice
-        // this is benign: executeTool() falls through with undefined and we re-enter the
-        // bootstrap path below. A full atomic getTool() refactor is tracked separately.
-        if (registryManager.hasToolHandler(toolName, effectiveInstanceUrl)) {
-          const result = await registryManager.executeTool(
-            toolName,
-            request.params.arguments,
-            effectiveInstanceUrl,
-          );
-          return {
-            content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
-          };
-        }
-      }
-
-      // Check if connection is initialized - try to initialize if needed
-      bootstrapStarted = true;
+      // Initialize connection, verify client, and rebuild the per-URL tool cache
       const oauthMode = isOAuthEnabled();
-
-      try {
-        // Ensure connection is initialized for this URL (no-op if already done)
-        if (!connectionManager.isConnected(effectiveInstanceUrl)) {
-          if (LOG_FORMAT === 'verbose') {
-            logInfo('Connection not initialized, attempting to initialize...');
-          }
-          await connectionManager.initialize(effectiveInstanceUrl);
-        }
-
-        // Verify client is available for this URL
-        connectionManager.getClient(effectiveInstanceUrl);
-
-        // In OAuth mode, ensure introspection is done for the effective URL
-        if (oauthMode) {
-          await connectionManager.ensureIntrospected(effectiveInstanceUrl);
-        }
-
-        // Mark bootstrap complete BEFORE cache rebuild — refreshCache is local
-        // bookkeeping, not a connectivity step. If it fails, the tool call should
-        // still proceed (not return CONNECTION_FAILED for a successful connection).
-        bootstrapComplete = true;
-
-        // Rebuild per-URL registry cache AFTER full bootstrap (initialize + introspection)
-        // so tier/version/widget availability are all populated.
-        // Cache is keyed by normalized URL — concurrent multi-instance requests
-        // each get their own cache entry and cannot interfere (#379).
-        {
-          const { RegistryManager } = await import('./registry-manager');
-          RegistryManager.getInstance().refreshCache(effectiveInstanceUrl);
-        }
-        // Best-effort log enrichment — getInstanceInfo may throw in OAuth-deferred
-        // or degraded mode where version detection hasn't completed yet.
-        if (LOG_FORMAT === 'verbose') {
-          try {
-            const instanceInfo = connectionManager.getInstanceInfo(effectiveInstanceUrl);
-            logInfo(`Connection verified: ${instanceInfo.version} ${instanceInfo.tier}`);
-          } catch {
-            logDebug('Connection verified but instance info not yet available', {
-              instanceUrl: effectiveInstanceUrl,
-            });
-          }
-        }
-      } catch (initError) {
-        // Use bootstrapComplete (not isConnected) — isConnected flips after
-        // initialize() but getClient/ensureIntrospected can still fail before
-        // bootstrapComplete is set, and those failures should return CONNECTION_FAILED.
-        if (!bootstrapComplete) {
-          const errorCategory = initError instanceof Error ? classifyError(initError) : 'permanent';
-          // Report bootstrap failure to HealthMonitor. When the handler has already
-          // timed out, we still forward auth/permanent errors so the instance
-          // converges to `failed` instead of staying in `reconnecting` indefinitely.
-          if (initError instanceof Error) {
-            if (!timedOut || errorCategory === 'auth' || errorCategory === 'permanent') {
-              healthMonitor.reportError(effectiveInstanceUrl, initError);
-            }
-          }
-          logError(
-            `Connection initialization failed: ${initError instanceof Error ? initError.message : String(initError)}`,
-            { instanceUrl: effectiveInstanceUrl },
-          );
-          // Return structured CONNECTION_FAILED so clients get instance_url,
-          // reconnecting status, and suggested fix (not a generic "Bad Request")
-          const action =
-            request.params.arguments && typeof request.params.arguments.action === 'string'
-              ? request.params.arguments.action
-              : 'unknown';
-          // Use error classification together with HealthMonitor state to determine
-          // the derived connection state. For untracked URLs, getState() falls back
-          // to 'disconnected', so we must not rely on that alone — otherwise
-          // permanent/auth failures would incorrectly appear retriable.
-          const monitorState = healthMonitor.getState(effectiveInstanceUrl);
-          // Prefer explicit monitor states when available; otherwise derive from
-          // the error category:
-          // - auth/permanent → failed (no auto-retry)
-          // - transient/other → disconnected (retriable)
-          let derivedState: 'connecting' | 'disconnected' | 'failed';
-          if (monitorState === 'connecting' || monitorState === 'failed') {
-            derivedState = monitorState;
-          } else if (errorCategory === 'auth' || errorCategory === 'permanent') {
-            derivedState = 'failed';
-          } else {
-            derivedState = 'disconnected';
-          }
-          const connError = createConnectionFailedError(
-            toolName,
-            action,
-            effectiveInstanceUrl,
-            derivedState,
-          );
-
-          // Skip bookkeeping if timeout already recorded the error
-          if (!timedOut) {
-            recordEarlyReturnError(toolName, action, connError.message);
-          }
-
-          return {
-            content: [{ type: 'text', text: JSON.stringify(connError, null, 2) }],
-            isError: true,
-          };
-        }
-        // Connected but getClient()/ensureIntrospected() failed — rethrow as
-        // generic tool error. These are NOT connection failures (initialize
-        // succeeded), so CONNECTION_FAILED would be misleading. The error will
-        // be caught by the outer handler and returned as a standard tool error.
-        throw initError;
-      }
+      const bootstrapFailure = await ensureBootstrapped(
+        toolName,
+        toolArguments,
+        effectiveInstanceUrl,
+        oauthMode,
+        connectionManager,
+        healthMonitor,
+        () => timedOut,
+        bootstrapState,
+      );
+      if (bootstrapFailure) return bootstrapFailure;
 
       // Dynamic tool dispatch using the new registry manager
       const toolArgs = request.params.arguments;
@@ -780,7 +818,7 @@ export async function setupHandlers(server: Server): Promise<void> {
         // Only report to health monitor and clear inflight if bootstrap was
         // actually attempted (not for disconnected manage_context bypass which
         // does no GitLab I/O and shouldn't affect connection health).
-        if (bootstrapStarted && !bootstrapComplete) {
+        if (bootstrapState.started && !bootstrapState.complete) {
           // Use "timed out" so classifyError() reliably treats this as transient
           // and triggers disconnected → auto-reconnect. Use a plain Error (not
           // InitializationTimeoutError) because this is a handler-level timeout,

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -380,7 +380,7 @@ export async function setupHandlers(server: Server): Promise<void> {
   server.setRequestHandler(CallToolRequestSchema, async (request, extra) => {
     // Capture instance URL early — used for both handlerWork and timeout reporting.
     // Must be resolved before Promise.race so timeout branch doesn't re-derive a
-    // potentially different URL after a concurrent switch_instance.
+    // potentially different URL after a concurrent instance change.
     const { getGitLabApiUrlFromContext: getUrlFromCtx, isOAuthEnabled } =
       await import('./oauth/index');
     // In OAuth mode, use the per-request context URL to avoid bleeding the
@@ -391,7 +391,7 @@ export async function setupHandlers(server: Server): Promise<void> {
     // error) would block health monitoring and tool-list initialization. The
     // fallback is safe because GITLAB_BASE_URL is always configured.
     // In static-token mode, prefer the actively selected instance URL so
-    // switch_instance requests continue routing to the current instance.
+    // requests continue routing to the current instance.
     const rawInstanceUrl = isOAuthEnabled()
       ? (getUrlFromCtx() ?? GITLAB_BASE_URL)
       : (ConnectionManager.getInstance().getCurrentInstanceUrl() ?? GITLAB_BASE_URL);
@@ -401,7 +401,7 @@ export async function setupHandlers(server: Server): Promise<void> {
     // Keep per-session instance URL in sync so ListTools requests reflect the correct
     // instance. In OAuth mode this resolves the actual instance from the token context
     // (replacing the GITLAB_BASE_URL default set at session creation). In static-token
-    // mode this is the pre-dispatch URL; switch_instance is corrected post-dispatch below.
+    // mode this is the actively selected instance URL at the time of the call.
     const callSessionId = extra?.sessionId;
     if (callSessionId) {
       const { getSessionManager: getSessionMgrForCall } = await import('./session-manager');
@@ -457,8 +457,7 @@ export async function setupHandlers(server: Server): Promise<void> {
       }
 
       // Use the instance URL captured before Promise.race (requestInstanceUrl)
-      // to ensure the entire dispatch path uses the same URL, even if a concurrent
-      // switch_instance changes getCurrentInstanceUrl mid-request.
+      // to ensure the entire dispatch path uses the same URL.
       const effectiveInstanceUrl = requestInstanceUrl;
       const connectionManager = ConnectionManager.getInstance();
 
@@ -717,26 +716,6 @@ export async function setupHandlers(server: Server): Promise<void> {
           request.params.arguments,
           effectiveInstanceUrl,
         );
-
-        // For switch_instance in static-token mode: requestInstanceUrl was captured
-        // before the tool ran and holds the old instance URL. Re-read
-        // getCurrentInstanceUrl() post-dispatch so the session immediately reflects
-        // the new instance, ensuring a tools/list_changed notification triggers
-        // ListTools with the correct catalog for the switched instance.
-        if (
-          !oauthMode &&
-          callSessionId &&
-          toolName === 'manage_context' &&
-          action === 'switch_instance'
-        ) {
-          const { getSessionManager: getPostSwitchSessionMgr } = await import('./session-manager');
-          getPostSwitchSessionMgr().setSessionInstanceUrl(
-            callSessionId,
-            normalizeInstanceUrl(
-              ConnectionManager.getInstance().getCurrentInstanceUrl() ?? GITLAB_BASE_URL,
-            ),
-          );
-        }
 
         // Report success — skip if handler already timed out (late completion
         // must not overwrite the timeout error already sent to HealthMonitor)

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -274,7 +274,6 @@ async function tryManageContextFastPath(
 // Cognitive complexity is elevated but justified: bootstrapState mutations, error
 // classification, HealthMonitor reporting, and derived-state computation are tightly
 // coupled. Further extraction would add indirection without reducing conceptual complexity.
-// eslint-disable-next-line sonarjs/cognitive-complexity
 async function ensureBootstrapped(
   ctx: BootstrapContext,
 ): Promise<{ content: Array<{ type: string; text: string }>; isError: true } | undefined> {

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -643,6 +643,12 @@ export async function setupHandlers(server: Server): Promise<void> {
     // specific instance (contextless calls occur during health checks / non-OAuth
     // transport; persisting the fallback would reset multi-tenant tool filtering).
     // In static-token mode always track the active instance URL.
+    //
+    // NOTE: manage_context/switch_profile (OAuth) and switch_preset (static) do not
+    // need a post-dispatch re-pin here. For switch_profile, the OAuth context URL is
+    // per-request from the token — the next call will carry the new profile's URL and
+    // update the session naturally. For switch_preset, the instance URL does not change
+    // (presets change tool filtering, not the GitLab host).
     const callSessionId = extra?.sessionId;
     if (callSessionId && (!oauthEnabled || oauthContextUrl !== undefined)) {
       const { getSessionManager: getSessionMgrForCall } = await import('./session-manager');

--- a/src/session-manager.ts
+++ b/src/session-manager.ts
@@ -59,8 +59,8 @@ export class SessionManager {
    * Handlers are registered identically on each instance.
    *
    * @param instanceUrl - GitLab instance URL for this session. Defaults to GITLAB_BASE_URL.
-   *   In OAuth mode, this is updated on the first tool call when the token context resolves
-   *   the actual instance URL. In static-token mode, updated when switch_instance is called.
+   *   Updated on each tool call: in OAuth mode when the token context resolves the actual
+   *   instance URL; in static-token mode when ConnectionManager reflects an instance change.
    */
   async createSession(
     sessionId: string,
@@ -120,8 +120,8 @@ export class SessionManager {
   /**
    * Update the GitLab instance URL for an active session.
    * Called by the tool handler when the effective instance URL is resolved:
-   * - OAuth mode: updated on the first tool call when the token context provides the URL
-   * - Static-token mode: updated when switch_instance changes the active instance
+   * - OAuth mode: updated on each tool call when the token context provides the URL
+   * - Static-token mode: updated on each tool call from ConnectionManager's active instance
    */
   setSessionInstanceUrl(sessionId: string, url: string): void {
     const normalizedUrl = normalizeInstanceUrl(url);

--- a/src/session-manager.ts
+++ b/src/session-manager.ts
@@ -129,6 +129,16 @@ export class SessionManager {
     if (session && session.instanceUrl !== normalizedUrl) {
       session.instanceUrl = normalizedUrl;
       logDebug('Session instance URL updated', { sessionId, instanceUrl: normalizedUrl });
+      // Notify the session so the client re-fetches the tool list for the new instance.
+      void session.server
+        .notification({ method: 'notifications/tools/list_changed' })
+        .catch((error: unknown) => {
+          logDebug('Failed to notify session of tool list change after instance URL update', {
+            sessionId,
+            instanceUrl: normalizedUrl,
+            err: error,
+          });
+        });
     }
   }
 

--- a/src/session-manager.ts
+++ b/src/session-manager.ts
@@ -1,6 +1,6 @@
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
-import { packageName, packageVersion } from './config';
+import { packageName, packageVersion, GITLAB_BASE_URL } from './config';
 import { setupHandlers } from './handlers';
 import { setDetectedSchemaMode } from './utils/schema-utils';
 import { logInfo, logWarn, logError, logDebug } from './logger';
@@ -16,6 +16,8 @@ interface ManagedSession {
   sessionId: string;
   createdAt: number;
   lastActivityAt: number;
+  /** GitLab instance URL this session is targeting. Defaults to GITLAB_BASE_URL. */
+  instanceUrl: string;
 }
 
 /**
@@ -54,8 +56,16 @@ export class SessionManager {
   /**
    * Create a new per-session Server instance and connect it to the given transport.
    * Handlers are registered identically on each instance.
+   *
+   * @param instanceUrl - GitLab instance URL for this session. Defaults to GITLAB_BASE_URL.
+   *   In OAuth mode, this is updated on the first tool call when the token context resolves
+   *   the actual instance URL. In static-token mode, updated when switch_instance is called.
    */
-  async createSession(sessionId: string, transport: Transport): Promise<Server> {
+  async createSession(
+    sessionId: string,
+    transport: Transport,
+    instanceUrl?: string,
+  ): Promise<Server> {
     // Guard against duplicate session IDs — close existing before allocating new resources
     if (this.sessions.has(sessionId)) {
       logWarn('Duplicate sessionId detected — closing existing session', { sessionId });
@@ -88,6 +98,7 @@ export class SessionManager {
       sessionId,
       createdAt: now,
       lastActivityAt: now,
+      instanceUrl: instanceUrl ?? GITLAB_BASE_URL,
     });
 
     logInfo('Session created', { sessionId, activeSessions: this.sessions.size });
@@ -103,6 +114,40 @@ export class SessionManager {
     if (session) {
       session.lastActivityAt = Date.now();
     }
+  }
+
+  /**
+   * Update the GitLab instance URL for an active session.
+   * Called by the tool handler when the effective instance URL is resolved:
+   * - OAuth mode: updated on the first tool call when the token context provides the URL
+   * - Static-token mode: updated when switch_instance changes the active instance
+   */
+  setSessionInstanceUrl(sessionId: string, url: string): void {
+    const session = this.sessions.get(sessionId);
+    if (session && session.instanceUrl !== url) {
+      session.instanceUrl = url;
+      logDebug('Session instance URL updated', { sessionId, instanceUrl: url });
+    }
+  }
+
+  /**
+   * Get the GitLab instance URL associated with a session.
+   * Returns undefined if the session does not exist.
+   */
+  getSessionInstanceUrl(sessionId: string): string | undefined {
+    return this.sessions.get(sessionId)?.instanceUrl;
+  }
+
+  /**
+   * Return a map of instance URL → session count across all active sessions.
+   * Used by the dashboard to show per-instance session distribution.
+   */
+  getSessionsByInstance(): Map<string, number> {
+    const counts = new Map<string, number>();
+    for (const session of this.sessions.values()) {
+      counts.set(session.instanceUrl, (counts.get(session.instanceUrl) ?? 0) + 1);
+    }
+    return counts;
   }
 
   /**
@@ -124,12 +169,21 @@ export class SessionManager {
   }
 
   /**
-   * Send tools/list_changed notification to ALL active sessions.
+   * Send tools/list_changed notification to active sessions.
+   *
+   * @param instanceUrl - When provided, only sessions targeting this instance are notified.
+   *   When omitted, all sessions are notified. Use the filtered form when a state change
+   *   affects only one instance (e.g. HealthMonitor state transition) to avoid spurious
+   *   re-fetches in sessions targeting unrelated instances.
    */
-  async broadcastToolsListChanged(): Promise<void> {
+  async broadcastToolsListChanged(instanceUrl?: string): Promise<void> {
     const promises: Promise<void>[] = [];
 
     for (const [sessionId, session] of this.sessions) {
+      // Skip sessions targeting a different instance when a filter is active
+      if (instanceUrl !== undefined && session.instanceUrl !== instanceUrl) {
+        continue;
+      }
       promises.push(
         session.server
           .notification({ method: 'notifications/tools/list_changed' })
@@ -144,7 +198,11 @@ export class SessionManager {
 
     await Promise.allSettled(promises);
 
-    logInfo('Broadcast tools/list_changed to all sessions', { sessionCount: this.sessions.size });
+    logInfo('Broadcast tools/list_changed', {
+      sessionCount: this.sessions.size,
+      notifiedCount: promises.length,
+      instanceUrl: instanceUrl ?? 'all',
+    });
   }
 
   /**

--- a/src/session-manager.ts
+++ b/src/session-manager.ts
@@ -179,11 +179,16 @@ export class SessionManager {
    *   re-fetches in sessions targeting unrelated instances.
    */
   async broadcastToolsListChanged(instanceUrl?: string): Promise<void> {
+    // Normalize before comparing — session.instanceUrl is always stored normalized,
+    // so the filter must also be normalized to ensure consistent matching.
+    const normalizedFilter =
+      instanceUrl !== undefined ? normalizeInstanceUrl(instanceUrl) : undefined;
+
     const promises: Promise<void>[] = [];
 
     for (const [sessionId, session] of this.sessions) {
       // Skip sessions targeting a different instance when a filter is active
-      if (instanceUrl !== undefined && session.instanceUrl !== instanceUrl) {
+      if (normalizedFilter !== undefined && session.instanceUrl !== normalizedFilter) {
         continue;
       }
       promises.push(
@@ -203,7 +208,7 @@ export class SessionManager {
     logInfo('Broadcast tools/list_changed', {
       sessionCount: this.sessions.size,
       notifiedCount: promises.length,
-      instanceUrl: instanceUrl ?? 'all',
+      instanceUrl: normalizedFilter ?? 'all',
     });
   }
 

--- a/src/session-manager.ts
+++ b/src/session-manager.ts
@@ -4,6 +4,7 @@ import { packageName, packageVersion, GITLAB_BASE_URL } from './config';
 import { setupHandlers } from './handlers';
 import { setDetectedSchemaMode } from './utils/schema-utils';
 import { logInfo, logWarn, logError, logDebug } from './logger';
+import { normalizeInstanceUrl } from './utils/url';
 
 /** Default session idle timeout: 30 minutes */
 const DEFAULT_SESSION_TIMEOUT_MS = 30 * 60 * 1000;
@@ -98,7 +99,7 @@ export class SessionManager {
       sessionId,
       createdAt: now,
       lastActivityAt: now,
-      instanceUrl: instanceUrl ?? GITLAB_BASE_URL,
+      instanceUrl: normalizeInstanceUrl(instanceUrl ?? GITLAB_BASE_URL),
     });
 
     logInfo('Session created', { sessionId, activeSessions: this.sessions.size });
@@ -123,10 +124,11 @@ export class SessionManager {
    * - Static-token mode: updated when switch_instance changes the active instance
    */
   setSessionInstanceUrl(sessionId: string, url: string): void {
+    const normalizedUrl = normalizeInstanceUrl(url);
     const session = this.sessions.get(sessionId);
-    if (session && session.instanceUrl !== url) {
-      session.instanceUrl = url;
-      logDebug('Session instance URL updated', { sessionId, instanceUrl: url });
+    if (session && session.instanceUrl !== normalizedUrl) {
+      session.instanceUrl = normalizedUrl;
+      logDebug('Session instance URL updated', { sessionId, instanceUrl: normalizedUrl });
     }
   }
 

--- a/tests/unit/dashboard/metrics.test.ts
+++ b/tests/unit/dashboard/metrics.test.ts
@@ -27,6 +27,7 @@ jest.mock('../../../src/services/InstanceRegistry', () => ({
 jest.mock('../../../src/session-manager', () => ({
   getSessionManager: jest.fn(() => ({
     activeSessionCount: 0,
+    getSessionsByInstance: jest.fn(() => new Map<string, number>()),
   })),
 }));
 
@@ -394,6 +395,7 @@ describe('Dashboard Metrics', () => {
       jest.doMock('../../../src/session-manager', () => ({
         getSessionManager: jest.fn(() => ({
           activeSessionCount: 0,
+          getSessionsByInstance: jest.fn(() => new Map<string, number>()),
         })),
       }));
       jest.doMock('../../../src/registry-manager', () => ({
@@ -433,6 +435,7 @@ describe('Dashboard Metrics', () => {
       jest.doMock('../../../src/session-manager', () => ({
         getSessionManager: jest.fn(() => ({
           activeSessionCount: 0,
+          getSessionsByInstance: jest.fn(() => new Map<string, number>()),
         })),
       }));
       jest.doMock('../../../src/registry-manager', () => ({
@@ -476,6 +479,7 @@ describe('Dashboard Metrics', () => {
     it('should include active session count', () => {
       (getSessionManager as jest.Mock).mockReturnValueOnce({
         activeSessionCount: 5,
+        getSessionsByInstance: jest.fn(() => new Map<string, number>()),
       });
 
       const metrics = collectMetrics();

--- a/tests/unit/dashboard/metrics.test.ts
+++ b/tests/unit/dashboard/metrics.test.ts
@@ -476,14 +476,26 @@ describe('Dashboard Metrics', () => {
       expect(metrics.config.sourceDetails).toBe('/etc/gitlab-mcp/config.yaml');
     });
 
-    it('should include active session count', () => {
+    it('should include active session count and per-instance breakdown (#398)', () => {
+      // Verifies that collectMetrics() correctly wires getSessionsByInstance()
+      // into sessions.byInstance (regression: previously always returned {})
       (getSessionManager as jest.Mock).mockReturnValueOnce({
         activeSessionCount: 5,
-        getSessionsByInstance: jest.fn(() => new Map<string, number>()),
+        getSessionsByInstance: jest.fn(
+          () =>
+            new Map<string, number>([
+              ['https://gitlab.com', 3],
+              ['https://self-managed.example.com', 2],
+            ]),
+        ),
       });
 
       const metrics = collectMetrics();
       expect(metrics.sessions.total).toBe(5);
+      expect(metrics.sessions.byInstance).toEqual({
+        'https://gitlab.com': 3,
+        'https://self-managed.example.com': 2,
+      });
     });
 
     it('should convert InstanceSummary to InstanceStatus correctly', () => {

--- a/tests/unit/handlers.test.ts
+++ b/tests/unit/handlers.test.ts
@@ -119,6 +119,7 @@ jest.mock('../../src/logging/index', () => ({
 const mockSessionManager = {
   getSessionInstanceUrl: jest.fn().mockReturnValue('https://gitlab.example.com'),
   setSessionInstanceUrl: jest.fn(),
+  broadcastToolsListChanged: jest.fn().mockResolvedValue(undefined),
 };
 
 jest.mock('../../src/session-manager', () => ({
@@ -909,6 +910,59 @@ describe('handlers', () => {
       mockHealthMonitor.getState.mockReturnValue('healthy');
     });
 
+    it('should fall through to bootstrap when manage_context handler not yet cached (tryManageContextFastPath null path)', async () => {
+      // Line 246: tryManageContextFastPath returns null when hasToolHandler=false for manage_context.
+      // This happens when the instance is unreachable but the registry cache is not yet populated.
+      // The handler falls through to ensureBootstrapped, which returns CONNECTION_FAILED.
+      mockHealthMonitor.isInstanceReachable.mockReturnValue(false);
+      mockHealthMonitor.getState.mockReturnValue('disconnected');
+      mockConnectionManager.isConnected.mockReturnValue(false);
+      mockConnectionManager.initialize.mockRejectedValueOnce(new Error('ECONNREFUSED'));
+      // hasToolHandler returns false — registry not yet cached for this URL
+      mockRegistryManager.hasToolHandler.mockReturnValue(false);
+
+      const result = await callToolHandler({
+        params: {
+          name: 'manage_context',
+          arguments: { action: 'whoami' },
+        },
+      });
+
+      // Falls through to bootstrap → bootstrap fails → CONNECTION_FAILED
+      expect(result.isError).toBe(true);
+      const parsed = JSON.parse(result.content![0].text);
+      expect(parsed.error_code).toBe('CONNECTION_FAILED');
+
+      // Restore
+      mockConnectionManager.isConnected.mockReturnValue(true);
+      mockConnectionManager.initialize.mockResolvedValue(undefined);
+      mockHealthMonitor.isInstanceReachable.mockReturnValue(true);
+      mockHealthMonitor.getState.mockReturnValue('healthy');
+      mockRegistryManager.hasToolHandler.mockReturnValue(true);
+    });
+
+    it('should rethrow when refreshCache throws after bootstrapState.complete=true (line 357)', async () => {
+      // Line 357: when bootstrapState.complete is already true but refreshCache throws,
+      // ensureBootstrapped rethrows the error (not CONNECTION_FAILED). The outer handler
+      // catches it and returns a generic error response.
+      mockRegistryManager.refreshCache.mockImplementationOnce(() => {
+        throw new Error('Cache rebuild failed');
+      });
+
+      const result = await callToolHandler({
+        params: {
+          name: 'test_tool',
+          arguments: {},
+        },
+      });
+
+      // Rethrown error becomes a generic tool error (not CONNECTION_FAILED)
+      expect(result.isError).toBe(true);
+      const parsed = JSON.parse(result.content![0].text);
+      expect(parsed.error_code).toBeUndefined();
+      expect(parsed.error).toContain('Cache rebuild failed');
+    });
+
     it('should route reachable manage_context through normal bootstrap and report health', async () => {
       // When instance IS reachable, manage_context goes through full bootstrap
       // (unlike the disconnected fast-path above)
@@ -968,6 +1022,29 @@ describe('handlers', () => {
 
       // refreshCache should have been called exactly once with the instance URL
       expect(mockRegistryManager.refreshCache).toHaveBeenCalledTimes(1);
+      expect(mockRegistryManager.refreshCache).toHaveBeenCalledWith('https://gitlab.example.com');
+    });
+
+    it('should log warning when broadcastToolsListChanged rejects in state change callback (line 424)', async () => {
+      // Line 424: .catch() on broadcastToolsListChangedForStateChange when broadcast fails.
+      // The catch handler logs a warning but does not rethrow (fire-and-forget pattern).
+      const stateChangeCallback = mockHealthMonitor.onStateChange.mock.calls[0]?.[0];
+      expect(stateChangeCallback).toBeDefined();
+
+      mockSessionManager.broadcastToolsListChanged.mockRejectedValueOnce(
+        new Error('Broadcast failed'),
+      );
+      mockRegistryManager.refreshCache.mockClear();
+
+      if (stateChangeCallback) {
+        stateChangeCallback('https://gitlab.example.com', 'disconnected', 'healthy');
+        // Flush microtasks through the fire-and-forget catch path
+        await new Promise((resolve) => process.nextTick(resolve));
+        await new Promise((resolve) => process.nextTick(resolve));
+        await new Promise((resolve) => process.nextTick(resolve));
+      }
+
+      // Despite broadcast failure, refreshCache should still have been called
       expect(mockRegistryManager.refreshCache).toHaveBeenCalledWith('https://gitlab.example.com');
     });
 
@@ -1666,6 +1743,22 @@ describe('handlers', () => {
   });
 
   describe('setupHandlers - health monitor startup failure', () => {
+    it('should log warning and continue when refreshCache throws during initial setup (line 448)', async () => {
+      // Cover line 448: logWarn in catch block when initial refreshCache() call throws.
+      // setupHandlers must still succeed (handlers registered) despite cache failure.
+      resetHandlersState();
+      mockRegistryManager.refreshCache.mockImplementationOnce(() => {
+        throw new Error('Registry cache init failed');
+      });
+
+      await expect(setupHandlers(mockServer)).resolves.not.toThrow();
+      // Both handlers should still be registered despite cache failure
+      expect(mockServer.setRequestHandler).toHaveBeenCalledTimes(2);
+
+      // Restore
+      mockRegistryManager.refreshCache.mockReturnValue(undefined);
+    });
+
     it('should reset healthMonitorStartup promise on health monitor init failure', async () => {
       // Cover lines 222-223: healthMonitorStartup = null; throw error
       mockHealthMonitor.initialize.mockRejectedValueOnce(new Error('Health monitor init failed'));

--- a/tests/unit/handlers.test.ts
+++ b/tests/unit/handlers.test.ts
@@ -489,6 +489,29 @@ describe('handlers', () => {
       (oauth.getGitLabApiUrlFromContext as jest.Mock).mockReturnValue(null);
     });
 
+    it('should NOT update session instanceUrl when OAuth context URL is absent (#398)', async () => {
+      // Regression guard: contextless OAuth calls (health checks, non-OAuth transport)
+      // fall back to GITLAB_BASE_URL for routing — that fallback must NOT be written into
+      // SessionManager, which would silently overwrite a session already pinned to another
+      // instance and break multi-tenant tool catalog filtering on the next ListTools call.
+      const oauth = await import('../../src/oauth/index');
+      (oauth.isOAuthEnabled as jest.Mock).mockReturnValue(true);
+      // getGitLabApiUrlFromContext returns null — contextless / startup health check
+      (oauth.getGitLabApiUrlFromContext as jest.Mock).mockReturnValue(null);
+
+      await callToolHandler(
+        { params: { name: 'get_project', arguments: { id: 'proj-1' } } },
+        { sessionId: 'sess-pinned' },
+      );
+
+      // Session URL must NOT be updated (fallback GITLAB_BASE_URL must not overwrite pinned URL)
+      expect(mockSessionManager.setSessionInstanceUrl).not.toHaveBeenCalled();
+
+      // Restore defaults
+      (oauth.isOAuthEnabled as jest.Mock).mockReturnValue(false);
+      (oauth.getGitLabApiUrlFromContext as jest.Mock).mockReturnValue(null);
+    });
+
     it('should execute tool and return result', async () => {
       const mockRequest = {
         params: {
@@ -981,6 +1004,23 @@ describe('handlers', () => {
         expect(parsed.error_code).toBe('CONNECTION_FAILED');
       },
     );
+
+    it('should return error and NOT call reportSuccess when post-bootstrap executeTool returns undefined (TOCTOU)', async () => {
+      // Regression guard: hasToolHandler passes but executeTool returns undefined due to
+      // concurrent refreshCache swapping the cache. Must throw (converting to McpError)
+      // rather than serializing JSON.stringify(undefined) as a valid response.
+      // reportSuccess must NOT be called for a cache miss.
+      mockRegistryManager.hasToolHandler.mockReturnValue(true);
+      mockRegistryManager.executeTool.mockResolvedValueOnce(undefined);
+
+      const result = await callToolHandler({
+        params: { name: 'test_tool', arguments: {} },
+      });
+
+      // Should return an error response (McpError), not reportSuccess
+      expect(result.isError).toBe(true);
+      expect(mockHealthMonitor.reportSuccess).not.toHaveBeenCalled();
+    });
 
     it('should log warning and continue when refreshCache throws after bootstrap (cache isolated try/catch)', async () => {
       // refreshCache is wrapped in its own try/catch — a failure must NOT abort the tool call.

--- a/tests/unit/handlers.test.ts
+++ b/tests/unit/handlers.test.ts
@@ -90,7 +90,7 @@ jest.mock('../../src/oauth/index', () => ({
   isOAuthEnabled: jest.fn().mockReturnValue(false),
   isAuthenticationConfigured: jest.fn().mockReturnValue(true),
   getTokenContext: jest.fn().mockReturnValue(null),
-  getGitLabApiUrlFromContext: jest.fn().mockReturnValue(null),
+  getGitLabApiUrlFromContext: jest.fn().mockReturnValue(undefined),
 }));
 
 // Mock logging/index so connection-tracker paths (lines 712-715) can be exercised
@@ -485,7 +485,7 @@ describe('handlers', () => {
 
       // Restore defaults so subsequent tests are unaffected
       (oauth.isOAuthEnabled as jest.Mock).mockReturnValue(false);
-      (oauth.getGitLabApiUrlFromContext as jest.Mock).mockReturnValue(null);
+      (oauth.getGitLabApiUrlFromContext as jest.Mock).mockReturnValue(undefined);
     });
 
     it('should NOT update session instanceUrl when OAuth context URL is absent (#398)', async () => {
@@ -496,7 +496,7 @@ describe('handlers', () => {
       const oauth = await import('../../src/oauth/index');
       (oauth.isOAuthEnabled as jest.Mock).mockReturnValue(true);
       // getGitLabApiUrlFromContext returns null — contextless / startup health check
-      (oauth.getGitLabApiUrlFromContext as jest.Mock).mockReturnValue(null);
+      (oauth.getGitLabApiUrlFromContext as jest.Mock).mockReturnValue(undefined);
 
       await callToolHandler(
         { params: { name: 'get_project', arguments: { id: 'proj-1' } } },
@@ -508,7 +508,7 @@ describe('handlers', () => {
 
       // Restore defaults
       (oauth.isOAuthEnabled as jest.Mock).mockReturnValue(false);
-      (oauth.getGitLabApiUrlFromContext as jest.Mock).mockReturnValue(null);
+      (oauth.getGitLabApiUrlFromContext as jest.Mock).mockReturnValue(undefined);
     });
 
     it('should execute tool and return result', async () => {
@@ -1135,6 +1135,10 @@ describe('handlers', () => {
 
       // Despite broadcast failure, refreshCache should still have been called
       expect(mockRegistryManager.refreshCache).toHaveBeenCalledWith('https://gitlab.example.com');
+      // Broadcast must be scoped to the affected instance — not a global broadcast
+      expect(mockSessionManager.broadcastToolsListChanged).toHaveBeenCalledWith(
+        'https://gitlab.example.com',
+      );
       // Warning must be logged so the failure is observable without crashing
       expect(logWarn).toHaveBeenCalledWith(
         'Failed to broadcast tools/list_changed after state change',
@@ -1914,7 +1918,7 @@ describe('handlers', () => {
       (oauth.isOAuthEnabled as jest.Mock).mockReturnValue(false);
       (oauth.isAuthenticationConfigured as jest.Mock).mockReturnValue(true);
       (oauth.getTokenContext as jest.Mock).mockReturnValue(null);
-      (oauth.getGitLabApiUrlFromContext as jest.Mock).mockReturnValue(null);
+      (oauth.getGitLabApiUrlFromContext as jest.Mock).mockReturnValue(undefined);
     });
 
     it('should call ensureIntrospected in OAuth mode (line 493)', async () => {
@@ -1974,7 +1978,7 @@ describe('handlers', () => {
 
       // Restore
       mockConnectionManager.isConnected.mockReturnValue(true);
-      (oauth.getGitLabApiUrlFromContext as jest.Mock).mockReturnValue(null);
+      (oauth.getGitLabApiUrlFromContext as jest.Mock).mockReturnValue(undefined);
     });
 
     it('should return CONNECTION_FAILED when introspection fails before bootstrap completes', async () => {
@@ -2026,7 +2030,7 @@ describe('handlers', () => {
       expect(mockHealthMonitor.reportError).toHaveBeenCalledWith(oauthUrl, expect.any(Error));
 
       // Restore
-      (oauth.getGitLabApiUrlFromContext as jest.Mock).mockReturnValue(null);
+      (oauth.getGitLabApiUrlFromContext as jest.Mock).mockReturnValue(undefined);
     });
 
     it('should short-circuit with CONNECTION_FAILED for OAuth URL when unreachable', async () => {
@@ -2051,7 +2055,7 @@ describe('handlers', () => {
       // Restore
       mockHealthMonitor.isInstanceReachable.mockReturnValue(true);
       mockHealthMonitor.getState.mockReturnValue('healthy');
-      (oauth.getGitLabApiUrlFromContext as jest.Mock).mockReturnValue(null);
+      (oauth.getGitLabApiUrlFromContext as jest.Mock).mockReturnValue(undefined);
     });
   });
 
@@ -2235,7 +2239,7 @@ describe('handlers', () => {
       mockConnectionManager.isConnected.mockReturnValue(true);
       mockConnectionManager.initialize.mockResolvedValue(undefined);
       (oauth.isOAuthEnabled as jest.Mock).mockReturnValue(false);
-      (oauth.getGitLabApiUrlFromContext as jest.Mock).mockReturnValue(null);
+      (oauth.getGitLabApiUrlFromContext as jest.Mock).mockReturnValue(undefined);
     }, 5000);
 
     it('should not report success/error after deferred init resolves post-timeout', async () => {

--- a/tests/unit/handlers.test.ts
+++ b/tests/unit/handlers.test.ts
@@ -412,14 +412,13 @@ describe('handlers', () => {
         );
       });
 
-      it('should fall back to GITLAB_BASE_URL when sessionId is absent', async () => {
-        // No extra.sessionId provided (e.g. stdio transport before session tracking)
+      it('should pass undefined to getAllToolDefinitions when sessionId is absent (registry resolves via OAuth context chain)', async () => {
+        // No extra.sessionId (e.g. stdio transport) — pass undefined so registry resolves
+        // via OAuth context URL → current URL → GITLAB_BASE_URL chain (#398).
         await listToolsHandler({ method: 'tools/list' });
 
         expect(mockSessionManager.getSessionInstanceUrl).not.toHaveBeenCalled();
-        expect(mockRegistryManager.getAllToolDefinitions).toHaveBeenCalledWith(
-          'https://gitlab.example.com',
-        );
+        expect(mockRegistryManager.getAllToolDefinitions).toHaveBeenCalledWith(undefined);
       });
 
       it('should pass undefined to getAllToolDefinitions when session has no tracked URL (registry resolves via OAuth context chain)', async () => {

--- a/tests/unit/handlers.test.ts
+++ b/tests/unit/handlers.test.ts
@@ -495,7 +495,7 @@ describe('handlers', () => {
       // instance and break multi-tenant tool catalog filtering on the next ListTools call.
       const oauth = await import('../../src/oauth/index');
       (oauth.isOAuthEnabled as jest.Mock).mockReturnValue(true);
-      // getGitLabApiUrlFromContext returns null — contextless / startup health check
+      // getGitLabApiUrlFromContext returns undefined — contextless / startup health check
       (oauth.getGitLabApiUrlFromContext as jest.Mock).mockReturnValue(undefined);
 
       await callToolHandler(

--- a/tests/unit/handlers.test.ts
+++ b/tests/unit/handlers.test.ts
@@ -1853,7 +1853,7 @@ describe('handlers', () => {
         throw new Error('Registry cache init failed');
       });
 
-      await expect(setupHandlers(mockServer)).resolves.not.toThrow();
+      await setupHandlers(mockServer);
       // Both handlers should still be registered despite cache failure
       expect(mockServer.setRequestHandler).toHaveBeenCalledTimes(2);
       // Cache failure is logged as a warning
@@ -1876,7 +1876,7 @@ describe('handlers', () => {
       // After failure, healthMonitorStartup is reset to null so next call retries
       // A second call should attempt initialization again
       mockHealthMonitor.initialize.mockResolvedValue(undefined);
-      await expect(setupHandlers(mockServer)).resolves.not.toThrow();
+      await setupHandlers(mockServer);
       expect(mockHealthMonitor.initialize).toHaveBeenCalledTimes(2);
       // State-change listener must not be double-registered after retry
       expect(mockHealthMonitor.onStateChange).toHaveBeenCalledTimes(1);

--- a/tests/unit/handlers.test.ts
+++ b/tests/unit/handlers.test.ts
@@ -453,6 +453,40 @@ describe('handlers', () => {
       expect(mockSessionManager.setSessionInstanceUrl).not.toHaveBeenCalled();
     });
 
+    it('should update session instanceUrl to post-switch URL after manage_context switch_instance (#398)', async () => {
+      // Regression: requestInstanceUrl is captured BEFORE tool execution, so a
+      // pre-dispatch-only update records the OLD URL for switch_instance. After the
+      // tool runs, ConnectionManager.getCurrentInstanceUrl() reflects the new instance;
+      // the handler must re-read it and update the session so an immediate tools/list
+      // request serves the correct catalog.
+      mockConnectionManager.getCurrentInstanceUrl.mockReturnValue('https://old.gitlab.com');
+
+      // Simulate switch_instance: during tool execution the ConnectionManager is updated
+      mockRegistryManager.executeTool.mockImplementationOnce(async () => {
+        mockConnectionManager.getCurrentInstanceUrl.mockReturnValue('https://new.gitlab.com');
+        return { success: true, current: 'https://new.gitlab.com' };
+      });
+
+      await callToolHandler(
+        {
+          params: {
+            name: 'manage_context',
+            arguments: { action: 'switch_instance', instance_url: 'https://new.gitlab.com' },
+          },
+        },
+        { sessionId: 'sess-switch' },
+      );
+
+      // The session must end up on the post-switch URL, not the pre-dispatch one
+      expect(mockSessionManager.setSessionInstanceUrl).toHaveBeenLastCalledWith(
+        'sess-switch',
+        'https://new.gitlab.com',
+      );
+
+      // Restore
+      mockConnectionManager.getCurrentInstanceUrl.mockReturnValue('https://gitlab.example.com');
+    });
+
     it('should execute tool and return result', async () => {
       const mockRequest = {
         params: {

--- a/tests/unit/handlers.test.ts
+++ b/tests/unit/handlers.test.ts
@@ -945,68 +945,42 @@ describe('handlers', () => {
       mockHealthMonitor.getState.mockReturnValue('healthy');
     });
 
-    it('should fall through to bootstrap when manage_context handler not yet cached (tryManageContextFastPath null path)', async () => {
-      // Line 246: tryManageContextFastPath returns null when hasToolHandler=false for manage_context.
-      // This happens when the instance is unreachable but the registry cache is not yet populated.
-      // The handler falls through to ensureBootstrapped, which returns CONNECTION_FAILED.
-      mockHealthMonitor.isInstanceReachable.mockReturnValue(false);
-      mockHealthMonitor.getState.mockReturnValue('disconnected');
-      mockConnectionManager.isConnected.mockReturnValue(false);
-      mockConnectionManager.initialize.mockRejectedValueOnce(new Error('ECONNREFUSED'));
-      // hasToolHandler returns false — registry not yet cached for this URL
-      mockRegistryManager.hasToolHandler.mockReturnValue(false);
+    it.each([
+      {
+        label: 'handler not yet cached (hasToolHandler=false)',
+        hasToolHandler: false,
+        // executeTool not called — no undefined to guard against here
+        stubExecuteUndefined: false,
+      },
+      {
+        label: 'TOCTOU: executeTool returns undefined after hasToolHandler=true',
+        hasToolHandler: true,
+        // Regression guard: fast-path must return null, not {text:"undefined"}
+        stubExecuteUndefined: true,
+      },
+    ])(
+      'should fall through to bootstrap when tryManageContextFastPath returns null — $label',
+      async ({ hasToolHandler, stubExecuteUndefined }) => {
+        // Instance unreachable → tryManageContextFastPath is entered for manage_context
+        mockHealthMonitor.isInstanceReachable.mockReturnValue(false);
+        mockHealthMonitor.getState.mockReturnValue('disconnected');
+        mockConnectionManager.isConnected.mockReturnValue(false);
+        mockConnectionManager.initialize.mockRejectedValueOnce(new Error('ECONNREFUSED'));
+        mockRegistryManager.hasToolHandler.mockReturnValue(hasToolHandler);
+        if (stubExecuteUndefined) {
+          mockRegistryManager.executeTool.mockResolvedValueOnce(undefined);
+        }
 
-      const result = await callToolHandler({
-        params: {
-          name: 'manage_context',
-          arguments: { action: 'whoami' },
-        },
-      });
+        const result = await callToolHandler({
+          params: { name: 'manage_context', arguments: { action: 'whoami' } },
+        });
 
-      // Falls through to bootstrap → bootstrap fails → CONNECTION_FAILED
-      expect(result.isError).toBe(true);
-      const parsed = JSON.parse(result.content![0].text);
-      expect(parsed.error_code).toBe('CONNECTION_FAILED');
-
-      // Restore
-      mockConnectionManager.isConnected.mockReturnValue(true);
-      mockConnectionManager.initialize.mockResolvedValue(undefined);
-      mockHealthMonitor.isInstanceReachable.mockReturnValue(true);
-      mockHealthMonitor.getState.mockReturnValue('healthy');
-      mockRegistryManager.hasToolHandler.mockReturnValue(true);
-    });
-
-    it('should fall through to bootstrap when executeTool returns undefined (TOCTOU cache miss)', async () => {
-      // Regression guard for TOCTOU gap: hasToolHandler returns true but a concurrent
-      // refreshCache swaps the cache before executeTool runs → executeTool returns undefined.
-      // The fast-path must return null (fall through to bootstrap) instead of wrapping
-      // undefined as a successful {text: "undefined"} response.
-      mockHealthMonitor.isInstanceReachable.mockReturnValue(false);
-      mockHealthMonitor.getState.mockReturnValue('disconnected');
-      mockConnectionManager.isConnected.mockReturnValue(false);
-      mockConnectionManager.initialize.mockRejectedValueOnce(new Error('ECONNREFUSED'));
-      // hasToolHandler true but executeTool returns undefined (TOCTOU: cache was replaced)
-      mockRegistryManager.hasToolHandler.mockReturnValue(true);
-      mockRegistryManager.executeTool.mockResolvedValueOnce(undefined);
-
-      const result = await callToolHandler({
-        params: {
-          name: 'manage_context',
-          arguments: { action: 'whoami' },
-        },
-      });
-
-      // Must fall through to bootstrap → CONNECTION_FAILED (not a {text: "undefined"} response)
-      expect(result.isError).toBe(true);
-      const parsed = JSON.parse(result.content![0].text);
-      expect(parsed.error_code).toBe('CONNECTION_FAILED');
-
-      // Restore
-      mockConnectionManager.isConnected.mockReturnValue(true);
-      mockConnectionManager.initialize.mockResolvedValue(undefined);
-      mockHealthMonitor.isInstanceReachable.mockReturnValue(true);
-      mockHealthMonitor.getState.mockReturnValue('healthy');
-    });
+        // Fast-path returns null → falls through to ensureBootstrapped → CONNECTION_FAILED
+        expect(result.isError).toBe(true);
+        const parsed = JSON.parse(result.content![0].text);
+        expect(parsed.error_code).toBe('CONNECTION_FAILED');
+      },
+    );
 
     it('should log warning and continue when refreshCache throws after bootstrap (cache isolated try/catch)', async () => {
       // refreshCache is wrapped in its own try/catch — a failure must NOT abort the tool call.

--- a/tests/unit/handlers.test.ts
+++ b/tests/unit/handlers.test.ts
@@ -467,6 +467,28 @@ describe('handlers', () => {
       expect(mockSessionManager.setSessionInstanceUrl).not.toHaveBeenCalled();
     });
 
+    it('should persist the OAuth context URL when sessionId is present (#398)', async () => {
+      // Verifies OAuth path: when isOAuthEnabled=true and getGitLabApiUrlFromContext returns
+      // an instance URL, setSessionInstanceUrl is called with the OAuth URL (not GITLAB_BASE_URL).
+      // Regression guard: a fallback to GITLAB_BASE_URL in OAuth mode would silently break
+      // multi-tenant tool catalog filtering.
+      const oauth = await import('../../src/oauth/index');
+      const oauthUrl = 'https://oauth-instance.example.com';
+      (oauth.isOAuthEnabled as jest.Mock).mockReturnValue(true);
+      (oauth.getGitLabApiUrlFromContext as jest.Mock).mockReturnValue(oauthUrl);
+
+      await callToolHandler(
+        { params: { name: 'get_project', arguments: { id: 'proj-1' } } },
+        { sessionId: 'sess-oauth' },
+      );
+
+      expect(mockSessionManager.setSessionInstanceUrl).toHaveBeenCalledWith('sess-oauth', oauthUrl);
+
+      // Restore defaults so subsequent tests are unaffected
+      (oauth.isOAuthEnabled as jest.Mock).mockReturnValue(false);
+      (oauth.getGitLabApiUrlFromContext as jest.Mock).mockReturnValue(null);
+    });
+
     it('should execute tool and return result', async () => {
       const mockRequest = {
         params: {
@@ -952,6 +974,38 @@ describe('handlers', () => {
       mockHealthMonitor.isInstanceReachable.mockReturnValue(true);
       mockHealthMonitor.getState.mockReturnValue('healthy');
       mockRegistryManager.hasToolHandler.mockReturnValue(true);
+    });
+
+    it('should fall through to bootstrap when executeTool returns undefined (TOCTOU cache miss)', async () => {
+      // Regression guard for TOCTOU gap: hasToolHandler returns true but a concurrent
+      // refreshCache swaps the cache before executeTool runs → executeTool returns undefined.
+      // The fast-path must return null (fall through to bootstrap) instead of wrapping
+      // undefined as a successful {text: "undefined"} response.
+      mockHealthMonitor.isInstanceReachable.mockReturnValue(false);
+      mockHealthMonitor.getState.mockReturnValue('disconnected');
+      mockConnectionManager.isConnected.mockReturnValue(false);
+      mockConnectionManager.initialize.mockRejectedValueOnce(new Error('ECONNREFUSED'));
+      // hasToolHandler true but executeTool returns undefined (TOCTOU: cache was replaced)
+      mockRegistryManager.hasToolHandler.mockReturnValue(true);
+      mockRegistryManager.executeTool.mockResolvedValueOnce(undefined);
+
+      const result = await callToolHandler({
+        params: {
+          name: 'manage_context',
+          arguments: { action: 'whoami' },
+        },
+      });
+
+      // Must fall through to bootstrap → CONNECTION_FAILED (not a {text: "undefined"} response)
+      expect(result.isError).toBe(true);
+      const parsed = JSON.parse(result.content![0].text);
+      expect(parsed.error_code).toBe('CONNECTION_FAILED');
+
+      // Restore
+      mockConnectionManager.isConnected.mockReturnValue(true);
+      mockConnectionManager.initialize.mockResolvedValue(undefined);
+      mockHealthMonitor.isInstanceReachable.mockReturnValue(true);
+      mockHealthMonitor.getState.mockReturnValue('healthy');
     });
 
     it('should log warning and continue when refreshCache throws after bootstrap (cache isolated try/catch)', async () => {

--- a/tests/unit/handlers.test.ts
+++ b/tests/unit/handlers.test.ts
@@ -1092,6 +1092,27 @@ describe('handlers', () => {
       mockConnectionManager.initialize.mockResolvedValue(undefined);
     });
 
+    it('should handle non-Error thrown from initialize (coverage: catch block non-Error branches)', async () => {
+      // Simulates a non-standard rejection: string/object rather than Error instance.
+      // Exercises the ternary fallback paths in the catch block of ensureBootstrapped.
+      mockConnectionManager.isConnected.mockReturnValue(false);
+      mockConnectionManager.initialize.mockRejectedValue('string rejection');
+
+      const result = await callToolHandler({
+        params: { name: 'test_tool', arguments: {} },
+      });
+
+      expect(result.isError).toBe(true);
+      const parsed = JSON.parse((result.content as Array<{ text: string }>)[0].text);
+      expect(parsed.error_code).toBe('CONNECTION_FAILED');
+      // Non-Error: initError instanceof Error is false → reportError NOT called
+      expect(mockHealthMonitor.reportError).not.toHaveBeenCalled();
+
+      // Restore
+      mockConnectionManager.isConnected.mockReturnValue(true);
+      mockConnectionManager.initialize.mockResolvedValue(undefined);
+    });
+
     it('should invoke state change callback for tool list updates', async () => {
       // Capture the callback registered via onStateChange
       const stateChangeCallback = mockHealthMonitor.onStateChange.mock.calls[0]?.[0];
@@ -1183,6 +1204,23 @@ describe('handlers', () => {
 
       await callToolHandler(mockRequest);
 
+      expect(mockRegistryManager.executeTool).toHaveBeenCalledWith(
+        'test_tool',
+        {},
+        'https://gitlab.example.com',
+      );
+    });
+
+    it('should fall back to GITLAB_BASE_URL when getCurrentInstanceUrl returns null (non-OAuth mode)', async () => {
+      // Exercises the `?? GITLAB_BASE_URL` fallback in the non-OAuth URL resolution path.
+      await setupHandlers(mockServer);
+      callToolHandler = getRegisteredHandler(mockServer, CallToolRequestSchema);
+
+      mockConnectionManager.getCurrentInstanceUrl.mockReturnValueOnce(null);
+
+      await callToolHandler({ params: { name: 'test_tool', arguments: {} } });
+
+      // Tool should be invoked with the GITLAB_BASE_URL fallback
       expect(mockRegistryManager.executeTool).toHaveBeenCalledWith(
         'test_tool',
         {},
@@ -1472,6 +1510,62 @@ describe('handlers', () => {
       expect(parsed.tool).toBe('original_tool');
       expect(parsed.action).toBe('original_action');
       expect(parsed.http_status).toBe(418);
+    });
+  });
+
+  describe('ensureBootstrapped — LOG_FORMAT=verbose paths', () => {
+    // These tests temporarily switch LOG_FORMAT to 'verbose' to exercise the
+    // diagnostic logging branches inside ensureBootstrapped (lines 294, 322-326).
+    // The config module mock object is mutated per-describe and restored in afterAll.
+    let configMock: { LOG_FORMAT: string; HANDLER_TIMEOUT_MS: number; GITLAB_BASE_URL: string };
+
+    beforeAll(() => {
+      configMock = jest.requireMock('../../src/config');
+      configMock.LOG_FORMAT = 'verbose';
+    });
+
+    afterAll(() => {
+      configMock.LOG_FORMAT = 'condensed';
+    });
+
+    beforeEach(async () => {
+      jest.clearAllMocks();
+      await setupHandlers(mockServer);
+      callToolHandler = getRegisteredHandler(mockServer, CallToolRequestSchema);
+
+      // Default mocks needed by bootstrap + tool execution
+      mockConnectionManager.isConnected.mockReturnValue(false); // triggers line 294 log
+      mockConnectionManager.initialize.mockResolvedValue(undefined);
+      mockConnectionManager.getClient.mockReturnValue({});
+      mockConnectionManager.getInstanceInfo.mockReturnValue({
+        version: '16.0.0',
+        tier: 'ultimate',
+      });
+      mockRegistryManager.hasToolHandler.mockReturnValue(true);
+      mockRegistryManager.executeTool.mockResolvedValue({ result: 'ok' });
+      mockHealthMonitor.isInstanceReachable.mockReturnValue(true);
+      mockHealthMonitor.isAnyInstanceHealthy.mockReturnValue(true);
+      mockHealthMonitor.getState.mockReturnValue('healthy');
+    });
+
+    afterEach(() => {
+      mockConnectionManager.isConnected.mockReturnValue(true);
+    });
+
+    it('should log init message and connection-verified info when getInstanceInfo succeeds (lines 294, 323-324)', async () => {
+      // isConnected=false triggers the "Connection not initialized" verbose log (line 294).
+      // After bootstrap, getInstanceInfo succeeds → "Connection verified: ..." log (lines 323-324).
+      const result = await callToolHandler({ params: { name: 'test_tool', arguments: {} } });
+      expect(result.isError).toBeFalsy();
+    });
+
+    it('should log "instance info not yet available" when getInstanceInfo throws (lines 294, 326)', async () => {
+      // getInstanceInfo throws → catches inside the verbose block → logDebug at line 326.
+      mockConnectionManager.getInstanceInfo.mockImplementationOnce(() => {
+        throw new Error('Not yet available');
+      });
+      const result = await callToolHandler({ params: { name: 'test_tool', arguments: {} } });
+      expect(result.isError).toBeFalsy();
     });
   });
 

--- a/tests/unit/handlers.test.ts
+++ b/tests/unit/handlers.test.ts
@@ -954,13 +954,14 @@ describe('handlers', () => {
       mockRegistryManager.hasToolHandler.mockReturnValue(true);
     });
 
-    it('should rethrow when refreshCache throws after bootstrapState.complete=true (line 357)', async () => {
-      // Line 357: when bootstrapState.complete is already true but refreshCache throws,
-      // ensureBootstrapped rethrows the error (not CONNECTION_FAILED). The outer handler
-      // catches it and returns a generic error response.
+    it('should log warning and continue when refreshCache throws after bootstrap (cache isolated try/catch)', async () => {
+      // refreshCache is wrapped in its own try/catch — a failure must NOT abort the tool call.
+      // The comment in ensureBootstrapped says "If it fails, the tool call should still proceed".
+      const { logWarn } = await import('../../src/logger');
       mockRegistryManager.refreshCache.mockImplementationOnce(() => {
         throw new Error('Cache rebuild failed');
       });
+      mockRegistryManager.executeTool.mockResolvedValue({ result: 'ok' });
 
       const result = await callToolHandler({
         params: {
@@ -969,11 +970,18 @@ describe('handlers', () => {
         },
       });
 
-      // Rethrown error becomes a generic tool error (not CONNECTION_FAILED)
-      expect(result.isError).toBe(true);
+      // Tool call succeeds despite refreshCache throwing
+      expect(result.isError).toBeUndefined();
       const parsed = JSON.parse(result.content![0].text);
-      expect(parsed.error_code).toBeUndefined();
-      expect(parsed.error).toContain('Cache rebuild failed');
+      expect(parsed.result).toBe('ok');
+      // Cache failure is logged as a warning, not surfaced to the user
+      expect(logWarn).toHaveBeenCalledWith(
+        'Failed to refresh registry cache after bootstrap',
+        expect.objectContaining({
+          instanceUrl: 'https://gitlab.example.com',
+          err: expect.any(Error),
+        }),
+      );
     });
 
     it('should route reachable manage_context through normal bootstrap and report health', async () => {
@@ -1041,6 +1049,7 @@ describe('handlers', () => {
     it('should log warning when broadcastToolsListChanged rejects in state change callback (line 424)', async () => {
       // Line 424: .catch() on broadcastToolsListChangedForStateChange when broadcast fails.
       // The catch handler logs a warning but does not rethrow (fire-and-forget pattern).
+      const { logWarn } = await import('../../src/logger');
       const stateChangeCallback = mockHealthMonitor.onStateChange.mock.calls[0]?.[0];
       expect(stateChangeCallback).toBeDefined();
 
@@ -1059,6 +1068,14 @@ describe('handlers', () => {
 
       // Despite broadcast failure, refreshCache should still have been called
       expect(mockRegistryManager.refreshCache).toHaveBeenCalledWith('https://gitlab.example.com');
+      // Warning must be logged so the failure is observable without crashing
+      expect(logWarn).toHaveBeenCalledWith(
+        'Failed to broadcast tools/list_changed after state change',
+        expect.objectContaining({
+          instanceUrl: 'https://gitlab.example.com',
+          err: expect.any(Error),
+        }),
+      );
     });
 
     it('should handle CONNECTION_FAILED with missing action field', async () => {
@@ -1759,6 +1776,7 @@ describe('handlers', () => {
     it('should log warning and continue when refreshCache throws during initial setup (line 448)', async () => {
       // Cover line 448: logWarn in catch block when initial refreshCache() call throws.
       // setupHandlers must still succeed (handlers registered) despite cache failure.
+      const { logWarn } = await import('../../src/logger');
       resetHandlersState();
       mockRegistryManager.refreshCache.mockImplementationOnce(() => {
         throw new Error('Registry cache init failed');
@@ -1767,6 +1785,11 @@ describe('handlers', () => {
       await expect(setupHandlers(mockServer)).resolves.not.toThrow();
       // Both handlers should still be registered despite cache failure
       expect(mockServer.setRequestHandler).toHaveBeenCalledTimes(2);
+      // Cache failure is logged as a warning
+      expect(logWarn).toHaveBeenCalledWith(
+        'Failed to refresh registry cache during handler setup',
+        expect.objectContaining({ err: expect.any(Error) }),
+      );
 
       // Restore
       mockRegistryManager.refreshCache.mockReturnValue(undefined);

--- a/tests/unit/handlers.test.ts
+++ b/tests/unit/handlers.test.ts
@@ -453,40 +453,6 @@ describe('handlers', () => {
       expect(mockSessionManager.setSessionInstanceUrl).not.toHaveBeenCalled();
     });
 
-    it('should update session instanceUrl to post-switch URL after manage_context switch_instance (#398)', async () => {
-      // Regression: requestInstanceUrl is captured BEFORE tool execution, so a
-      // pre-dispatch-only update records the OLD URL for switch_instance. After the
-      // tool runs, ConnectionManager.getCurrentInstanceUrl() reflects the new instance;
-      // the handler must re-read it and update the session so an immediate tools/list
-      // request serves the correct catalog.
-      mockConnectionManager.getCurrentInstanceUrl.mockReturnValue('https://old.gitlab.com');
-
-      // Simulate switch_instance: during tool execution the ConnectionManager is updated
-      mockRegistryManager.executeTool.mockImplementationOnce(async () => {
-        mockConnectionManager.getCurrentInstanceUrl.mockReturnValue('https://new.gitlab.com');
-        return { success: true, current: 'https://new.gitlab.com' };
-      });
-
-      await callToolHandler(
-        {
-          params: {
-            name: 'manage_context',
-            arguments: { action: 'switch_instance', instance_url: 'https://new.gitlab.com' },
-          },
-        },
-        { sessionId: 'sess-switch' },
-      );
-
-      // The session must end up on the post-switch URL, not the pre-dispatch one
-      expect(mockSessionManager.setSessionInstanceUrl).toHaveBeenLastCalledWith(
-        'sess-switch',
-        'https://new.gitlab.com',
-      );
-
-      // Restore
-      mockConnectionManager.getCurrentInstanceUrl.mockReturnValue('https://gitlab.example.com');
-    });
-
     it('should execute tool and return result', async () => {
       const mockRequest = {
         params: {

--- a/tests/unit/handlers.test.ts
+++ b/tests/unit/handlers.test.ts
@@ -114,6 +114,19 @@ jest.mock('../../src/logging/index', () => ({
   getCurrentRequestId: jest.fn(() => mockGetCurrentRequestId()),
 }));
 
+// Mock SessionManager — needed by the ListToolsRequestSchema and CallToolRequestSchema handlers
+// for per-session instance URL tracking (#398).
+const mockSessionManager = {
+  getSessionInstanceUrl: jest.fn().mockReturnValue('https://gitlab.example.com'),
+  setSessionInstanceUrl: jest.fn(),
+};
+
+jest.mock('../../src/session-manager', () => ({
+  getSessionManager: jest.fn(() => mockSessionManager),
+  resetSessionManager: jest.fn(),
+  STDIO_SESSION_ID: 'stdio',
+}));
+
 /** Handler result type matching MCP SDK response shape */
 interface HandlerResult {
   content?: Array<{ type: string; text: string }>;
@@ -184,6 +197,10 @@ describe('handlers', () => {
     ]);
     mockRegistryManager.hasToolHandler.mockReturnValue(true);
     mockRegistryManager.executeTool.mockResolvedValue({ result: 'success' });
+
+    // SessionManager mock defaults for per-session instance URL tracking (#398)
+    mockSessionManager.getSessionInstanceUrl.mockReturnValue('https://gitlab.example.com');
+    mockSessionManager.setSessionInstanceUrl.mockReturnValue(undefined);
   });
 
   describe('setupHandlers', () => {
@@ -367,12 +384,73 @@ describe('handlers', () => {
 
       expect(result.tools![0].inputSchema.type).toBe('object');
     });
+
+    describe('per-session instance URL resolution (#398)', () => {
+      it('should pass session instanceUrl to getAllToolDefinitions when sessionId is provided', async () => {
+        // Session targeting a non-default instance
+        mockSessionManager.getSessionInstanceUrl.mockReturnValue('https://custom.gitlab.com');
+
+        await listToolsHandler({ method: 'tools/list' }, { sessionId: 'sess-abc' });
+
+        expect(mockSessionManager.getSessionInstanceUrl).toHaveBeenCalledWith('sess-abc');
+        expect(mockRegistryManager.getAllToolDefinitions).toHaveBeenCalledWith(
+          'https://custom.gitlab.com',
+        );
+      });
+
+      it('should fall back to GITLAB_BASE_URL when sessionId is absent', async () => {
+        // No extra.sessionId provided (e.g. stdio transport before session tracking)
+        await listToolsHandler({ method: 'tools/list' });
+
+        expect(mockSessionManager.getSessionInstanceUrl).not.toHaveBeenCalled();
+        expect(mockRegistryManager.getAllToolDefinitions).toHaveBeenCalledWith(
+          'https://gitlab.example.com',
+        );
+      });
+
+      it('should fall back to GITLAB_BASE_URL when session has no tracked URL', async () => {
+        // Session exists but instanceUrl not yet set (getSessionInstanceUrl returns undefined)
+        mockSessionManager.getSessionInstanceUrl.mockReturnValue(undefined);
+
+        await listToolsHandler({ method: 'tools/list' }, { sessionId: 'new-sess' });
+
+        expect(mockRegistryManager.getAllToolDefinitions).toHaveBeenCalledWith(
+          'https://gitlab.example.com',
+        );
+      });
+    });
   });
 
   describe('call tool handler', () => {
     beforeEach(async () => {
       await setupHandlers(mockServer);
       callToolHandler = getRegisteredHandler(mockServer, CallToolRequestSchema);
+    });
+
+    it('should update session instanceUrl on each tool call (#398)', async () => {
+      // Verifies that the CallTool handler keeps per-session instance URL in sync
+      // so subsequent ListTools calls resolve the correct tool catalog for that session.
+      const request = {
+        params: { name: 'get_project', arguments: { id: 'proj-1' } },
+      };
+
+      await callToolHandler(request, { sessionId: 'sess-xyz' });
+
+      expect(mockSessionManager.setSessionInstanceUrl).toHaveBeenCalledWith(
+        'sess-xyz',
+        'https://gitlab.example.com',
+      );
+    });
+
+    it('should not update session instanceUrl when sessionId is absent (#398)', async () => {
+      // No extra.sessionId — no crash, no spurious session update
+      const request = {
+        params: { name: 'get_project', arguments: { id: 'proj-1' } },
+      };
+
+      await callToolHandler(request);
+
+      expect(mockSessionManager.setSessionInstanceUrl).not.toHaveBeenCalled();
     });
 
     it('should execute tool and return result', async () => {

--- a/tests/unit/handlers.test.ts
+++ b/tests/unit/handlers.test.ts
@@ -421,10 +421,10 @@ describe('handlers', () => {
         expect(mockRegistryManager.getAllToolDefinitions).toHaveBeenCalledWith(undefined);
       });
 
-      it('should pass undefined to getAllToolDefinitions when session has no tracked URL (registry resolves via OAuth context chain)', async () => {
-        // Session exists but instanceUrl not yet set — pass undefined so registry can
-        // resolve via OAuth context URL → current URL → GITLAB_BASE_URL chain instead
-        // of short-circuiting with a stale GITLAB_BASE_URL fallback (#398).
+      it('should pass undefined to getAllToolDefinitions for unknown/expired sessionId (registry resolves via OAuth context chain)', async () => {
+        // SessionManager always sets instanceUrl on createSession(); undefined from
+        // getSessionInstanceUrl means the sessionId is unknown or expired. Pass it
+        // through so the registry's resolution chain is not short-circuited (#398).
         mockSessionManager.getSessionInstanceUrl.mockReturnValue(undefined);
 
         await listToolsHandler({ method: 'tools/list' }, { sessionId: 'new-sess' });

--- a/tests/unit/handlers.test.ts
+++ b/tests/unit/handlers.test.ts
@@ -422,15 +422,15 @@ describe('handlers', () => {
         );
       });
 
-      it('should fall back to GITLAB_BASE_URL when session has no tracked URL', async () => {
-        // Session exists but instanceUrl not yet set (getSessionInstanceUrl returns undefined)
+      it('should pass undefined to getAllToolDefinitions when session has no tracked URL (registry resolves via OAuth context chain)', async () => {
+        // Session exists but instanceUrl not yet set — pass undefined so registry can
+        // resolve via OAuth context URL → current URL → GITLAB_BASE_URL chain instead
+        // of short-circuiting with a stale GITLAB_BASE_URL fallback (#398).
         mockSessionManager.getSessionInstanceUrl.mockReturnValue(undefined);
 
         await listToolsHandler({ method: 'tools/list' }, { sessionId: 'new-sess' });
 
-        expect(mockRegistryManager.getAllToolDefinitions).toHaveBeenCalledWith(
-          'https://gitlab.example.com',
-        );
+        expect(mockRegistryManager.getAllToolDefinitions).toHaveBeenCalledWith(undefined);
       });
     });
   });

--- a/tests/unit/handlers.test.ts
+++ b/tests/unit/handlers.test.ts
@@ -114,6 +114,16 @@ jest.mock('../../src/logging/index', () => ({
   getCurrentRequestId: jest.fn(() => mockGetCurrentRequestId()),
 }));
 
+// Mock ContextManager — returns default context (no scope.path by default).
+// Tests that need scope.path coverage override mockContextManager.getContext directly.
+const mockContextManager = {
+  getContext: jest.fn().mockReturnValue({ readOnly: false }),
+};
+
+jest.mock('../../src/entities/context/context-manager', () => ({
+  getContextManager: jest.fn(() => mockContextManager),
+}));
+
 // Mock SessionManager — needed by the ListToolsRequestSchema and CallToolRequestSchema handlers
 // for per-session instance URL tracking (#398).
 const mockSessionManager = {
@@ -202,6 +212,9 @@ describe('handlers', () => {
     // SessionManager mock defaults for per-session instance URL tracking (#398)
     mockSessionManager.getSessionInstanceUrl.mockReturnValue('https://gitlab.example.com');
     mockSessionManager.setSessionInstanceUrl.mockReturnValue(undefined);
+
+    // ContextManager default: no scope path (most tests don't need it)
+    mockContextManager.getContext.mockReturnValue({ readOnly: false });
   });
 
   describe('setupHandlers', () => {
@@ -2026,6 +2039,26 @@ describe('handlers', () => {
       expect(mockRequestTracker.getStack).toHaveBeenCalledWith('req-789');
       // recordError should NOT have been called (no sessionId)
       expect(mockConnectionTracker.recordError).not.toHaveBeenCalled();
+    });
+
+    it('should set context path when sessionContext.scope.path is present (line 713)', async () => {
+      // Line 713: requestTracker.setContextForCurrentRequest is called only when
+      // contextManager.getContext() returns a context with scope.path set.
+      mockContextManager.getContext.mockReturnValue({
+        scope: { path: 'groups/my-group' },
+        readOnly: false,
+      });
+
+      await callToolHandler({
+        params: {
+          name: 'test_tool',
+          arguments: {},
+        },
+      });
+
+      expect(mockRequestTracker.setContextForCurrentRequest).toHaveBeenCalledWith(
+        'groups/my-group',
+      );
     });
   });
 

--- a/tests/unit/session-manager.test.ts
+++ b/tests/unit/session-manager.test.ts
@@ -18,6 +18,7 @@ jest.mock('@modelcontextprotocol/sdk/server/index.js', () => ({
 jest.mock('../../src/config', () => ({
   packageName: 'test-package',
   packageVersion: '1.0.0',
+  GITLAB_BASE_URL: 'https://gitlab.example.com',
 }));
 
 jest.mock('../../src/handlers', () => ({
@@ -235,6 +236,111 @@ describe('SessionManager', () => {
     it('should work with zero sessions', async () => {
       manager.start();
       await expect(manager.broadcastToolsListChanged()).resolves.toBeUndefined();
+    });
+  });
+
+  describe('per-session instance URL tracking (#398)', () => {
+    it('should default instanceUrl to GITLAB_BASE_URL on session creation', async () => {
+      manager.start();
+      await manager.createSession('session-1', mockTransport as any);
+
+      expect(manager.getSessionInstanceUrl('session-1')).toBe('https://gitlab.example.com');
+    });
+
+    it('should use provided instanceUrl on session creation', async () => {
+      manager.start();
+      await manager.createSession('session-1', mockTransport as any, 'https://custom.gitlab.com');
+
+      expect(manager.getSessionInstanceUrl('session-1')).toBe('https://custom.gitlab.com');
+    });
+
+    it('should return undefined for non-existent session', () => {
+      expect(manager.getSessionInstanceUrl('does-not-exist')).toBeUndefined();
+    });
+
+    it('should update instanceUrl via setSessionInstanceUrl', async () => {
+      manager.start();
+      await manager.createSession('session-1', mockTransport as any);
+
+      manager.setSessionInstanceUrl('session-1', 'https://other.gitlab.com');
+
+      expect(manager.getSessionInstanceUrl('session-1')).toBe('https://other.gitlab.com');
+    });
+
+    it('should no-op setSessionInstanceUrl for non-existent session', () => {
+      // Should not throw
+      expect(() =>
+        manager.setSessionInstanceUrl('does-not-exist', 'https://gitlab.example.com'),
+      ).not.toThrow();
+    });
+
+    it('should return per-instance session counts from getSessionsByInstance', async () => {
+      manager.start();
+      await manager.createSession('session-1', mockTransport as any, 'https://a.gitlab.com');
+      await manager.createSession('session-2', mockTransport as any, 'https://a.gitlab.com');
+      await manager.createSession('session-3', mockTransport as any, 'https://b.gitlab.com');
+
+      const counts = manager.getSessionsByInstance();
+
+      expect(counts.get('https://a.gitlab.com')).toBe(2);
+      expect(counts.get('https://b.gitlab.com')).toBe(1);
+      expect(counts.size).toBe(2);
+    });
+
+    it('should return empty map when no sessions exist', () => {
+      const counts = manager.getSessionsByInstance();
+      expect(counts.size).toBe(0);
+    });
+  });
+
+  describe('broadcastToolsListChanged — per-instance filtering (#398)', () => {
+    // NOTE: The Server mock returns `{ ...mockServer }` for each new Server(),
+    // which means all server instances share the same `notification` jest.fn()
+    // reference. We verify filtering by checking the total call count rather than
+    // per-server individual call assertions.
+
+    it('should notify only sessions matching the given instanceUrl', async () => {
+      // Reset the shared notification mock before this test
+      mockServer.notification.mockClear();
+
+      manager.start();
+      await manager.createSession('session-a1', mockTransport as any, 'https://a.gitlab.com');
+      await manager.createSession('session-a2', mockTransport as any, 'https://a.gitlab.com');
+      await manager.createSession('session-b', mockTransport as any, 'https://b.gitlab.com');
+
+      await manager.broadcastToolsListChanged('https://a.gitlab.com');
+
+      // Only the 2 sessions targeting 'a.gitlab.com' should be notified — NOT session-b
+      expect(mockServer.notification).toHaveBeenCalledTimes(2);
+      expect(mockServer.notification).toHaveBeenCalledWith({
+        method: 'notifications/tools/list_changed',
+      });
+    });
+
+    it('should notify all sessions when no instanceUrl filter is provided', async () => {
+      mockServer.notification.mockClear();
+
+      manager.start();
+      await manager.createSession('session-1', mockTransport as any, 'https://a.gitlab.com');
+      await manager.createSession('session-2', mockTransport as any, 'https://b.gitlab.com');
+
+      await manager.broadcastToolsListChanged();
+
+      // Both sessions notified when no filter
+      expect(mockServer.notification).toHaveBeenCalledTimes(2);
+    });
+
+    it('should no-op when no sessions match the instanceUrl filter', async () => {
+      mockServer.notification.mockClear();
+
+      manager.start();
+      await manager.createSession('session-1', mockTransport as any, 'https://a.gitlab.com');
+
+      await expect(
+        manager.broadcastToolsListChanged('https://unrelated.gitlab.com'),
+      ).resolves.toBeUndefined();
+
+      expect(mockServer.notification).not.toHaveBeenCalled();
     });
   });
 

--- a/tests/unit/session-manager.test.ts
+++ b/tests/unit/session-manager.test.ts
@@ -3,16 +3,15 @@
  * Verifies per-session Server isolation, cleanup, and broadcast behavior
  */
 
-const mockServer = {
-  connect: jest.fn().mockResolvedValue(undefined),
-  close: jest.fn().mockResolvedValue(undefined),
-  notification: jest.fn().mockResolvedValue(undefined),
-  oninitialized: null as (() => void) | null,
-  getClientVersion: jest.fn().mockReturnValue({ name: 'test-client' }),
-};
-
 jest.mock('@modelcontextprotocol/sdk/server/index.js', () => ({
-  Server: jest.fn(() => ({ ...mockServer })),
+  Server: jest.fn().mockImplementation(() => ({
+    connect: jest.fn().mockResolvedValue(undefined),
+    close: jest.fn().mockResolvedValue(undefined),
+    // Fresh spy per instance so tests can assert which server was notified
+    notification: jest.fn().mockResolvedValue(undefined),
+    oninitialized: null,
+    getClientVersion: jest.fn().mockReturnValue({ name: 'test-client' }),
+  })),
 }));
 
 jest.mock('../../src/config', () => ({
@@ -268,31 +267,38 @@ describe('SessionManager', () => {
     });
 
     it('should send tools/list_changed notification when instanceUrl changes', async () => {
-      mockServer.notification.mockClear();
       manager.start();
-      await manager.createSession('session-1', mockTransport as any);
+      const server = await manager.createSession('session-1', mockTransport as any);
 
-      // URL changes → notification must be sent
+      // URL changes → notification must be sent to this specific session's server
       manager.setSessionInstanceUrl('session-1', 'https://other.gitlab.com');
 
       // Allow the fire-and-forget promise to settle
       await Promise.resolve();
 
-      expect(mockServer.notification).toHaveBeenCalledWith({
+      expect(server.notification).toHaveBeenCalledWith({
         method: 'notifications/tools/list_changed',
       });
     });
 
     it('should NOT send tools/list_changed notification when instanceUrl is unchanged', async () => {
       manager.start();
-      await manager.createSession('session-1', mockTransport as any, 'https://a.gitlab.com');
-      mockServer.notification.mockClear();
+      const server = await manager.createSession(
+        'session-1',
+        mockTransport as any,
+        'https://a.gitlab.com',
+      );
 
       // Same URL again → no notification
       manager.setSessionInstanceUrl('session-1', 'https://a.gitlab.com');
       await Promise.resolve();
 
-      expect(mockServer.notification).not.toHaveBeenCalled();
+      // notification may have been called during connect — only check that the
+      // URL-unchanged path does NOT add an extra notification call
+      const callsBefore = (server.notification as jest.Mock).mock.calls.length;
+      manager.setSessionInstanceUrl('session-1', 'https://a.gitlab.com');
+      await Promise.resolve();
+      expect((server.notification as jest.Mock).mock.calls.length).toBe(callsBefore);
     });
 
     it('should no-op setSessionInstanceUrl for non-existent session', () => {
@@ -322,53 +328,77 @@ describe('SessionManager', () => {
   });
 
   describe('broadcastToolsListChanged — per-instance filtering (#398)', () => {
-    // NOTE: The Server mock returns `{ ...mockServer }` for each new Server(),
-    // which means all server instances share the same `notification` jest.fn()
-    // reference. We verify filtering by checking the total call count rather than
-    // per-server individual call assertions.
-
     it('should notify only sessions matching the given instanceUrl', async () => {
-      // Reset the shared notification mock before this test
-      mockServer.notification.mockClear();
-
       manager.start();
-      await manager.createSession('session-a1', mockTransport as any, 'https://a.gitlab.com');
-      await manager.createSession('session-a2', mockTransport as any, 'https://a.gitlab.com');
-      await manager.createSession('session-b', mockTransport as any, 'https://b.gitlab.com');
+      const serverA1 = await manager.createSession(
+        'session-a1',
+        mockTransport as any,
+        'https://a.gitlab.com',
+      );
+      const serverA2 = await manager.createSession(
+        'session-a2',
+        mockTransport as any,
+        'https://a.gitlab.com',
+      );
+      const serverB = await manager.createSession(
+        'session-b',
+        mockTransport as any,
+        'https://b.gitlab.com',
+      );
 
       await manager.broadcastToolsListChanged('https://a.gitlab.com');
 
-      // Only the 2 sessions targeting 'a.gitlab.com' should be notified — NOT session-b
-      expect(mockServer.notification).toHaveBeenCalledTimes(2);
-      expect(mockServer.notification).toHaveBeenCalledWith({
+      // Only sessions targeting 'a.gitlab.com' should be notified — NOT session-b
+      expect(serverA1.notification).toHaveBeenCalledWith({
+        method: 'notifications/tools/list_changed',
+      });
+      expect(serverA2.notification).toHaveBeenCalledWith({
+        method: 'notifications/tools/list_changed',
+      });
+      expect(serverB.notification).not.toHaveBeenCalledWith({
         method: 'notifications/tools/list_changed',
       });
     });
 
     it('should notify all sessions when no instanceUrl filter is provided', async () => {
-      mockServer.notification.mockClear();
-
       manager.start();
-      await manager.createSession('session-1', mockTransport as any, 'https://a.gitlab.com');
-      await manager.createSession('session-2', mockTransport as any, 'https://b.gitlab.com');
+      const server1 = await manager.createSession(
+        'session-1',
+        mockTransport as any,
+        'https://a.gitlab.com',
+      );
+      const server2 = await manager.createSession(
+        'session-2',
+        mockTransport as any,
+        'https://b.gitlab.com',
+      );
 
       await manager.broadcastToolsListChanged();
 
       // Both sessions notified when no filter
-      expect(mockServer.notification).toHaveBeenCalledTimes(2);
+      expect(server1.notification).toHaveBeenCalledWith({
+        method: 'notifications/tools/list_changed',
+      });
+      expect(server2.notification).toHaveBeenCalledWith({
+        method: 'notifications/tools/list_changed',
+      });
     });
 
     it('should no-op when no sessions match the instanceUrl filter', async () => {
-      mockServer.notification.mockClear();
-
       manager.start();
-      await manager.createSession('session-1', mockTransport as any, 'https://a.gitlab.com');
+      const server = await manager.createSession(
+        'session-1',
+        mockTransport as any,
+        'https://a.gitlab.com',
+      );
 
       await expect(
         manager.broadcastToolsListChanged('https://unrelated.gitlab.com'),
       ).resolves.toBeUndefined();
 
-      expect(mockServer.notification).not.toHaveBeenCalled();
+      expect(server.notification).not.toHaveBeenCalledWith({
+        method: 'notifications/tools/list_changed',
+      });
     });
   });
 

--- a/tests/unit/session-manager.test.ts
+++ b/tests/unit/session-manager.test.ts
@@ -308,6 +308,26 @@ describe('SessionManager', () => {
       ).not.toThrow();
     });
 
+    it('should swallow notification errors when instanceUrl changes (fire-and-forget catch)', async () => {
+      manager.start();
+      const server = await manager.createSession('session-1', mockTransport as any);
+
+      // Make the notification call reject
+      (server.notification as jest.Mock).mockRejectedValueOnce(new Error('Transport closed'));
+
+      // Should not throw despite notification failure
+      expect(() =>
+        manager.setSessionInstanceUrl('session-1', 'https://other.gitlab.com'),
+      ).not.toThrow();
+
+      // Allow the fire-and-forget promise (and its catch) to settle
+      await Promise.resolve();
+      await Promise.resolve();
+
+      // URL was still updated despite notification failure
+      expect(manager.getSessionInstanceUrl('session-1')).toBe('https://other.gitlab.com');
+    });
+
     it('should return per-instance session counts from getSessionsByInstance', async () => {
       manager.start();
       await manager.createSession('session-1', mockTransport as any, 'https://a.gitlab.com');

--- a/tests/unit/session-manager.test.ts
+++ b/tests/unit/session-manager.test.ts
@@ -267,6 +267,34 @@ describe('SessionManager', () => {
       expect(manager.getSessionInstanceUrl('session-1')).toBe('https://other.gitlab.com');
     });
 
+    it('should send tools/list_changed notification when instanceUrl changes', async () => {
+      mockServer.notification.mockClear();
+      manager.start();
+      await manager.createSession('session-1', mockTransport as any);
+
+      // URL changes → notification must be sent
+      manager.setSessionInstanceUrl('session-1', 'https://other.gitlab.com');
+
+      // Allow the fire-and-forget promise to settle
+      await Promise.resolve();
+
+      expect(mockServer.notification).toHaveBeenCalledWith({
+        method: 'notifications/tools/list_changed',
+      });
+    });
+
+    it('should NOT send tools/list_changed notification when instanceUrl is unchanged', async () => {
+      manager.start();
+      await manager.createSession('session-1', mockTransport as any, 'https://a.gitlab.com');
+      mockServer.notification.mockClear();
+
+      // Same URL again → no notification
+      manager.setSessionInstanceUrl('session-1', 'https://a.gitlab.com');
+      await Promise.resolve();
+
+      expect(mockServer.notification).not.toHaveBeenCalled();
+    });
+
     it('should no-op setSessionInstanceUrl for non-existent session', () => {
       // Should not throw
       expect(() =>


### PR DESCRIPTION
## Summary

- Add \`instanceUrl\` field to \`ManagedSession\` and expose \`setSessionInstanceUrl\` / \`getSessionInstanceUrl\` / \`getSessionsByInstance()\` on \`SessionManager\`
- \`ListToolsRequestSchema\` handler resolves \`extra.sessionId → instanceUrl\` and passes it to \`getAllToolDefinitions()\`, so each session receives a tool list filtered for its target GitLab instance; absent or unknown sessionId passes \`undefined\` so the registry resolves via its built-in OAuth context → current URL → GITLAB_BASE_URL chain
- \`CallToolRequestSchema\` handler updates the session's \`instanceUrl\` on every tool call — OAuth sessions use the real context URL when available (contextless calls do NOT overwrite pinned sessions); static-token sessions track the active \`ConnectionManager\` instance URL
- \`setSessionInstanceUrl\` emits a \`notifications/tools/list_changed\` fire-and-forget notification when the URL actually changes, so clients re-fetch the tool list for the new instance immediately
- OAuth sentinel changed from \`null\` to \`undefined\` to match \`getGitLabApiUrlFromContext()\` return type (\`string | undefined\`); the old \`null\` guard silently passed the missing-context path
- \`broadcastToolsListChanged(instanceUrl?)\` filters to sessions targeting the changed instance (URL normalized before comparison); the HealthMonitor state-change callback passes \`instanceUrl\` to avoid spurious re-fetches in unrelated sessions
- \`dashboard/metrics.ts\` populates \`sessions.byInstance\` from \`getSessionsByInstance()\` instead of an empty object
- Extract \`checkUnreachableInstance\`, \`tryManageContextFastPath\`, \`ensureBootstrapped\` as module-level helpers; introduce \`BootstrapContext\` interface (satisfies SonarCloud 7-param limit) and \`BootstrapState\` for shared mutable state
- Isolate \`refreshCache\` in its own try/catch — cache rebuild failure logs a warning and does not abort a successfully established tool call

## Test plan

- [x] 4941/4941 tests pass, lint clean
- [x] \`SessionManager\` — new tests: \`instanceUrl\` default, custom URL on creation, \`setSessionInstanceUrl\`, \`getSessionInstanceUrl\`, \`getSessionsByInstance\`, \`tools/list_changed\` notification on URL change (not sent when URL unchanged), filtered \`broadcastToolsListChanged\`; per-instance Server notification spies (not shared mock)
- [x] \`handlers\` — new tests: ListTools passes session instanceUrl / undefined for unknown session; CallTool updates session instanceUrl (OAuth path with context URL, no-op without context URL); TOCTOU guard for post-bootstrap executeTool undefined; \`it.each\` for fast-path regression
- [x] \`metrics\` — existing tests pass with updated session manager mock

Closes #398