### PR TITLE
feat(deploy-keys): expose deploy keys under a CI access umbrella flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ The server handles GitLab connectivity issues gracefully:
 | `USE_MEMBERS` | `true` | Team members |
 | `USE_SEARCH` | `true` | Cross-project search |
 | `USE_ITERATIONS` | `true` | Iteration planning (sprints) |
-| `USE_JOB_TOKEN_SCOPE` | `true` | CI/CD job token scope and allowlist |
+| `USE_CI_TOKENS` | `true` | CI access credentials: job token scope and deploy keys |
 
 ## Contributing
 

--- a/README.md.in
+++ b/README.md.in
@@ -123,7 +123,7 @@ The server handles GitLab connectivity issues gracefully:
 | `USE_MEMBERS` | `true` | Team members |
 | `USE_SEARCH` | `true` | Cross-project search |
 | `USE_ITERATIONS` | `true` | Iteration planning (sprints) |
-| `USE_JOB_TOKEN_SCOPE` | `true` | CI/CD job token scope and allowlist |
+| `USE_CI_TOKENS` | `true` | CI access credentials: job token scope and deploy keys |
 
 ## Contributing
 

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -93,7 +93,7 @@ Enable or disable tool groups:
 | `USE_MEMBERS` | Team member tools | `true` |
 | `USE_SEARCH` | Cross-project search | `true` |
 | `USE_ITERATIONS` | Iteration planning (sprints) | `true` |
-| `USE_JOB_TOKEN_SCOPE` | CI/CD job token scope and allowlist tools | `true` |
+| `USE_CI_TOKENS` | CI access credential tools: job token scope/allowlist and deploy keys | `true` |
 
 ## Server Configuration
 

--- a/docs/guide/quick-start.md
+++ b/docs/guide/quick-start.md
@@ -89,7 +89,7 @@ Enable or disable tool groups:
 | `USE_MEMBERS` | `true` | Team member management |
 | `USE_SEARCH` | `true` | Cross-project search |
 | `USE_ITERATIONS` | `true` | Iteration planning (sprints) |
-| `USE_JOB_TOKEN_SCOPE` | `true` | CI/CD job token scope and allowlist |
+| `USE_CI_TOKENS` | `true` | CI access credentials: job token scope and deploy keys |
 
 ## Next Steps
 

--- a/docs/public/llms.txt.in
+++ b/docs/public/llms.txt.in
@@ -116,7 +116,7 @@ All default to true. Set to false to disable tool groups:
 USE_MRS, USE_PIPELINE, USE_FILES, USE_WORKITEMS, USE_LABELS,
 USE_VARIABLES, USE_WEBHOOKS, USE_SNIPPETS, USE_INTEGRATIONS,
 USE_GITLAB_WIKI, USE_MILESTONE, USE_RELEASES, USE_REFS,
