### PR TITLE
chore(shared): mark ci_job_token_scope_enabled as deprecated

### DIFF
--- a/src/entities/shared.ts
+++ b/src/entities/shared.ts
@@ -141,6 +141,12 @@ export const GitLabProjectSchema = z.object({
   ci_delete_pipelines_in_seconds: z.number().nullable().optional(),
   ci_forward_deployment_enabled: flexibleBoolean.optional(),
   ci_forward_deployment_rollback_allowed: flexibleBoolean.optional(),
+  /**
+   * @deprecated Removed from the Projects API response on GitLab 19.0+ (always
+   * absent there; hardcoded to false on 18.x). Read-only and tolerant: do not
+   * add writers, and prefer the dedicated job token scope settings endpoints
+   * (browse_job_token_scope / manage_job_token_scope) for inbound/outbound scope.
+   */
   ci_job_token_scope_enabled: flexibleBoolean.optional(),
   ci_separated_caches: flexibleBoolean.optional(),
   ci_allow_fork_pipelines_to_run_in_parent_project: flexibleBoolean.optional(),


### PR DESCRIPTION
## Summary

GitLab 19.0 removes `ci_job_token_scope_enabled` from the Projects API response (always absent on 19.0+; hardcoded to `false` on 18.x). Our reader in `entities/shared.ts` is already tolerant (`flexibleBoolean.optional()`), so nothing breaks, but the dead field had no warning.

## Changes

- Add a `@deprecated` JSDoc above `ci_job_token_scope_enabled` in `src/entities/shared.ts`: marks it removed on 19.0+, read-only/tolerant, do not add writers, and points to the dedicated job token scope endpoints (`browse_job_token_scope` / `manage_job_token_scope`).

Skipped the optional one-time `logWarn`: it adds runtime noise for a field that is simply absent on supported versions; the JSDoc is the right guard.

## Testing

Comment-only change (no behaviour change). `yarn lint` and `yarn build` pass.

Closes #444