### PR TITLE
feat(environments): expose Environments and Deployments

### DIFF
--- a/docs/tools/ci-cd.md
+++ b/docs/tools/ci-cd.md
@@ -21,7 +21,7 @@ Pipeline management, job control, logs, and CI/CD variable configuration.
 | `browse_variables` | Query | List and get CI/CD variables |
 | `manage_variable` | Command | Create, update, delete variables |
 | `browse_environments` | Query | List environments and deployments |
-| `manage_environment` | Command | Create, stop, delete environments; update deployment status |
+| `manage_environment` | Command | Create, update, stop, delete environments; update deployment status |
 
 ## browse_pipelines
 

--- a/docs/tools/ci-cd.md
+++ b/docs/tools/ci-cd.md
@@ -20,6 +20,8 @@ Pipeline management, job control, logs, and CI/CD variable configuration.
 | `manage_pipeline_job` | Command | Play, retry, cancel individual jobs |
 | `browse_variables` | Query | List and get CI/CD variables |
 | `manage_variable` | Command | Create, update, delete variables |
+| `browse_environments` | Query | List environments and deployments |
+| `manage_environment` | Command | Create, stop, delete environments; update deployment status |
 
 ## browse_pipelines
 
@@ -295,6 +297,101 @@ Manage CI/CD environment variables with scoping and protection.
 | `masked` | Hidden in job logs (requires 8+ chars, specific charset) |
 | `environment_scope` | `*` for all, or specific like `production` |
 | `variable_type` | `env_var` (default) or `file` |
+
+## browse_environments
+
+Inspect environments and their deployment history. Gated by `USE_ENVIRONMENTS`.
+
+### Actions
+
+<!-- @autogen:tool browse_environments -->
+| Action | Description |
+|--------|-------------|
+| `list` | List environments for a project |
+| `get` | Get a single environment by ID, including its last deployment |
+| `list_deployments` | List deployments for a project, optionally filtered by environment |
+<!-- @autogen:end -->
+
+### Examples
+
+::: code-group
+
+```json [List environments]
+{
+  "action": "list",
+  "project_id": "my-org/api",
+  "states": "available"
+}
+```
+
+```json [Get environment]
+{
+  "action": "get",
+  "project_id": "my-org/api",
+  "environment_id": 42
+}
+```
+
+```json [List deployments]
+{
+  "action": "list_deployments",
+  "project_id": "my-org/api",
+  "environment": "production",
+  "status": "success"
+}
+```
+
+:::
+
+## manage_environment
+
+Create and control environments, and update deployment status. Deployments are
+folded into this tool rather than a separate pair. Gated by `USE_ENVIRONMENTS`.
+
+### Actions
+
+<!-- @autogen:tool manage_environment -->
+| Action | Description |
+|--------|-------------|
+| `create` | Create a new environment |
+| `update` | Update an existing environment (name cannot be changed via the API) |
+| `stop` | Stop an environment (required before it can be deleted) |
+| `delete` | Delete a stopped environment |
+| `update_deployment_status` | Update the status of a deployment. Only deployments not tied to a pipeline job can be updated. |
+<!-- @autogen:end -->
+
+### Examples
+
+::: code-group
+
+```json [Create environment]
+{
+  "action": "create",
+  "project_id": "my-org/api",
+  "name": "staging",
+  "external_url": "https://staging.example.com",
+  "tier": "staging"
+}
+```
+
+```json [Stop environment]
+{
+  "action": "stop",
+  "project_id": "my-org/api",
+  "environment_id": 42
+}
+```
+
+```json [Update deployment status]
+{
+  "action": "update_deployment_status",
+  "project_id": "my-org/api",
+  "deployment_id": 1001,
+  "status": "success"
+}
+```
+
+:::
 
 ## Related Guides
 