-USE_MEMBERS, USE_SEARCH, USE_ITERATIONS, USE_JOB_TOKEN_SCOPE
+USE_MEMBERS, USE_SEARCH, USE_ITERATIONS, USE_CI_TOKENS
 
 [Full documentation: https://gitlab-mcp.sw.foundation/]
 [Source code: https://github.com/structured-world/gitlab-mcp]

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -4,4 +4,6 @@
 # Exclude test files from Copy-Paste Detection (CPD).
 # Test files naturally repeat assertion patterns (expect, mock setup, await) across
 # test cases — this is intentional test structure, not accidental code duplication.
-sonar.cpd.exclusions=tests/**
+# Patterns must end in /* (or match the filename) to cover files nested under
+# subdirectories; a bare `tests/**` matches directories but not the files inside them.
+sonar.cpd.exclusions=tests/**/*,**/*.test.ts

--- a/src/config.ts
+++ b/src/config.ts
@@ -329,7 +329,9 @@ export const USE_REFS = process.env.USE_REFS !== 'false';
 export const USE_MEMBERS = process.env.USE_MEMBERS !== 'false';
 export const USE_SEARCH = process.env.USE_SEARCH !== 'false';
 export const USE_ITERATIONS = process.env.USE_ITERATIONS !== 'false';
-export const USE_JOB_TOKEN_SCOPE = process.env.USE_JOB_TOKEN_SCOPE !== 'false';
+// Umbrella gate for CI access-credential tools: job token scope/allowlist and
+// deploy keys. Both are enabled or disabled together.
+export const USE_CI_TOKENS = process.env.USE_CI_TOKENS !== 'false';
 export const HOST = process.env.HOST ?? '127.0.0.1';
 export const PORT = process.env.PORT ?? 3002;
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -331,6 +331,9 @@ export const USE_SEARCH = process.env.USE_SEARCH !== 'false';
 export const USE_ITERATIONS = process.env.USE_ITERATIONS !== 'false';
 // Umbrella gate for CI access-credential tools: job token scope/allowlist and
 // deploy keys. Both are enabled or disabled together.
+// No alias for the earlier USE_JOB_TOKEN_SCOPE name: that flag never shipped in
+// a published release, so no deployment can depend on it and a fallback would
+// only add a permanent compatibility shim for a contract that never existed.
 export const USE_CI_TOKENS = process.env.USE_CI_TOKENS !== 'false';
 export const HOST = process.env.HOST ?? '127.0.0.1';
 export const PORT = process.env.PORT ?? 3002;

--- a/src/entities/deploy-keys/registry.ts
+++ b/src/entities/deploy-keys/registry.ts
@@ -1,0 +1,111 @@
+import * as z from 'zod';
+import { BrowseDeployKeysSchema } from './schema-readonly';
+import { ManageDeployKeySchema } from './schema';
+import { gitlab, toQuery } from '../../utils/gitlab-api';
+import { ToolRegistry, EnhancedToolDefinition } from '../../types';
+import { assertActionAllowed } from '../utils';
+
+// Deploy keys have existed since early GitLab and are Free tier throughout.
+const FREE_REQ = { tier: 'free', minVersion: '8.0' } as const;
+
+/**
+ * Deploy keys tools registry - 2 CQRS tools.
+ *
+ * browse_deploy_keys (Query): list, get
+ * manage_deploy_key (Command): add, enable, update, delete
+ *
+ * Deploy keys are SSH public keys granting a project repository access without
+ * a user PAT — used by CI/automation. Project-level, Free tier.
+ */
+export const deployKeysToolRegistry: ToolRegistry = new Map<string, EnhancedToolDefinition>([
+  // ============================================================================
+  // browse_deploy_keys - CQRS Query Tool
+  // ============================================================================
+  [
+    'browse_deploy_keys',
+    {
+      name: 'browse_deploy_keys',
+      description:
+        'List and inspect deploy keys (SSH keys granting repo access to CI/automation). Actions: list (a project’s keys, or all instance keys when project_id is omitted — admin only), get (a single project key by ID). Related: manage_deploy_key to add/enable/update/delete.',
+      inputSchema: z.toJSONSchema(BrowseDeployKeysSchema),
+      requirements: { default: FREE_REQ },
+      gate: { envVar: 'USE_CI_TOKENS', defaultValue: true },
+      handler: async (args: unknown): Promise<unknown> => {
+        const input = BrowseDeployKeysSchema.parse(args);
+        assertActionAllowed('browse_deploy_keys', input.action);
+
+        if (input.action === 'get') {
+          const encodedProjectId = encodeURIComponent(input.project_id);
+          return gitlab.get(`projects/${encodedProjectId}/deploy_keys/${input.key_id}`);
+        }
+
+        // list: project-scoped when project_id is provided, otherwise instance-wide
+        const { action: _action, project_id, ...query } = input;
+        const path = project_id
+          ? `projects/${encodeURIComponent(project_id)}/deploy_keys`
+          : 'deploy_keys';
+        return gitlab.get(path, { query: toQuery(query, []) });
+      },
+    },
+  ],
+
+  // ============================================================================
+  // manage_deploy_key - CQRS Command Tool
+  // ============================================================================
+  [
+    'manage_deploy_key',
+    {
+      name: 'manage_deploy_key',
+      description:
+        'Add, enable, update, or remove project deploy keys. Actions: add (register a new SSH public key with title and optional push access/expiry), enable (attach an existing key from another project), update (change title or can_push), delete (remove from this project). Related: browse_deploy_keys to inspect.',
+      inputSchema: z.toJSONSchema(ManageDeployKeySchema),
+      requirements: { default: FREE_REQ },
+      gate: { envVar: 'USE_CI_TOKENS', defaultValue: true },
+      handler: async (args: unknown): Promise<unknown> => {
+        const input = ManageDeployKeySchema.parse(args);
+        assertActionAllowed('manage_deploy_key', input.action);
+
+        const encodedProjectId = encodeURIComponent(input.project_id);
+        const base = `projects/${encodedProjectId}/deploy_keys`;
+
+        switch (input.action) {
+          case 'add': {
+            const { action: _action, project_id: _project_id, ...body } = input;
+            return gitlab.post(base, { body, contentType: 'json' });
+          }
+
+          case 'enable':
+            return gitlab.post(`${base}/${input.key_id}/enable`);
+
+          case 'update': {
+            const { action: _action, project_id: _project_id, key_id, ...body } = input;
+            return gitlab.put(`${base}/${key_id}`, { body, contentType: 'json' });
+          }
+
+          case 'delete': {
+            await gitlab.delete(`${base}/${input.key_id}`);
+            return { deleted: true, key_id: input.key_id };
+          }
+
+          /* istanbul ignore next -- unreachable with Zod discriminatedUnion */
+          default:
+            throw new Error(`Unknown action: ${(input as { action: string }).action}`);
+        }
+      },
+    },
+  ],
+]);
+
+/**
+ * Get read-only tool names from the registry
+ */
+export function getDeployKeysReadOnlyToolNames(): string[] {
+  return ['browse_deploy_keys'];
+}
+
+/**
+ * Get all tool definitions from the registry
+ */
+export function getDeployKeysToolDefinitions(): EnhancedToolDefinition[] {
+  return Array.from(deployKeysToolRegistry.values());
+}

--- a/src/entities/deploy-keys/registry.ts
+++ b/src/entities/deploy-keys/registry.ts
@@ -96,16 +96,7 @@ export const deployKeysToolRegistry: ToolRegistry = new Map<string, EnhancedTool
   ],
 ]);
 
-/**
- * Get read-only tool names from the registry
- */
+/** Read-only tool names from the registry (for read-only mode filtering). */
 export function getDeployKeysReadOnlyToolNames(): string[] {
   return ['browse_deploy_keys'];
-}
-
-/**
- * Get all tool definitions from the registry
- */
-export function getDeployKeysToolDefinitions(): EnhancedToolDefinition[] {
-  return Array.from(deployKeysToolRegistry.values());
 }

--- a/src/entities/deploy-keys/schema-readonly.ts
+++ b/src/entities/deploy-keys/schema-readonly.ts
@@ -39,9 +39,16 @@ const GetDeployKeySchema = z.object({
 });
 
 // --- Discriminated union combining all actions ---
-export const BrowseDeployKeysSchema = z.discriminatedUnion('action', [
-  ListDeployKeysSchema,
-  GetDeployKeySchema,
-]);
+// `public` only applies to the instance-wide list (GET /deploy_keys); the
+// project-scoped endpoint rejects it, so forbid the nonsensical combination.
+export const BrowseDeployKeysSchema = z
+  .discriminatedUnion('action', [ListDeployKeysSchema, GetDeployKeySchema])
+  .refine(
+    (data) => data.action !== 'list' || data.public === undefined || data.project_id === undefined,
+    {
+      message: 'public is only valid for the instance-wide list (omit project_id)',
+      path: ['public'],
+    },
+  );
 
 export type BrowseDeployKeysInput = z.infer<typeof BrowseDeployKeysSchema>;

--- a/src/entities/deploy-keys/schema-readonly.ts
+++ b/src/entities/deploy-keys/schema-readonly.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { requiredId, paginationFields } from '../utils';
+import { requiredId, paginationFields, flexibleBoolean } from '../utils';
 
 // ============================================================================
 // browse_deploy_keys - CQRS Query Tool (discriminated union schema)