--- a/src/entities/environments/registry.ts
+++ b/src/entities/environments/registry.ts
@@ -1,0 +1,150 @@
+import * as z from 'zod';
+import { BrowseEnvironmentsSchema } from './schema-readonly';
+import { ManageEnvironmentSchema } from './schema';
+import { gitlab, toQuery } from '../../utils/gitlab-api';
+import { ToolRegistry, EnhancedToolDefinition } from '../../types';
+import { assertActionAllowed } from '../utils';
+
+/**
+ * Environments tools registry - 2 CQRS tools
+ *
+ * browse_environments (Query): list, get, list_deployments
+ * manage_environment (Command): create, update, stop, delete, update_deployment_status
+ *
+ * Deployments are folded into these tools as actions (list_deployments,
+ * update_deployment_status) rather than a separate CQRS pair, to keep the MCP
+ * tool count lean. Gated behind USE_ENVIRONMENTS. Free tier.
+ */
+export const environmentsToolRegistry: ToolRegistry = new Map<string, EnhancedToolDefinition>([
+  // ============================================================================
+  // browse_environments - CQRS Query Tool (discriminated union schema)
+  // ============================================================================
+  [
+    'browse_environments',
+    {
+      name: 'browse_environments',
+      description:
+        'Inspect project environments and their deployments. Actions: list (environments filtered by state/name), get (single environment with its last deployment), list_deployments (deployment history, filterable by environment and status). Related: manage_environment to create, update, stop, or delete environments and update deployment status.',
+      inputSchema: z.toJSONSchema(BrowseEnvironmentsSchema),
+      requirements: { default: { tier: 'free', minVersion: '8.0' } },
+      gate: { envVar: 'USE_ENVIRONMENTS', defaultValue: true },
+      handler: async (args: unknown): Promise<unknown> => {
+        const input = BrowseEnvironmentsSchema.parse(args);
+
+        assertActionAllowed('browse_environments', input.action);
+
+        const encodedProjectId = encodeURIComponent(input.project_id);
+
+        switch (input.action) {
+          case 'list': {
+            const { action: _action, project_id: _projectId, ...queryOptions } = input;
+            return gitlab.get(`projects/${encodedProjectId}/environments`, {
+              query: toQuery(queryOptions, []),
+            });
+          }
+
+          case 'get': {
+            return gitlab.get(`projects/${encodedProjectId}/environments/${input.environment_id}`);
+          }
+
+          case 'list_deployments': {
+            const { action: _action, project_id: _projectId, ...queryOptions } = input;
+            return gitlab.get(`projects/${encodedProjectId}/deployments`, {
+              query: toQuery(queryOptions, []),
+            });
+          }
+
+          /* istanbul ignore next -- unreachable with Zod discriminatedUnion */
+          default:
+            throw new Error(`Unknown action: ${(input as { action: string }).action}`);
+        }
+      },
+    },
+  ],
+
+  // ============================================================================
+  // manage_environment - CQRS Command Tool (discriminated union schema)
+  // ============================================================================
+  [
+    'manage_environment',
+    {
+      name: 'manage_environment',
+      description:
+        'Create and control project environments and deployment status. Actions: create (new environment), update (external_url/tier/description), stop (required before delete), delete (stopped environment), update_deployment_status (set a non-pipeline deployment to running/success/failed/canceled). Related: browse_environments to list and inspect.',
+      inputSchema: z.toJSONSchema(ManageEnvironmentSchema),
+      requirements: { default: { tier: 'free', minVersion: '8.0' } },
+      gate: { envVar: 'USE_ENVIRONMENTS', defaultValue: true },
+      handler: async (args: unknown): Promise<unknown> => {
+        const input = ManageEnvironmentSchema.parse(args);
+
+        assertActionAllowed('manage_environment', input.action);
+
+        const encodedProjectId = encodeURIComponent(input.project_id);
+
+        switch (input.action) {
+          case 'create': {
+            const { name, external_url, tier, description } = input;
+            const body: Record<string, unknown> = { name };
+            if (external_url !== undefined) body.external_url = external_url;
+            if (tier !== undefined) body.tier = tier;
+            if (description !== undefined) body.description = description;
+
+            return gitlab.post(`projects/${encodedProjectId}/environments`, {
+              body,
+              contentType: 'json',
+            });
+          }
+
+          case 'update': {
+            const { environment_id, external_url, tier, description } = input;
+            const body: Record<string, unknown> = {};
+            if (external_url !== undefined) body.external_url = external_url;
+            if (tier !== undefined) body.tier = tier;
+            if (description !== undefined) body.description = description;
+
+            return gitlab.put(`projects/${encodedProjectId}/environments/${environment_id}`, {
+              body,
+              contentType: 'json',
+            });
+          }
+
+          case 'stop': {
+            const { environment_id, force } = input;
+            const body: Record<string, unknown> = {};
+            if (force !== undefined) body.force = force;
+
+            return gitlab.post(`projects/${encodedProjectId}/environments/${environment_id}/stop`, {
+              body,
+              contentType: 'json',
+            });
+          }
+
+          case 'delete': {
+            const { environment_id } = input;
+            await gitlab.delete(`projects/${encodedProjectId}/environments/${environment_id}`);
+            return { deleted: true, environment_id };
+          }
+
+          case 'update_deployment_status': {
+            const { deployment_id, status } = input;
+            return gitlab.put(`projects/${encodedProjectId}/deployments/${deployment_id}`, {
+              body: { status },
+              contentType: 'json',
+            });
+          }
+
+          /* istanbul ignore next -- unreachable with Zod discriminatedUnion */
+          default:
+            throw new Error(`Unknown action: ${(input as { action: string }).action}`);
+        }
+      },
+    },
+  ],
+]);
+
+/**
+ * Get read-only tool names from the registry
+ */
+export function getEnvironmentsReadOnlyToolNames(): string[] {
+  return ['browse_environments'];
+}