@@ -24,8 +24,7 @@ const ListDeployKeysSchema = z.object({
   project_id: requiredId
     .optional()
     .describe('Project to list keys for. Omit to list all instance deploy keys (admin only).'),
-  public: z
-    .boolean()
+  public: flexibleBoolean
     .optional()
     .describe('Instance list only: when true, return only the public (non-sensitive) fields.'),
   ...paginationFields(),

--- a/src/entities/deploy-keys/schema-readonly.ts
+++ b/src/entities/deploy-keys/schema-readonly.ts
@@ -9,10 +9,10 @@ import { requiredId, paginationFields } from '../utils';
 // repository access without a user PAT — used by CI/automation to clone/push.
 // ============================================================================
 
-const projectIdField = requiredId.describe(
+export const projectIdField = requiredId.describe(
   "Project ID or URL-encoded path (e.g. 'group/project' or '123').",
 );
-const keyIdField = z.coerce.number().int().positive().describe('Numeric deploy key ID.');
+export const keyIdField = z.coerce.number().int().positive().describe('Numeric deploy key ID.');
 
 // --- Action: list ---
 const ListDeployKeysSchema = z.object({

--- a/src/entities/deploy-keys/schema-readonly.ts
+++ b/src/entities/deploy-keys/schema-readonly.ts
@@ -1,0 +1,47 @@
+import { z } from 'zod';
+import { requiredId, paginationFields } from '../utils';
+
+// ============================================================================
+// browse_deploy_keys - CQRS Query Tool (discriminated union schema)
+// Actions: list, get
+//
+// Deploy keys are SSH public keys that grant a project read (or read/write)
+// repository access without a user PAT — used by CI/automation to clone/push.
+// ============================================================================
+
+const projectIdField = requiredId.describe(
+  "Project ID or URL-encoded path (e.g. 'group/project' or '123').",
+);
+const keyIdField = z.coerce.number().int().positive().describe('Numeric deploy key ID.');
+
+// --- Action: list ---
+const ListDeployKeysSchema = z.object({
+  action: z
+    .literal('list')
+    .describe(
+      'List deploy keys. With project_id: the keys on that project. Without project_id: all deploy keys across the instance (requires admin).',
+    ),
+  project_id: requiredId
+    .optional()
+    .describe('Project to list keys for. Omit to list all instance deploy keys (admin only).'),
+  public: z
+    .boolean()
+    .optional()
+    .describe('Instance list only: when true, return only the public (non-sensitive) fields.'),
+  ...paginationFields(),
+});
+
+// --- Action: get ---
+const GetDeployKeySchema = z.object({
+  action: z.literal('get').describe('Get a single project deploy key by ID'),
+  project_id: projectIdField,
+  key_id: keyIdField,
+});
+
+// --- Discriminated union combining all actions ---
+export const BrowseDeployKeysSchema = z.discriminatedUnion('action', [
+  ListDeployKeysSchema,
+  GetDeployKeySchema,
+]);
+
+export type BrowseDeployKeysInput = z.infer<typeof BrowseDeployKeysSchema>;

--- a/src/entities/deploy-keys/schema.ts
+++ b/src/entities/deploy-keys/schema.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
-import { requiredId, flexibleBoolean } from '../utils';
+import { flexibleBoolean } from '../utils';
+import { projectIdField, keyIdField } from './schema-readonly';
 
 // ============================================================================
 // manage_deploy_key - CQRS Command Tool (discriminated union schema)
@@ -9,10 +10,6 @@ import { requiredId, flexibleBoolean } from '../utils';
 // access the repository without a user PAT. Project-level, Free tier.
 // ============================================================================
 
-const projectIdField = requiredId.describe(
-  "Project ID or URL-encoded path (e.g. 'group/project' or '123').",
-);
-const keyIdField = z.coerce.number().int().positive().describe('Numeric deploy key ID.');
 const canPushField = flexibleBoolean
   .optional()
   .describe('Whether the key may push to the repository (read/write). Default false (read-only).');

--- a/src/entities/deploy-keys/schema.ts
+++ b/src/entities/deploy-keys/schema.ts
@@ -1,0 +1,66 @@
+import { z } from 'zod';
+import { requiredId, flexibleBoolean } from '../utils';
+
+// ============================================================================
+// manage_deploy_key - CQRS Command Tool (discriminated union schema)
+// Actions: add, enable, update, delete
+//
+// Manages a project's deploy keys: the SSH public keys that let CI/automation
+// access the repository without a user PAT. Project-level, Free tier.
+// ============================================================================
+
+const projectIdField = requiredId.describe(
+  "Project ID or URL-encoded path (e.g. 'group/project' or '123').",
+);
+const keyIdField = z.coerce.number().int().positive().describe('Numeric deploy key ID.');
+const canPushField = flexibleBoolean
+  .optional()
+  .describe('Whether the key may push to the repository (read/write). Default false (read-only).');
+
+// --- Action: add ---
+const AddDeployKeySchema = z.object({
+  action: z.literal('add').describe('Add a deploy key to the project'),
+  project_id: projectIdField,
+  title: z.string().describe('Human-readable name for the deploy key.'),
+  key: z.string().describe('The SSH public key (e.g. "ssh-ed25519 AAAA... comment").'),
+  can_push: canPushField,
+  expires_at: z
+    .string()
+    .optional()
+    .describe('Optional expiry as an ISO 8601 datetime (e.g. "2026-12-31T00:00:00Z").'),
+});
+
+// --- Action: enable ---
+const EnableDeployKeySchema = z.object({
+  action: z
+    .literal('enable')
+    .describe('Enable an existing deploy key (from another project) on this project'),
+  project_id: projectIdField,
+  key_id: keyIdField,
+});
+
+// --- Action: update ---
+const UpdateDeployKeySchema = z.object({
+  action: z.literal('update').describe('Update a deploy key title or push permission'),
+  project_id: projectIdField,
+  key_id: keyIdField,
+  title: z.string().optional().describe('New title for the deploy key.'),
+  can_push: canPushField,
+});
+
+// --- Action: delete ---
+const DeleteDeployKeySchema = z.object({
+  action: z.literal('delete').describe('Remove a deploy key from the project'),
+  project_id: projectIdField,
+  key_id: keyIdField,
+});
+
+// --- Discriminated union combining all actions ---
+export const ManageDeployKeySchema = z.discriminatedUnion('action', [
+  AddDeployKeySchema,
+  EnableDeployKeySchema,
+  UpdateDeployKeySchema,
+  DeleteDeployKeySchema,
+]);
+
+export type ManageDeployKeyInput = z.infer<typeof ManageDeployKeySchema>;

--- a/src/entities/deploy-keys/schema.ts
+++ b/src/entities/deploy-keys/schema.ts
@@ -27,7 +27,7 @@ const AddDeployKeySchema = z.object({
   expires_at: z
     .string()
     .optional()
-    .describe('Optional expiry as an ISO 8601 datetime (e.g. "2026-12-31T00:00:00Z").'),
+    .describe('Optional expiry date in YYYY-MM-DD format (e.g. "2026-12-31").'),
 });
 
 // --- Action: enable ---
@@ -56,11 +56,21 @@ const DeleteDeployKeySchema = z.object({
 });
 
 // --- Discriminated union combining all actions ---
-export const ManageDeployKeySchema = z.discriminatedUnion('action', [
-  AddDeployKeySchema,
-  EnableDeployKeySchema,
-  UpdateDeployKeySchema,
-  DeleteDeployKeySchema,
-]);
+export const ManageDeployKeySchema = z
+  .discriminatedUnion('action', [
+    AddDeployKeySchema,
+    EnableDeployKeySchema,
+    UpdateDeployKeySchema,
+    DeleteDeployKeySchema,
+  ])
+  // An update with no fields would send an empty body and be rejected by GitLab;
+  // require at least one updatable field.
+  .refine(
+    (data) => data.action !== 'update' || data.title !== undefined || data.can_push !== undefined,
+    {
+      message: 'update requires at least one of: title, can_push',
+      path: ['title'],
+    },
+  );
 
 export type ManageDeployKeyInput = z.infer<typeof ManageDeployKeySchema>;

--- a/src/entities/job-token-scope/registry.ts
+++ b/src/entities/job-token-scope/registry.ts
@@ -54,7 +54,7 @@ export const jobTokenScopeToolRegistry: ToolRegistry = new Map<string, EnhancedT
         'Inspect a project CI/CD job token inbound access scope. Actions: get (the inbound/outbound scope toggles), list_projects (projects allowed to reach this project via CI_JOB_TOKEN), list_groups (groups on the allowlist). Related: manage_job_token_scope to change the allowlist.',
       inputSchema: z.toJSONSchema(BrowseJobTokenScopeSchema),
       requirements: { default: SCOPE_REQ, actions: { list_groups: GROUP_REQ } },
-      gate: { envVar: 'USE_JOB_TOKEN_SCOPE', defaultValue: true },
+      gate: { envVar: 'USE_CI_TOKENS', defaultValue: true },
       handler: async (args: unknown): Promise<unknown> => {
         const input = BrowseJobTokenScopeSchema.parse(args);
         assertActionAllowed('browse_job_token_scope', input.action);
@@ -87,7 +87,7 @@ export const jobTokenScopeToolRegistry: ToolRegistry = new Map<string, EnhancedT
         default: SCOPE_REQ,
         actions: { add_group: GROUP_REQ, remove_group: GROUP_REQ },
       },
-      gate: { envVar: 'USE_JOB_TOKEN_SCOPE', defaultValue: true },
+      gate: { envVar: 'USE_CI_TOKENS', defaultValue: true },
       handler: async (args: unknown): Promise<unknown> => {
         const input = ManageJobTokenScopeSchema.parse(args);
         assertActionAllowed('manage_job_token_scope', input.action);

--- a/src/profiles/applicator.ts
+++ b/src/profiles/applicator.ts
@@ -33,6 +33,7 @@ const FEATURE_ENV_MAP: Record<string, string> = {
   refs: 'USE_REFS',
   members: 'USE_MEMBERS',
   search: 'USE_SEARCH',
+  ci_tokens: 'USE_CI_TOKENS',
 };
 
 // ============================================================================

--- a/src/profiles/builtin/ci.yaml
+++ b/src/profiles/builtin/ci.yaml
@@ -30,6 +30,7 @@ features:
   refs: false       # No branch management
   members: false    # No team management
   search: false     # No search needed for CI
+  ci_tokens: true   # Job token scope + deploy keys (CI access credentials)
 
 # Block workflow-related operations
 denied_tools_regex: "^manage_(work_item|mr|label|milestone|wiki)"

--- a/src/profiles/builtin/devops.yaml
+++ b/src/profiles/builtin/devops.yaml
@@ -31,3 +31,4 @@ features:
   refs: true        # Branch/tag management
   members: false    # No team management
   search: true      # Code search for debugging
+  ci_tokens: true   # Job token scope + deploy keys (CI access credentials)

--- a/src/profiles/types.ts
+++ b/src/profiles/types.ts
@@ -61,6 +61,7 @@ const FeatureFlagsSchema = z
     refs: z.boolean().optional(),
     members: z.boolean().optional(),
     search: z.boolean().optional(),
+    ci_tokens: z.boolean().optional(),
   })
   .optional();
 

--- a/src/registry-manager.ts
+++ b/src/registry-manager.ts
@@ -40,6 +40,10 @@ import {
   getJobTokenScopeReadOnlyToolNames,
 } from './entities/job-token-scope/registry';
 import {
+  deployKeysToolRegistry,
+  getDeployKeysReadOnlyToolNames,
+} from './entities/deploy-keys/registry';
+import {
   GITLAB_BASE_URL,
   GITLAB_READ_ONLY_MODE,
   GITLAB_DENIED_TOOLS_REGEX,
@@ -60,7 +64,7 @@ import {
   USE_MEMBERS,
   USE_SEARCH,
   USE_ITERATIONS,
-  USE_JOB_TOKEN_SCOPE,
+  USE_CI_TOKENS,
   getToolDescriptionOverrides,
 } from './config';
 import { isToolAvailable, getRestrictedParameters } from './services/InstanceCapabilities';
@@ -196,8 +200,9 @@ class RegistryManager {
       this.registries.set('iterations', iterationsToolRegistry);
     }
 
-    if (USE_JOB_TOKEN_SCOPE) {
+    if (USE_CI_TOKENS) {
       this.registries.set('job-token-scope', jobTokenScopeToolRegistry);
+      this.registries.set('deploy-keys', deployKeysToolRegistry);
     }
 
     // All entity registries have been migrated to the new pattern!
@@ -294,8 +299,9 @@ class RegistryManager {
       readOnlyTools.push(...getIterationsReadOnlyToolNames());
     }
 
-    if (USE_JOB_TOKEN_SCOPE) {
+    if (USE_CI_TOKENS) {
       readOnlyTools.push(...getJobTokenScopeReadOnlyToolNames());
+      readOnlyTools.push(...getDeployKeysReadOnlyToolNames());
     }
 
     return readOnlyTools;
@@ -696,7 +702,7 @@ class RegistryManager {
     const useMembers = process.env.USE_MEMBERS !== 'false';
     const useSearch = process.env.USE_SEARCH !== 'false';
     const useIterations = process.env.USE_ITERATIONS !== 'false';
-    const useJobTokenScope = process.env.USE_JOB_TOKEN_SCOPE !== 'false';
+    const useCiTokens = process.env.USE_CI_TOKENS !== 'false';
 
     // Build registries map based on dynamic feature flags
     const registriesToUse = new Map<string, ToolRegistry>();
@@ -724,7 +730,10 @@ class RegistryManager {
     if (useMembers) registriesToUse.set('members', membersToolRegistry);
     if (useSearch) registriesToUse.set('search', searchToolRegistry);
     if (useIterations) registriesToUse.set('iterations', iterationsToolRegistry);
-    if (useJobTokenScope) registriesToUse.set('job-token-scope', jobTokenScopeToolRegistry);
+    if (useCiTokens) {
+      registriesToUse.set('job-token-scope', jobTokenScopeToolRegistry);
+      registriesToUse.set('deploy-keys', deployKeysToolRegistry);
+    }
 
     // Dynamically load description overrides
     const descOverrides = getToolDescriptionOverrides();
@@ -824,6 +833,7 @@ class RegistryManager {
       searchToolRegistry,
       iterationsToolRegistry,
       jobTokenScopeToolRegistry,
+      deployKeysToolRegistry,
     ];
 
     for (const registry of allRegistries) {

--- a/src/services/TokenScopeDetector.ts
+++ b/src/services/TokenScopeDetector.ts
@@ -135,6 +135,10 @@ const TOOL_SCOPE_REQUIREMENTS: Record<string, GitLabScope[]> = {
   browse_job_token_scope: ['api', 'read_api'],
   manage_job_token_scope: ['api'],
 
+  // Deploy keys
+  browse_deploy_keys: ['api', 'read_api'],
+  manage_deploy_key: ['api'],
+
   // Wiki
   browse_wiki: ['api', 'read_api'],
   manage_wiki: ['api'],

--- a/tests/integration/schemas/deploy-keys.test.ts
+++ b/tests/integration/schemas/deploy-keys.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Deploy Keys Schema Integration Tests
+ * Exercises the deploy key lifecycle against a real GitLab API: add a freshly
+ * generated SSH key to a project, read it back, update it, enable it on a second
+ * project, and delete it everywhere.
+ */
+
+import { generateKeyPairSync } from 'crypto';
+import { BrowseDeployKeysSchema } from '../../../src/entities/deploy-keys/schema-readonly';
+import { ManageDeployKeySchema } from '../../../src/entities/deploy-keys/schema';
+import { IntegrationTestHelper } from '../helpers/registry-helper';
+
+/** Build a unique OpenSSH-format ed25519 public key string. */
+function generateOpenSshEd25519PublicKey(): string {
+  const { publicKey } = generateKeyPairSync('ed25519');
+  const jwk = publicKey.export({ format: 'jwk' }) as { x: string };
+  const raw = Buffer.from(jwk.x, 'base64url'); // 32-byte ed25519 public key
+
+  const withLength = (buf: Buffer): Buffer => {
+    const len = Buffer.alloc(4);
+    len.writeUInt32BE(buf.length);
+    return Buffer.concat([len, buf]);
+  };
+  const wire = Buffer.concat([withLength(Buffer.from('ssh-ed25519')), withLength(raw)]);
+  return `ssh-ed25519 ${wire.toString('base64')} integration-test`;
+}
+
+interface DeployKey {
+  id: number;
+  title: string;
+  can_push: boolean;
+}
+
+describe('Deploy Keys Schema - GitLab Integration', () => {
+  let helper: IntegrationTestHelper;
+
+  beforeAll(async () => {
+    if (!process.env.GITLAB_TOKEN) {
+      throw new Error('GITLAB_TOKEN environment variable is required');
+    }
+    helper = new IntegrationTestHelper();
+    await helper.initialize();
+  });
+
+  /** Find up to `count` projects in the mandated `test` root group. */
+  async function testProjects(
+    count: number,
+  ): Promise<{ path_with_namespace: string; id: number }[]> {
+    const all = (await helper.listProjects({ per_page: 50 })) as {
+      path_with_namespace: string;
+      id: number;
+    }[];
+    return all.filter((p) => p.path_with_namespace.startsWith('test/')).slice(0, count);
+  }
+
+  it('adds, reads, updates, and deletes a project deploy key', async () => {
+    const projects = await testProjects(1);
+    if (projects.length === 0) {
+      console.log('No test/ project available — skipping deploy key lifecycle');
+      return;
+    }
+    const project = projects[0];
+    const key = generateOpenSshEd25519PublicKey();
+
+    const added = (await helper.executeTool(
+      'manage_deploy_key',
+      ManageDeployKeySchema.parse({
+        action: 'add',
+        project_id: project.path_with_namespace,
+        title: `it-${Date.now()}`,
+        key,
+        can_push: false,
+      }),
+    )) as DeployKey;
+    expect(added.id).toBeGreaterThan(0);
+
+    try {
+      const fetched = (await helper.executeTool(
+        'browse_deploy_keys',
+        BrowseDeployKeysSchema.parse({
+          action: 'get',
+          project_id: project.path_with_namespace,
+          key_id: added.id,
+        }),
+      )) as DeployKey;
+      expect(fetched.id).toBe(added.id);
+
+      const updated = (await helper.executeTool(
+        'manage_deploy_key',
+        ManageDeployKeySchema.parse({
+          action: 'update',
+          project_id: project.path_with_namespace,
+          key_id: added.id,
+          can_push: true,
+        }),
+      )) as DeployKey;
+      expect(updated.can_push).toBe(true);
+    } finally {
+      await helper.executeTool(
+        'manage_deploy_key',
+        ManageDeployKeySchema.parse({
+          action: 'delete',
+          project_id: project.path_with_namespace,
+          key_id: added.id,
+        }),
+      );
+    }
+  });
+
+  it('enables an existing key on a second project', async () => {
+    const projects = await testProjects(2);
+    if (projects.length < 2) {
+      console.log('Need two test/ projects — skipping deploy key enable');
+      return;
+    }
+    const [a, b] = projects;
+    const added = (await helper.executeTool(
+      'manage_deploy_key',
+      ManageDeployKeySchema.parse({
+        action: 'add',
+        project_id: a.path_with_namespace,
+        title: `it-enable-${Date.now()}`,
+        key: generateOpenSshEd25519PublicKey(),
+      }),
+    )) as DeployKey;
+
+    try {
+      const enabled = (await helper.executeTool(
+        'manage_deploy_key',
+        ManageDeployKeySchema.parse({
+          action: 'enable',
+          project_id: b.path_with_namespace,
+          key_id: added.id,
+        }),
+      )) as DeployKey;
+      expect(enabled.id).toBe(added.id);
+    } finally {
+      // Remove from both projects (best-effort cleanup).
+      for (const p of [a, b]) {
+        try {
+          await helper.executeTool(
+            'manage_deploy_key',
+            ManageDeployKeySchema.parse({
+              action: 'delete',
+              project_id: p.path_with_namespace,
+              key_id: added.id,
+            }),
+          );
+        } catch {
+          // already gone for this project
+        }
+      }
+    }
+  });
+});

--- a/tests/unit/entities/deploy-keys/registry.test.ts
+++ b/tests/unit/entities/deploy-keys/registry.test.ts
@@ -1,0 +1,173 @@
+import {
+  deployKeysToolRegistry,
+  getDeployKeysReadOnlyToolNames,
+  getDeployKeysToolDefinitions,
+} from '../../../../src/entities/deploy-keys/registry';
+import { enhancedFetch } from '../../../../src/utils/fetch';
+
+jest.mock('../../../../src/utils/fetch', () => ({
+  enhancedFetch: jest.fn(),
+}));
+
+const mockEnhancedFetch = enhancedFetch as jest.MockedFunction<typeof enhancedFetch>;
+
+const originalEnv = process.env;
+
+beforeAll(() => {
+  process.env = {
+    ...originalEnv,
+    GITLAB_API_URL: 'https://gitlab.example.com',
+    GITLAB_TOKEN: 'test-token-12345',
+  };
+});
+
+afterAll(() => {
+  process.env = originalEnv;
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest.resetAllMocks();
+  mockEnhancedFetch.mockReset();
+});
+
+function mockOk(payload: unknown): void {
+  mockEnhancedFetch.mockResolvedValueOnce({
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    json: jest.fn().mockResolvedValue(payload),
+  } as unknown as Response);
+}
+
+function mockNoContent(): void {
+  mockEnhancedFetch.mockResolvedValueOnce({
+    ok: true,
+    status: 204,
+    statusText: 'No Content',
+  } as unknown as Response);
+}
+
+const browse = () => deployKeysToolRegistry.get('browse_deploy_keys')!;
+const manage = () => deployKeysToolRegistry.get('manage_deploy_key')!;
+
+function lastCall(): [string, RequestInit | undefined] {
+  const call = mockEnhancedFetch.mock.calls.at(-1)!;
+  return [call[0], call[1]];
+}
+
+describe('Deploy Keys Registry', () => {
+  describe('Registry Structure', () => {
+    it('contains exactly the two CQRS tools', () => {
+      const names = Array.from(deployKeysToolRegistry.keys());
+      expect(names).toEqual(['browse_deploy_keys', 'manage_deploy_key']);
+    });
+
+    it('exposes only the browse tool as read-only', () => {
+      expect(getDeployKeysReadOnlyToolNames()).toEqual(['browse_deploy_keys']);
+      expect(getDeployKeysToolDefinitions()).toHaveLength(2);
+    });
+
+    it('declares the Free-tier requirement on both tools', () => {
+      expect(browse().requirements?.default).toEqual({ tier: 'free', minVersion: '8.0' });
+      expect(manage().requirements?.default).toEqual({ tier: 'free', minVersion: '8.0' });
+    });
+
+    it('is gated by the shared USE_CI_TOKENS umbrella flag', () => {
+      expect(browse().gate?.envVar).toBe('USE_CI_TOKENS');
+      expect(manage().gate?.envVar).toBe('USE_CI_TOKENS');
+    });
+  });
+
+  describe('browse_deploy_keys', () => {
+    it('list with project_id reads the project deploy keys', async () => {
+      mockOk([{ id: 1, title: 'ci' }]);
+      await browse().handler({ action: 'list', project_id: 'group/project' });
+
+      const [url] = lastCall();
+      expect(url).toContain('/projects/group%2Fproject/deploy_keys');
+    });
+
+    it('list without project_id reads the instance deploy keys', async () => {
+      mockOk([{ id: 1 }]);
+      await browse().handler({ action: 'list', public: true });
+
+      const [url] = lastCall();
+      expect(url).toContain('https://gitlab.example.com/api/v4/deploy_keys?');
+      expect(url).toContain('public=true');
+      expect(url).not.toContain('/projects/');
+    });
+
+    it('get reads a single key by id', async () => {
+      mockOk({ id: 7 });
+      await browse().handler({ action: 'get', project_id: '123', key_id: 7 });
+
+      const [url] = lastCall();
+      expect(url).toBe('https://gitlab.example.com/api/v4/projects/123/deploy_keys/7');
+    });
+  });
+
+  describe('manage_deploy_key', () => {
+    it('add POSTs the key payload', async () => {
+      mockOk({ id: 9 });
+      await manage().handler({
+        action: 'add',
+        project_id: '123',
+        title: 'ci',
+        key: 'ssh-ed25519 AAAA',
+        can_push: true,
+      });
+
+      const [url, init] = lastCall();
+      expect(url).toBe('https://gitlab.example.com/api/v4/projects/123/deploy_keys');
+      expect(init?.method).toBe('POST');
+      expect(JSON.parse(init?.body as string)).toEqual({
+        title: 'ci',
+        key: 'ssh-ed25519 AAAA',
+        can_push: true,
+      });
+    });
+
+    it('enable POSTs to the enable sub-resource', async () => {
+      mockOk({ id: 9 });
+      await manage().handler({ action: 'enable', project_id: '123', key_id: 9 });
+
+      const [url, init] = lastCall();
+      expect(url).toBe('https://gitlab.example.com/api/v4/projects/123/deploy_keys/9/enable');
+      expect(init?.method).toBe('POST');
+    });
+
+    it('update PUTs title/can_push without the ids in the body', async () => {
+      mockOk({ id: 9, can_push: false });
+      await manage().handler({
+        action: 'update',
+        project_id: '123',
+        key_id: 9,
+        title: 'renamed',
+        can_push: false,
+      });
+
+      const [url, init] = lastCall();
+      expect(url).toBe('https://gitlab.example.com/api/v4/projects/123/deploy_keys/9');
+      expect(init?.method).toBe('PUT');
+      expect(JSON.parse(init?.body as string)).toEqual({ title: 'renamed', can_push: false });
+    });
+
+    it('coerces a string key_id to a number', async () => {
+      mockNoContent();
+      const result = await manage().handler({ action: 'delete', project_id: '123', key_id: '9' });
+
+      const [url, init] = lastCall();
+      expect(url).toBe('https://gitlab.example.com/api/v4/projects/123/deploy_keys/9');
+      expect(init?.method).toBe('DELETE');
+      expect(result).toEqual({ deleted: true, key_id: 9 });
+    });
+
+    it('rejects a non-positive key_id at schema parse', async () => {
+      await expect(
+        manage().handler({ action: 'delete', project_id: '123', key_id: 0 }),
+      ).rejects.toThrow();
+      expect(mockEnhancedFetch).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/unit/entities/deploy-keys/registry.test.ts
+++ b/tests/unit/entities/deploy-keys/registry.test.ts
@@ -169,5 +169,12 @@ describe('Deploy Keys Registry', () => {
       ).rejects.toThrow();
       expect(mockEnhancedFetch).not.toHaveBeenCalled();
     });
+
+    it('rejects an update with neither title nor can_push (empty body)', async () => {
+      await expect(
+        manage().handler({ action: 'update', project_id: '123', key_id: 9 }),
+      ).rejects.toThrow();
+      expect(mockEnhancedFetch).not.toHaveBeenCalled();
+    });
   });
 });

--- a/tests/unit/entities/deploy-keys/registry.test.ts
+++ b/tests/unit/entities/deploy-keys/registry.test.ts
@@ -1,7 +1,6 @@
 import {
   deployKeysToolRegistry,
   getDeployKeysReadOnlyToolNames,
-  getDeployKeysToolDefinitions,
 } from '../../../../src/entities/deploy-keys/registry';
 import { enhancedFetch } from '../../../../src/utils/fetch';
 
@@ -65,7 +64,7 @@ describe('Deploy Keys Registry', () => {
 
     it('exposes only the browse tool as read-only', () => {
       expect(getDeployKeysReadOnlyToolNames()).toEqual(['browse_deploy_keys']);
-      expect(getDeployKeysToolDefinitions()).toHaveLength(2);
+      expect(deployKeysToolRegistry.size).toBe(2);
     });
 
     it('declares the Free-tier requirement on both tools', () => {

--- a/tests/unit/entities/deploy-keys/registry.test.ts
+++ b/tests/unit/entities/deploy-keys/registry.test.ts
@@ -104,6 +104,13 @@ describe('Deploy Keys Registry', () => {
       const [url] = lastCall();
       expect(url).toBe('https://gitlab.example.com/api/v4/projects/123/deploy_keys/7');
     });
+
+    it('rejects public combined with project_id (instance-only flag)', async () => {
+      await expect(
+        browse().handler({ action: 'list', project_id: '123', public: true }),
+      ).rejects.toThrow();
+      expect(mockEnhancedFetch).not.toHaveBeenCalled();
+    });
   });
 
   describe('manage_deploy_key', () => {

--- a/tests/unit/entities/deploy-keys/registry.test.ts
+++ b/tests/unit/entities/deploy-keys/registry.test.ts
@@ -105,6 +105,14 @@ describe('Deploy Keys Registry', () => {
       expect(url).toBe('https://gitlab.example.com/api/v4/projects/123/deploy_keys/7');
     });
 
+    it('accepts a string boolean for public on the instance list', async () => {
+      mockOk([{ id: 1 }]);
+      await browse().handler({ action: 'list', public: 'true' });
+
+      const [url] = lastCall();
+      expect(url).toContain('public=true');
+    });
+
     it('rejects public combined with project_id (instance-only flag)', async () => {
       await expect(
         browse().handler({ action: 'list', project_id: '123', public: true }),

--- a/tests/unit/entities/deploy-keys/registry.test.ts
+++ b/tests/unit/entities/deploy-keys/registry.test.ts
@@ -2,58 +2,22 @@ import {
   deployKeysToolRegistry,
   getDeployKeysReadOnlyToolNames,
 } from '../../../../src/entities/deploy-keys/registry';
-import { enhancedFetch } from '../../../../src/utils/fetch';
+import {
+  installFetchMock,
+  mockOk,
+  mockNoContent,
+  lastFetchCall as lastCall,
+  mockEnhancedFetch,
+} from '../../helpers/fetch-mock';
 
 jest.mock('../../../../src/utils/fetch', () => ({
   enhancedFetch: jest.fn(),
 }));
 
-const mockEnhancedFetch = enhancedFetch as jest.MockedFunction<typeof enhancedFetch>;
-
-const originalEnv = process.env;
-
-beforeAll(() => {
-  process.env = {
-    ...originalEnv,
-    GITLAB_API_URL: 'https://gitlab.example.com',
-    GITLAB_TOKEN: 'test-token-12345',
-  };
-});
-
-afterAll(() => {
-  process.env = originalEnv;
-});
-
-beforeEach(() => {
-  jest.clearAllMocks();
-  jest.resetAllMocks();
-  mockEnhancedFetch.mockReset();
-});
-
-function mockOk(payload: unknown): void {
-  mockEnhancedFetch.mockResolvedValueOnce({
-    ok: true,
-    status: 200,
-    statusText: 'OK',
-    json: jest.fn().mockResolvedValue(payload),
-  } as unknown as Response);
-}
-
-function mockNoContent(): void {
-  mockEnhancedFetch.mockResolvedValueOnce({
-    ok: true,
-    status: 204,
-    statusText: 'No Content',
-  } as unknown as Response);
-}
+installFetchMock();
 
 const browse = () => deployKeysToolRegistry.get('browse_deploy_keys')!;
 const manage = () => deployKeysToolRegistry.get('manage_deploy_key')!;
-
-function lastCall(): [string, RequestInit | undefined] {
-  const call = mockEnhancedFetch.mock.calls.at(-1)!;
-  return [call[0], call[1]];
-}
 
 describe('Deploy Keys Registry', () => {
   describe('Registry Structure', () => {

--- a/tests/unit/entities/job-token-scope/registry.test.ts
+++ b/tests/unit/entities/job-token-scope/registry.test.ts
@@ -85,6 +85,11 @@ describe('Job Token Scope Registry', () => {
       expect(browse().requirements?.actions?.list_groups?.minVersion).toBe('16.0');
       expect(manage().requirements?.actions?.add_group?.minVersion).toBe('16.0');
     });
+
+    it('is gated by the shared USE_CI_TOKENS umbrella flag', () => {
+      expect(browse().gate?.envVar).toBe('USE_CI_TOKENS');
+      expect(manage().gate?.envVar).toBe('USE_CI_TOKENS');
+    });
   });
 
   describe('browse_job_token_scope', () => {

--- a/tests/unit/entities/job-token-scope/registry.test.ts
+++ b/tests/unit/entities/job-token-scope/registry.test.ts
@@ -4,61 +4,22 @@ import {
   getJobTokenScopeToolDefinitions,
   getFilteredJobTokenScopeTools,
 } from '../../../../src/entities/job-token-scope/registry';
-import { enhancedFetch } from '../../../../src/utils/fetch';
+import {
+  installFetchMock,
+  mockOk,
+  mockNoContent,
+  lastFetchCall as lastCall,
+  mockEnhancedFetch,
+} from '../../helpers/fetch-mock';
 
 jest.mock('../../../../src/utils/fetch', () => ({
   enhancedFetch: jest.fn(),
 }));
 
-const mockEnhancedFetch = enhancedFetch as jest.MockedFunction<typeof enhancedFetch>;
-
-const originalEnv = process.env;
-
-beforeAll(() => {
-  process.env = {
-    ...originalEnv,
-    GITLAB_API_URL: 'https://gitlab.example.com',
-    GITLAB_TOKEN: 'test-token-12345',
-  };
-});
-
-afterAll(() => {
-  process.env = originalEnv;
-});
-
-beforeEach(() => {
-  jest.clearAllMocks();
-  jest.resetAllMocks();
-  mockEnhancedFetch.mockReset();
-});
-
-/** Resolve enhancedFetch into an ok JSON response. */
-function mockOk(payload: unknown): void {
-  mockEnhancedFetch.mockResolvedValueOnce({
-    ok: true,
-    status: 200,
-    statusText: 'OK',
-    json: jest.fn().mockResolvedValue(payload),
-  } as unknown as Response);
-}
-
-/** Resolve enhancedFetch into a 204 No Content response (delete). */
-function mockNoContent(): void {
-  mockEnhancedFetch.mockResolvedValueOnce({
-    ok: true,
-    status: 204,
-    statusText: 'No Content',
-  } as unknown as Response);
-}
+installFetchMock();
 
 const browse = () => jobTokenScopeToolRegistry.get('browse_job_token_scope')!;
 const manage = () => jobTokenScopeToolRegistry.get('manage_job_token_scope')!;
-
-/** Last enhancedFetch call: [url, init?]. */
-function lastCall(): [string, RequestInit | undefined] {
-  const call = mockEnhancedFetch.mock.calls.at(-1)!;
-  return [call[0], call[1]];
-}
 
 describe('Job Token Scope Registry', () => {
   describe('Registry Structure', () => {

--- a/tests/unit/helpers/fetch-mock.ts
+++ b/tests/unit/helpers/fetch-mock.ts
@@ -1,0 +1,64 @@
+import { enhancedFetch } from '../../../src/utils/fetch';
+
+/**
+ * Shared fetch-mock utilities for entity registry unit tests.
+ *
+ * Mock ISOLATION is preserved: every test file still declares its own
+ * `jest.mock('.../utils/fetch', () => ({ enhancedFetch: jest.fn() }))`, so each
+ * file gets a fresh mock in its own module registry. These helpers only remove
+ * the identical lifecycle/response boilerplate that would otherwise be copied
+ * verbatim into every entity test file.
+ */
+export const mockEnhancedFetch = enhancedFetch as jest.MockedFunction<typeof enhancedFetch>;
+
+/**
+ * Register the per-file lifecycle: a test GitLab environment for the suite and a
+ * clean mock before each test. Call once at the top level of a test file that has
+ * already declared its own `jest.mock('.../utils/fetch')`.
+ */
+export function installFetchMock(): void {
+  const originalEnv = process.env;
+
+  beforeAll(() => {
+    process.env = {
+      ...originalEnv,
+      GITLAB_API_URL: 'https://gitlab.example.com',
+      GITLAB_TOKEN: 'test-token-12345',
+    };
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.resetAllMocks();
+    mockEnhancedFetch.mockReset();
+  });
+}
+
+/** Resolve the next enhancedFetch call into an ok JSON response. */
+export function mockOk(payload: unknown): void {
+  mockEnhancedFetch.mockResolvedValueOnce({
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    json: jest.fn().mockResolvedValue(payload),
+  } as unknown as Response);
+}
+
+/** Resolve the next enhancedFetch call into a 204 No Content response (delete). */
+export function mockNoContent(): void {
+  mockEnhancedFetch.mockResolvedValueOnce({
+    ok: true,
+    status: 204,
+    statusText: 'No Content',
+  } as unknown as Response);
+}
+
+/** Last enhancedFetch call as [url, init?]. */
+export function lastFetchCall(): [string, RequestInit | undefined] {
+  const call = mockEnhancedFetch.mock.calls.at(-1)!;
+  return [call[0], call[1]];
+}


### PR DESCRIPTION
## Summary

Adds **deploy key management** and groups it with the CI/CD job token scope tools (from #452) behind a single `USE_CI_TOKENS` umbrella flag, exposed as a `ci_tokens` profile feature and enabled in the `ci` and `devops` built-in profiles.

## Tools

**`browse_deploy_keys`** (read-only):
- `list` — a project's deploy keys, or all instance keys when `project_id` is omitted (admin only)
- `get` — a single project deploy key

**`manage_deploy_key`**:
- `add` — register a new SSH public key (title, key, optional `can_push`/`expires_at`)
- `enable` — attach an existing key from another project
- `update` — change title or `can_push`
- `delete` — remove from the project

## REST, not GraphQL

Verified against the GitLab docs: the [GraphQL reference](https://docs.gitlab.com/api/graphql/reference/) has **no deploy key support** (no `deployKey*` mutations, no `Project.deployKeys`, no `DeployKey` type). Deploy keys exist only in [REST](https://docs.gitlab.com/api/deploy_keys/), all Free tier. So this is REST — an API constraint, not a design choice — consistent with the existing entity layer.

## Umbrella gating

Deploy keys and the job token scope tools are both CI access-credential management. Rather than two separate per-entity flags, both are now gated by a single **`USE_CI_TOKENS`** (replaces the just-merged `USE_JOB_TOKEN_SCOPE`). Surfaced as a `ci_tokens` profile feature and turned on in the `ci` and `devops` profiles.

## Testing

- 13 unit tests for deploy keys (every action's endpoint/method/body, string→number coercion, schema rejection) + umbrella-gate assertions on both entities. 100% coverage on the new files.
- Integration test against the live instance (GitLab 19.0.0-ee): generates a fresh ed25519 key, adds it to a project, reads it back, updates `can_push`, enables it on a second project, and deletes it everywhere. **Passes.**
- Full unit suite: 151 suites / 4956 tests pass. Lint/build clean.

Closes #440