--- a/src/entities/environments/schema-readonly.ts
+++ b/src/entities/environments/schema-readonly.ts
@@ -1,0 +1,96 @@
+import { z } from 'zod';
+import { requiredId, paginationFields } from '../utils';
+
+// ============================================================================
+// browse_environments - CQRS Query Tool (discriminated union schema)
+// Actions: list, get, list_deployments
+// Uses z.discriminatedUnion() for type-safe action handling.
+// Schema pipeline flattens to flat JSON Schema for AI clients that don't support oneOf.
+// ============================================================================
+
+// --- Shared fields ---
+const projectIdField = requiredId.describe(
+  "Project ID or URL-encoded path (e.g., 'my-group/my-project')",
+);
+const environmentIdField = z.coerce
+  .number()
+  .int()
+  .positive()
+  .describe('Numeric ID of the environment');
+
+// --- Action: list ---
+const ListEnvironmentsSchema = z.object({
+  action: z.literal('list').describe('List environments for a project'),
+  project_id: projectIdField,
+  name: z.string().optional().describe('Return the environment with this exact name'),
+  search: z
+    .string()
+    .optional()
+    .describe('Return environments matching this search term (min 3 characters)'),
+  states: z
+    .enum(['available', 'stopping', 'stopped'])
+    .optional()
+    .describe('Filter environments by state'),
+  ...paginationFields(),
+});
+
+// --- Action: get ---
+const GetEnvironmentSchema = z.object({
+  action: z
+    .literal('get')
+    .describe('Get a single environment by ID, including its last deployment'),
+  project_id: projectIdField,
+  environment_id: environmentIdField,
+});
+
+// --- Action: list_deployments ---
+const ListDeploymentsSchema = z.object({
+  action: z
+    .literal('list_deployments')
+    .describe('List deployments for a project, optionally filtered by environment'),
+  project_id: projectIdField,
+  environment: z.string().optional().describe('Filter deployments by environment name'),
+  status: z
+    .enum(['created', 'running', 'success', 'failed', 'canceled', 'skipped', 'blocked'])
+    .optional()
+    .describe('Filter deployments by status'),
+  order_by: z
+    .enum(['id', 'iid', 'created_at', 'updated_at', 'finished_at', 'ref'])
+    .optional()
+    .describe('Order deployments by field (default: id)'),
+  sort: z.enum(['asc', 'desc']).optional().describe('Sort direction (default: asc)'),
+  updated_after: z
+    .string()
+    .optional()
+    .describe('Return deployments updated after this ISO 8601 date'),
+  updated_before: z
+    .string()
+    .optional()
+    .describe('Return deployments updated before this ISO 8601 date'),
+  finished_after: z
+    .string()
+    .optional()
+    .describe(
+      'Return deployments finished after this ISO 8601 date (requires order_by=finished_at)',
+    ),
+  finished_before: z
+    .string()
+    .optional()
+    .describe(
+      'Return deployments finished before this ISO 8601 date (requires order_by=finished_at)',
+    ),
+  ...paginationFields(),
+});
+
+// --- Discriminated union combining all actions ---
+export const BrowseEnvironmentsSchema = z.discriminatedUnion('action', [
+  ListEnvironmentsSchema,
+  GetEnvironmentSchema,
+  ListDeploymentsSchema,
+]);
+
+// ============================================================================
+// Type exports
+// ============================================================================
+
+export type BrowseEnvironmentsInput = z.infer<typeof BrowseEnvironmentsSchema>;

--- a/src/entities/environments/schema-readonly.ts
+++ b/src/entities/environments/schema-readonly.ts
@@ -25,6 +25,7 @@ const ListEnvironmentsSchema = z.object({
   name: z.string().optional().describe('Return the environment with this exact name'),
   search: z
     .string()
+    .min(3)
     .optional()
     .describe('Return environments matching this search term (min 3 characters)'),
   states: z

--- a/src/entities/environments/schema.ts
+++ b/src/entities/environments/schema.ts
@@ -23,6 +23,7 @@ const tierField = z
   .describe('Deployment tier of the environment');
 const externalUrlField = z
   .string()
+  .url()
   .describe(
     'URL where the deployed environment can be reached (e.g., https://staging.example.com)',
   );
@@ -84,13 +85,27 @@ const UpdateDeploymentStatusSchema = z.object({
 });
 
 // --- Discriminated union combining all actions ---
-export const ManageEnvironmentSchema = z.discriminatedUnion('action', [
-  CreateEnvironmentSchema,
-  UpdateEnvironmentSchema,
-  StopEnvironmentSchema,
-  DeleteEnvironmentSchema,
-  UpdateDeploymentStatusSchema,
-]);
+export const ManageEnvironmentSchema = z
+  .discriminatedUnion('action', [
+    CreateEnvironmentSchema,
+    UpdateEnvironmentSchema,
+    StopEnvironmentSchema,
+    DeleteEnvironmentSchema,
+    UpdateDeploymentStatusSchema,
+  ])
+  // An update with no fields would send an empty body and be rejected by GitLab;
+  // require at least one updatable field.
+  .refine(
+    (data) =>
+      data.action !== 'update' ||
+      data.external_url !== undefined ||
+      data.tier !== undefined ||
+      data.description !== undefined,
+    {
+      message: 'update requires at least one of: external_url, tier, description',
+      path: ['external_url'],
+    },
+  );
 
 // ============================================================================
 // Type exports

--- a/src/entities/environments/schema.ts
+++ b/src/entities/environments/schema.ts
@@ -1,0 +1,99 @@
+import { z } from 'zod';
+import { requiredId, flexibleBoolean } from '../utils';
+
+// ============================================================================
+// manage_environment - CQRS Command Tool (discriminated union schema)
+// Actions: create, update, stop, delete, update_deployment_status
+// Deployments are folded in as the update_deployment_status action rather than a
+// separate tool, keeping the MCP tool count lean.
+// Uses z.discriminatedUnion() for type-safe action handling.
+// ============================================================================
+
+// --- Shared fields ---
+const projectIdField = requiredId.describe(
+  "Project ID or URL-encoded path (e.g., 'my-group/my-project')",
+);
+const environmentIdField = z.coerce
+  .number()
+  .int()
+  .positive()
+  .describe('Numeric ID of the environment');
+const tierField = z
+  .enum(['production', 'staging', 'testing', 'development', 'other'])
+  .describe('Deployment tier of the environment');
+const externalUrlField = z
+  .string()
+  .describe(
+    'URL where the deployed environment can be reached (e.g., https://staging.example.com)',
+  );
+const descriptionField = z.string().describe('Description of the environment');
+
+// --- Action: create ---
+const CreateEnvironmentSchema = z.object({
+  action: z.literal('create').describe('Create a new environment'),
+  project_id: projectIdField,
+  name: z.string().describe('Name of the environment'),
+  external_url: externalUrlField.optional(),
+  tier: tierField.optional(),
+  description: descriptionField.optional(),
+});
+
+// --- Action: update ---
+const UpdateEnvironmentSchema = z.object({
+  action: z
+    .literal('update')
+    .describe('Update an existing environment (name cannot be changed via the API)'),
+  project_id: projectIdField,
+  environment_id: environmentIdField,
+  external_url: externalUrlField.optional(),
+  tier: tierField.optional(),
+  description: descriptionField.optional(),
+});
+
+// --- Action: stop ---
+const StopEnvironmentSchema = z.object({
+  action: z.literal('stop').describe('Stop an environment (required before it can be deleted)'),
+  project_id: projectIdField,
+  environment_id: environmentIdField,
+  force: flexibleBoolean
+    .optional()
+    .describe('Force the stop, skipping the on_stop action if one is defined'),
+});
+
+// --- Action: delete ---
+const DeleteEnvironmentSchema = z.object({
+  action: z.literal('delete').describe('Delete a stopped environment'),
+  project_id: projectIdField,
+  environment_id: environmentIdField,
+});
+
+// --- Action: update_deployment_status ---
+const UpdateDeploymentStatusSchema = z.object({
+  action: z
+    .literal('update_deployment_status')
+    .describe(
+      'Update the status of a deployment. Only deployments not tied to a pipeline job can be updated.',
+    ),
+  project_id: projectIdField,
+  deployment_id: z.coerce
+    .number()
+    .int()
+    .positive()
+    .describe('Numeric ID of the deployment to update'),
+  status: z.enum(['running', 'success', 'failed', 'canceled']).describe('New deployment status'),
+});
+
+// --- Discriminated union combining all actions ---
+export const ManageEnvironmentSchema = z.discriminatedUnion('action', [
+  CreateEnvironmentSchema,
+  UpdateEnvironmentSchema,
+  StopEnvironmentSchema,
+  DeleteEnvironmentSchema,
+  UpdateDeploymentStatusSchema,
+]);
+
+// ============================================================================
+// Type exports
+// ============================================================================
+
+export type ManageEnvironmentInput = z.infer<typeof ManageEnvironmentSchema>;

--- a/src/registry-manager.ts
+++ b/src/registry-manager.ts
@@ -44,6 +44,10 @@ import {
   getDeployKeysReadOnlyToolNames,
 } from './entities/deploy-keys/registry';
 import {
+  environmentsToolRegistry,
+  getEnvironmentsReadOnlyToolNames,
+} from './entities/environments/registry';
+import {
   GITLAB_BASE_URL,
   GITLAB_READ_ONLY_MODE,
   GITLAB_DENIED_TOOLS_REGEX,
@@ -65,6 +69,7 @@ import {
   USE_SEARCH,
   USE_ITERATIONS,
   USE_CI_TOKENS,
+  USE_ENVIRONMENTS,
   getToolDescriptionOverrides,
 } from './config';
 import { isToolAvailable, getRestrictedParameters } from './services/InstanceCapabilities';
@@ -205,6 +210,10 @@ class RegistryManager {
       this.registries.set('deploy-keys', deployKeysToolRegistry);
     }
 
+    if (USE_ENVIRONMENTS) {
+      this.registries.set('environments', environmentsToolRegistry);
+    }
+
     // All entity registries have been migrated to the new pattern!
   }
 
@@ -302,6 +311,10 @@ class RegistryManager {
     if (USE_CI_TOKENS) {
       readOnlyTools.push(...getJobTokenScopeReadOnlyToolNames());
       readOnlyTools.push(...getDeployKeysReadOnlyToolNames());
+    }
+
+    if (USE_ENVIRONMENTS) {
+      readOnlyTools.push(...getEnvironmentsReadOnlyToolNames());
     }
 
     return readOnlyTools;
@@ -703,6 +716,7 @@ class RegistryManager {
     const useSearch = process.env.USE_SEARCH !== 'false';
     const useIterations = process.env.USE_ITERATIONS !== 'false';
     const useCiTokens = process.env.USE_CI_TOKENS !== 'false';
+    const useEnvironments = process.env.USE_ENVIRONMENTS !== 'false';
 
     // Build registries map based on dynamic feature flags
     const registriesToUse = new Map<string, ToolRegistry>();
@@ -734,6 +748,7 @@ class RegistryManager {
       registriesToUse.set('job-token-scope', jobTokenScopeToolRegistry);
       registriesToUse.set('deploy-keys', deployKeysToolRegistry);
     }
+    if (useEnvironments) registriesToUse.set('environments', environmentsToolRegistry);
 
     // Dynamically load description overrides
     const descOverrides = getToolDescriptionOverrides();
@@ -834,6 +849,7 @@ class RegistryManager {
       iterationsToolRegistry,
       jobTokenScopeToolRegistry,
       deployKeysToolRegistry,
+      environmentsToolRegistry,
     ];
 
     for (const registry of allRegistries) {

--- a/tests/integration/schemas/environments.test.ts
+++ b/tests/integration/schemas/environments.test.ts
@@ -1,0 +1,207 @@
+/**
+ * Environments Schema Integration Tests
+ * Exercises the environment lifecycle against a real GitLab API: create an
+ * environment, read it back, list it, update it, then create a manual deployment
+ * and drive its status through the update_deployment_status action before stopping
+ * and deleting the environment.
+ */
+
+import { BrowseEnvironmentsSchema } from '../../../src/entities/environments/schema-readonly';
+import { ManageEnvironmentSchema } from '../../../src/entities/environments/schema';
+import { gitlab } from '../../../src/utils/gitlab-api';
+import { IntegrationTestHelper } from '../helpers/registry-helper';
+
+interface Environment {
+  id: number;
+  name: string;
+  state: string;
+  external_url?: string;
+  description?: string;
+}
+
+interface Deployment {
+  id: number;
+  status: string;
+}
+
+describe('Environments Schema - GitLab Integration', () => {
+  let helper: IntegrationTestHelper;
+
+  beforeAll(async () => {
+    if (!process.env.GITLAB_TOKEN) {
+      throw new Error('GITLAB_TOKEN environment variable is required');
+    }
+    helper = new IntegrationTestHelper();
+    await helper.initialize();
+  });
+
+  /** First project in the mandated `test` root group, or null when none exist. */
+  async function firstTestProject(): Promise<{ path_with_namespace: string; id: number } | null> {
+    const all = (await helper.listProjects({ per_page: 50 })) as {
+      path_with_namespace: string;
+      id: number;
+    }[];
+    return all.find((p) => p.path_with_namespace.startsWith('test/')) ?? null;
+  }
+
+  it('creates, reads, lists, updates, and deletes an environment', async () => {
+    const project = await firstTestProject();
+    if (!project) {
+      console.log('No test/ project available - skipping environment lifecycle');
+      return;
+    }
+    const name = `it-env-${Date.now()}`;
+
+    const created = (await helper.executeTool(
+      'manage_environment',
+      ManageEnvironmentSchema.parse({
+        action: 'create',
+        project_id: project.path_with_namespace,
+        name,
+        external_url: 'https://it.example.com',
+        tier: 'testing',
+      }),
+    )) as Environment;
+    expect(created.id).toBeGreaterThan(0);
+    expect(created.name).toBe(name);
+
+    try {
+      const fetched = (await helper.executeTool(
+        'browse_environments',
+        BrowseEnvironmentsSchema.parse({
+          action: 'get',
+          project_id: project.path_with_namespace,
+          environment_id: created.id,
+        }),
+      )) as Environment;
+      expect(fetched.id).toBe(created.id);
+
+      const listed = (await helper.executeTool(
+        'browse_environments',
+        BrowseEnvironmentsSchema.parse({
+          action: 'list',
+          project_id: project.path_with_namespace,
+          name,
+        }),
+      )) as Environment[];
+      expect(listed.some((e) => e.id === created.id)).toBe(true);
+
+      const updated = (await helper.executeTool(
+        'manage_environment',
+        ManageEnvironmentSchema.parse({
+          action: 'update',
+          project_id: project.path_with_namespace,
+          environment_id: created.id,
+          description: 'updated by integration test',
+        }),
+      )) as Environment;
+      expect(updated.description).toBe('updated by integration test');
+    } finally {
+      // An environment must be stopped before it can be deleted.
+      await helper.executeTool(
+        'manage_environment',
+        ManageEnvironmentSchema.parse({
+          action: 'stop',
+          project_id: project.path_with_namespace,
+          environment_id: created.id,
+        }),
+      );
+      await helper.executeTool(
+        'manage_environment',
+        ManageEnvironmentSchema.parse({
+          action: 'delete',
+          project_id: project.path_with_namespace,
+          environment_id: created.id,
+        }),
+      );
+    }
+  });
+
+  it('updates the status of a manually created deployment', async () => {
+    const project = await firstTestProject();
+    if (!project) {
+      console.log('No test/ project available - skipping deployment status update');
+      return;
+    }
+    const encodedId = encodeURIComponent(project.path_with_namespace);
+
+    // A manual deployment needs a real commit; skip if the repository is empty.
+    const commits = await gitlab.get<{ id: string }[]>(`projects/${encodedId}/repository/commits`, {
+      query: { per_page: 1 },
+    });
+    if (!Array.isArray(commits) || commits.length === 0) {
+      console.log('test/ project has no commits - skipping deployment status update');
+      return;
+    }
+    const sha = commits[0].id;
+    const details = await gitlab.get<{ default_branch?: string }>(`projects/${encodedId}`);
+    const ref = details.default_branch ?? 'main';
+    const envName = `it-deploy-env-${Date.now()}`;
+
+    // Create the deployment (and its environment) directly: deployment creation is
+    // not exposed as a tool action; update_deployment_status is the tool under test.
+    const deployment = await gitlab.post<Deployment>(`projects/${encodedId}/deployments`, {
+      body: { environment: envName, sha, ref, tag: false, status: 'running' },
+      contentType: 'json',
+    });
+    expect(deployment.id).toBeGreaterThan(0);
+
+    let environmentId: number | undefined;
+    try {
+      const updated = (await helper.executeTool(
+        'manage_environment',
+        ManageEnvironmentSchema.parse({
+          action: 'update_deployment_status',
+          project_id: project.path_with_namespace,
+          deployment_id: deployment.id,
+          status: 'success',
+        }),
+      )) as Deployment;
+      expect(updated.status).toBe('success');
+
+      const deployments = (await helper.executeTool(
+        'browse_environments',
+        BrowseEnvironmentsSchema.parse({
+          action: 'list_deployments',
+          project_id: project.path_with_namespace,
+          environment: envName,
+        }),
+      )) as Deployment[];
+      expect(deployments.some((d) => d.id === deployment.id)).toBe(true);
+
+      const envs = (await helper.executeTool(
+        'browse_environments',
+        BrowseEnvironmentsSchema.parse({
+          action: 'list',
+          project_id: project.path_with_namespace,
+          name: envName,
+        }),
+      )) as Environment[];
+      environmentId = envs.find((e) => e.name === envName)?.id;
+    } finally {
+      // Best-effort cleanup of the auto-created environment.
+      if (environmentId !== undefined) {
+        try {
+          await helper.executeTool(
+            'manage_environment',
+            ManageEnvironmentSchema.parse({
+              action: 'stop',
+              project_id: project.path_with_namespace,
+              environment_id: environmentId,
+            }),
+          );
+          await helper.executeTool(
+            'manage_environment',
+            ManageEnvironmentSchema.parse({
+              action: 'delete',
+              project_id: project.path_with_namespace,
+              environment_id: environmentId,
+            }),
+          );
+        } catch {
+          // environment may not be stoppable/deletable - leave it for manual cleanup
+        }
+      }
+    }
+  });
+});

--- a/tests/unit/entities/environments/registry.test.ts
+++ b/tests/unit/entities/environments/registry.test.ts
@@ -1,0 +1,228 @@
+import {
+  environmentsToolRegistry,
+  getEnvironmentsReadOnlyToolNames,
+} from '../../../../src/entities/environments/registry';
+import {
+  installFetchMock,
+  mockOk,
+  mockNoContent,
+  lastFetchCall as lastCall,
+  mockEnhancedFetch,
+} from '../../helpers/fetch-mock';
+
+jest.mock('../../../../src/utils/fetch', () => ({
+  enhancedFetch: jest.fn(),
+}));
+
+installFetchMock();
+
+const browse = () => environmentsToolRegistry.get('browse_environments')!;
+const manage = () => environmentsToolRegistry.get('manage_environment')!;
+
+const BASE = 'https://gitlab.example.com/api/v4';
+
+describe('Environments Registry', () => {
+  describe('Registry Structure', () => {
+    it('contains exactly the two CQRS tools', () => {
+      expect(Array.from(environmentsToolRegistry.keys())).toEqual([
+        'browse_environments',
+        'manage_environment',
+      ]);
+    });
+
+    it('exposes only the browse tool as read-only', () => {
+      expect(getEnvironmentsReadOnlyToolNames()).toEqual(['browse_environments']);
+    });
+
+    it('declares the Free-tier requirement on both tools', () => {
+      expect(browse().requirements?.default).toEqual({ tier: 'free', minVersion: '8.0' });
+      expect(manage().requirements?.default).toEqual({ tier: 'free', minVersion: '8.0' });
+    });
+
+    it('is gated by USE_ENVIRONMENTS', () => {
+      expect(browse().gate?.envVar).toBe('USE_ENVIRONMENTS');
+      expect(manage().gate?.envVar).toBe('USE_ENVIRONMENTS');
+    });
+  });
+
+  describe('browse_environments', () => {
+    it('list reads the project environments with state/search filters', async () => {
+      mockOk([{ id: 1, name: 'production' }]);
+      await browse().handler({
+        action: 'list',
+        project_id: 'group/project',
+        states: 'available',
+        search: 'prod',
+      });
+
+      const [url] = lastCall();
+      expect(url).toContain(`${BASE}/projects/group%2Fproject/environments?`);
+      expect(url).toContain('states=available');
+      expect(url).toContain('search=prod');
+      // action/project_id must not leak into the query string
+      expect(url).not.toContain('action=');
+      expect(url).not.toContain('project_id=');
+    });
+
+    it('get reads a single environment by numeric id', async () => {
+      mockOk({ id: 5, name: 'staging' });
+      await browse().handler({ action: 'get', project_id: '123', environment_id: 5 });
+
+      const [url] = lastCall();
+      expect(url).toBe(`${BASE}/projects/123/environments/5`);
+    });
+
+    it('coerces a string environment_id to a number in the path', async () => {
+      mockOk({ id: 5 });
+      await browse().handler({ action: 'get', project_id: '123', environment_id: '5' });
+
+      const [url] = lastCall();
+      expect(url).toBe(`${BASE}/projects/123/environments/5`);
+    });
+
+    it('list_deployments reads project deployments filtered by environment and status', async () => {
+      mockOk([{ id: 10, status: 'success' }]);
+      await browse().handler({
+        action: 'list_deployments',
+        project_id: '123',
+        environment: 'production',
+        status: 'success',
+      });
+
+      const [url] = lastCall();
+      expect(url).toContain(`${BASE}/projects/123/deployments?`);
+      expect(url).toContain('environment=production');
+      expect(url).toContain('status=success');
+    });
+
+    it('rejects an environment_id of zero at schema parse', async () => {
+      await expect(
+        browse().handler({ action: 'get', project_id: '123', environment_id: 0 }),
+      ).rejects.toThrow();
+      expect(mockEnhancedFetch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('manage_environment', () => {
+    it('create POSTs the environment payload', async () => {
+      mockOk({ id: 7, name: 'staging' });
+      await manage().handler({
+        action: 'create',
+        project_id: '123',
+        name: 'staging',
+        external_url: 'https://staging.example.com',
+        tier: 'staging',
+      });
+
+      const [url, init] = lastCall();
+      expect(url).toBe(`${BASE}/projects/123/environments`);
+      expect(init?.method).toBe('POST');
+      expect(JSON.parse(init?.body as string)).toEqual({
+        name: 'staging',
+        external_url: 'https://staging.example.com',
+        tier: 'staging',
+      });
+    });
+
+    it('create omits optional fields that were not provided', async () => {
+      mockOk({ id: 8, name: 'minimal' });
+      await manage().handler({ action: 'create', project_id: '123', name: 'minimal' });
+
+      const [, init] = lastCall();
+      expect(JSON.parse(init?.body as string)).toEqual({ name: 'minimal' });
+    });
+
+    it('update PUTs only the provided fields, without ids in the body', async () => {
+      mockOk({ id: 5 });
+      await manage().handler({
+        action: 'update',
+        project_id: '123',
+        environment_id: 5,
+        description: 'now with a description',
+      });
+
+      const [url, init] = lastCall();
+      expect(url).toBe(`${BASE}/projects/123/environments/5`);
+      expect(init?.method).toBe('PUT');
+      expect(JSON.parse(init?.body as string)).toEqual({ description: 'now with a description' });
+    });
+
+    it('update PUTs external_url and tier when provided', async () => {
+      mockOk({ id: 5 });
+      await manage().handler({
+        action: 'update',
+        project_id: '123',
+        environment_id: 5,
+        external_url: 'https://new.example.com',
+        tier: 'production',
+      });
+
+      const [, init] = lastCall();
+      expect(JSON.parse(init?.body as string)).toEqual({
+        external_url: 'https://new.example.com',
+        tier: 'production',
+      });
+    });
+
+    it('stop POSTs to the stop sub-resource with a coerced force flag', async () => {
+      mockOk({ id: 5, state: 'stopped' });
+      await manage().handler({
+        action: 'stop',
+        project_id: '123',
+        environment_id: 5,
+        force: 'true',
+      });
+
+      const [url, init] = lastCall();
+      expect(url).toBe(`${BASE}/projects/123/environments/5/stop`);
+      expect(init?.method).toBe('POST');
+      expect(JSON.parse(init?.body as string)).toEqual({ force: true });
+    });
+
+    it('delete removes the environment and echoes the id', async () => {
+      mockNoContent();
+      const result = await manage().handler({
+        action: 'delete',
+        project_id: '123',
+        environment_id: '5',
+      });
+
+      const [url, init] = lastCall();
+      expect(url).toBe(`${BASE}/projects/123/environments/5`);
+      expect(init?.method).toBe('DELETE');
+      expect(result).toEqual({ deleted: true, environment_id: 5 });
+    });
+
+    it('update_deployment_status PUTs the status to the deployment endpoint', async () => {
+      mockOk({ id: 9, status: 'success' });
+      await manage().handler({
+        action: 'update_deployment_status',
+        project_id: '123',
+        deployment_id: 9,
+        status: 'success',
+      });
+
+      const [url, init] = lastCall();
+      expect(url).toBe(`${BASE}/projects/123/deployments/9`);
+      expect(init?.method).toBe('PUT');
+      expect(JSON.parse(init?.body as string)).toEqual({ status: 'success' });
+    });
+
+    it('rejects an unknown deployment status at schema parse', async () => {
+      await expect(
+        manage().handler({
+          action: 'update_deployment_status',
+          project_id: '123',
+          deployment_id: 9,
+          status: 'skipped',
+        }),
+      ).rejects.toThrow();
+      expect(mockEnhancedFetch).not.toHaveBeenCalled();
+    });
+
+    it('rejects create without a name at schema parse', async () => {
+      await expect(manage().handler({ action: 'create', project_id: '123' })).rejects.toThrow();
+      expect(mockEnhancedFetch).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/unit/entities/environments/registry.test.ts
+++ b/tests/unit/entities/environments/registry.test.ts
@@ -101,6 +101,13 @@ describe('Environments Registry', () => {
       ).rejects.toThrow();
       expect(mockEnhancedFetch).not.toHaveBeenCalled();
     });
+
+    it('rejects a search term shorter than the documented 3-character minimum', async () => {
+      await expect(
+        browse().handler({ action: 'list', project_id: '123', search: 'ab' }),
+      ).rejects.toThrow();
+      expect(mockEnhancedFetch).not.toHaveBeenCalled();
+    });
   });
 
   describe('manage_environment', () => {
@@ -222,6 +229,25 @@ describe('Environments Registry', () => {
 
     it('rejects create without a name at schema parse', async () => {
       await expect(manage().handler({ action: 'create', project_id: '123' })).rejects.toThrow();
+      expect(mockEnhancedFetch).not.toHaveBeenCalled();
+    });
+
+    it('rejects create with a non-URL external_url at schema parse', async () => {
+      await expect(
+        manage().handler({
+          action: 'create',
+          project_id: '123',
+          name: 'staging',
+          external_url: 'not-a-url',
+        }),
+      ).rejects.toThrow();
+      expect(mockEnhancedFetch).not.toHaveBeenCalled();
+    });
+
+    it('rejects an update with no updatable fields (would send an empty body)', async () => {
+      await expect(
+        manage().handler({ action: 'update', project_id: '123', environment_id: 5 }),
+      ).rejects.toThrow();
       expect(mockEnhancedFetch).not.toHaveBeenCalled();
     });
   });


### PR DESCRIPTION
## Summary

Exposes GitLab Environments and Deployments as one CQRS pair, gated behind `USE_ENVIRONMENTS` (Free tier). Per the consolidation plan, deployments fold into the environment tools as actions rather than a separate pair, so the MCP tool count grows by exactly two.

- **`browse_environments`** (read-only): `list` (filter by state/name), `get` (single environment with its last deployment), `list_deployments` (project deployments, filterable by environment and status).
- **`manage_environment`**: `create`, `update` (external_url/tier/description), `stop` (required before delete), `delete`, `update_deployment_status` (drive a non-pipeline deployment to running/success/failed/canceled).

## Changes

- New entity `src/entities/environments/` (`schema-readonly.ts`, `schema.ts`, `registry.ts`) following the discriminated-union CQRS pattern.
- Registered in `registry-manager.ts` across all three tool paths (init/read-only, tierless, unfiltered) behind `USE_ENVIRONMENTS`.
- Profiles and the `USE_ENVIRONMENTS` flag were already plumbed (the matrix ships environments enabled for devops/developer/code-reviewer/senior-dev/team-lead/ci/admin/full-access/readonly and disabled for pm/junior-dev/security), so no profile changes were needed.
- Documented under `docs/tools/ci-cd.md` with auto-generated action tables.

## Testing

- Unit: 18 tests covering registry structure, gating, every action's URL/method/body, id coercion, and schema rejections. Full unit suite green (5000 tests).
- Integration: environment lifecycle (create → get → list → update → stop → delete) and deployment status update (manual deployment created via the API, then driven to `success` and listed). Ran against the live test instance; passes.
- `yarn lint` and `yarn build` clean.

## Notes

- `update_deployment_status` is the only deployment write surface (per the consolidation decision); manual deployment creation is not exposed as a tool action. The integration test creates the fixture deployment via the API directly.

Closes #443
