### PR TITLE
feat(projects): add restore action to manage_project

### DIFF
--- a/src/entities/core/registry.ts
+++ b/src/entities/core/registry.ts
@@ -564,7 +564,7 @@ export const coreToolRegistry: ToolRegistry = new Map<string, EnhancedToolDefini
     {
       name: 'manage_project',
       description:
-        'Create, update, or manage GitLab projects. Actions: create (new project with settings), fork (copy existing project), update (modify settings), delete (remove permanently), archive/unarchive (toggle read-only), transfer (move to different namespace). Related: browse_projects for discovery.',
+        'Create, update, or manage GitLab projects. Actions: create (new project with settings), fork (copy existing project), update (modify settings), delete (remove permanently), restore (recover a soft-deleted project before purge), archive/unarchive (toggle read-only), transfer (move to different namespace). Related: browse_projects for discovery, including include_deleted to find restorable projects.',
       inputSchema: z.toJSONSchema(ManageProjectSchema),
       requirements: {
         default: { tier: 'free', minVersion: '8.0' },
@@ -791,6 +791,19 @@ export const coreToolRegistry: ToolRegistry = new Map<string, EnhancedToolDefini
               headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
               body: body.toString(),
             });
+
+            if (!response.ok) {
+              throw new Error(`GitLab API error: ${response.status} ${response.statusText}`);
+            }
+
+            return await response.json();
+          }
+
+          case 'restore': {
+            const { project_id } = input;
+
+            const apiUrl = `${process.env.GITLAB_API_URL}/api/v4/projects/${normalizeProjectId(project_id)}/restore`;
+            const response = await enhancedFetch(apiUrl, { method: 'POST' });
 
             if (!response.ok) {
               throw new Error(`GitLab API error: ${response.status} ${response.statusText}`);

--- a/src/entities/core/registry.ts
+++ b/src/entities/core/registry.ts
@@ -23,6 +23,18 @@ import { ToolRegistry, EnhancedToolDefinition } from '../../types';
 import { assertActionAllowed } from '../utils';
 
 /**
+ * Minimal guard for the project payload returned by POST /projects/:id/restore.
+ * Validates the identifying field without coercing it (so the numeric id is
+ * returned unchanged) and passes through the rest of the project object.
+ */
+const RestoredProjectSchema = z
+  .object({
+    id: z.number().int().positive(),
+    marked_for_deletion_on: z.string().nullable().optional(),
+  })
+  .passthrough();
+
+/**
  * Core tools registry - CQRS consolidated
  * All tools use discriminated union schema pattern.
  * TypeScript automatically narrows types in each switch case.
@@ -809,7 +821,7 @@ export const coreToolRegistry: ToolRegistry = new Map<string, EnhancedToolDefini
               throw new Error(`GitLab API error: ${response.status} ${response.statusText}`);
             }
 
-            return await response.json();
+            return RestoredProjectSchema.parse(await response.json());
           }
 
           /* istanbul ignore next -- unreachable with Zod discriminatedUnion */

--- a/src/entities/core/registry.ts
+++ b/src/entities/core/registry.ts
@@ -821,7 +821,13 @@ export const coreToolRegistry: ToolRegistry = new Map<string, EnhancedToolDefini
               throw new Error(`GitLab API error: ${response.status} ${response.statusText}`);
             }
 
-            return RestoredProjectSchema.parse(await response.json());
+            const restored = RestoredProjectSchema.safeParse(await response.json());
+            if (!restored.success) {
+              throw new Error(
+                `GitLab API error: unexpected restore response shape (${restored.error.issues[0]?.message ?? 'invalid'})`,
+              );
+            }
+            return restored.data;
           }
 
           /* istanbul ignore next -- unreachable with Zod discriminatedUnion */

--- a/src/entities/core/schema.ts
+++ b/src/entities/core/schema.ts
@@ -143,6 +143,16 @@ const TransferProjectSchema = z.object({
   namespace: z.string().describe('Target namespace ID or path to transfer to.'),
 });
 
+// --- Action: restore ---
+const RestoreProjectSchema = z.object({
+  action: z
+    .literal('restore')
+    .describe(
+      'Restore a soft-deleted project within its deletion cooldown window (default 7 days). Fails once the project has been purged. Requires project Owner or instance Administrator.',
+    ),
+  project_id: requiredId.describe('Project ID or URL-encoded path of the project to restore.'),
+});
+
 // --- Discriminated union combining all actions ---
 export const ManageProjectSchema = z.discriminatedUnion('action', [
   CreateProjectSchema,
@@ -152,6 +162,7 @@ export const ManageProjectSchema = z.discriminatedUnion('action', [
   ArchiveProjectSchema,
   UnarchiveProjectSchema,
   TransferProjectSchema,
+  RestoreProjectSchema,
 ]);
 
 // ============================================================================

--- a/tests/integration/schemas/restore-project.test.ts
+++ b/tests/integration/schemas/restore-project.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Project Restore Schema Integration Tests
+ * Exercises the soft-delete recovery lifecycle against a real GitLab API:
+ * create a project in the test group, soft-delete it, then restore it via the
+ * manage_project restore action and assert it is no longer marked for deletion.
+ *
+ * Restore only works while a project is within its deletion cooldown window. If
+ * the instance/group purges immediately (adjourned deletion disabled), the test
+ * skips the restore assertion rather than failing on an environment difference.
+ */
+
+import { ManageProjectSchema } from '../../../src/entities/core/schema';
+import { BrowseProjectsSchema } from '../../../src/entities/core/schema-readonly';
+import { IntegrationTestHelper } from '../helpers/registry-helper';
+
+interface Project {
+  id: number;
+  path_with_namespace: string;
+  marked_for_deletion_on?: string | null;
+}
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+describe('Project Restore - GitLab Integration', () => {
+  let helper: IntegrationTestHelper;
+
+  beforeAll(async () => {
+    if (!process.env.GITLAB_TOKEN) {
+      throw new Error('GITLAB_TOKEN environment variable is required');
+    }
+    helper = new IntegrationTestHelper();
+    await helper.initialize();
+  });
+
+  it('creates, soft-deletes, and restores a project', async () => {
+    const name = `it-restore-${Date.now()}`;
+
+    const created = (await helper.executeTool(
+      'manage_project',
+      ManageProjectSchema.parse({
+        action: 'create',
+        name,
+        namespace: 'test',
+        initialize_with_readme: true,
+      }),
+    )) as Project;
+    expect(created.id).toBeGreaterThan(0);
+    const projectId = created.id;
+
+    let restored = false;
+    try {
+      // A brand-new project finishes repository setup asynchronously; deleting
+      // mid-setup can 500. Wait until it is fully readable, then delete with a
+      // short retry to ride out the creation race.
+      for (let i = 0; i < 5; i++) {
+        try {
+          await helper.executeTool(
+            'browse_projects',
+            BrowseProjectsSchema.parse({ action: 'get', project_id: String(projectId) }),
+          );
+          break;
+        } catch {
+          await sleep(2000);
+        }
+      }
+
+      // Soft-delete. On an instance with adjourned deletion this marks the
+      // project for deletion; otherwise it purges immediately. enhancedFetch
+      // already retries transient 5xx internally, so a single attempt suffices.
+      let deleted = false;
+      try {
+        await helper.executeTool(
+          'manage_project',
+          ManageProjectSchema.parse({ action: 'delete', project_id: String(projectId) }),
+        );
+        deleted = true;
+      } catch {
+        deleted = false;
+      }
+
+      if (!deleted) {
+        // The instance would not delete the project (some GitLab deployments return
+        // 5xx for programmatic project deletion). Without a soft-deleted project
+        // there is no precondition for restore; the restore action itself is covered
+        // by unit tests. Best-effort cleanup then skip.
+        console.log('Instance did not delete the project - skipping restore assertion');
+        await helper
+          .executeTool(
+            'manage_project',
+            ManageProjectSchema.parse({ action: 'delete', project_id: String(projectId) }),
+          )
+          .catch(() => {});
+        return;
+      }
+
+      // Determine whether the project is recoverable (still present, marked).
+      let markedForDeletion = false;
+      try {
+        const afterDelete = (await helper.executeTool(
+          'browse_projects',
+          BrowseProjectsSchema.parse({ action: 'get', project_id: String(projectId) }),
+        )) as Project;
+        markedForDeletion = Boolean(afterDelete.marked_for_deletion_on);
+      } catch {
+        // GET 404 -> already purged, not recoverable
+        markedForDeletion = false;
+      }
+
+      if (!markedForDeletion) {
+        console.log(
+          'Project purged immediately (adjourned deletion disabled) - skipping restore assertion',
+        );
+        return;
+      }
+
+      const result = (await helper.executeTool(
+        'manage_project',
+        ManageProjectSchema.parse({ action: 'restore', project_id: String(projectId) }),
+      )) as Project;
+      expect(result.id).toBe(projectId);
+      restored = true;
+
+      const afterRestore = (await helper.executeTool(
+        'browse_projects',
+        BrowseProjectsSchema.parse({ action: 'get', project_id: String(projectId) }),
+      )) as Project;
+      expect(afterRestore.marked_for_deletion_on ?? null).toBeNull();
+    } finally {
+      // Best-effort cleanup: delete the project again if we restored it.
+      if (restored) {
+        try {
+          await helper.executeTool(
+            'manage_project',
+            ManageProjectSchema.parse({ action: 'delete', project_id: String(projectId) }),
+          );
+        } catch {
+          // already gone / cooldown - leave for manual cleanup
+        }
+      }
+    }
+  }, 60000);
+});

--- a/tests/integration/schemas/restore-project.test.ts
+++ b/tests/integration/schemas/restore-project.test.ts
@@ -34,13 +34,15 @@ describe('Project Restore - GitLab Integration', () => {
 
   it('creates, soft-deletes, and restores a project', async () => {
     const name = `it-restore-${Date.now()}`;
+    // Defaults to the mandated 'test' root group; overridable for other instances.
+    const namespace = process.env.GITLAB_TEST_NAMESPACE ?? 'test';
 
     const created = (await helper.executeTool(
       'manage_project',
       ManageProjectSchema.parse({
         action: 'create',
         name,
-        namespace: 'test',
+        namespace,
         initialize_with_readme: true,
       }),
     )) as Project;
@@ -118,6 +120,9 @@ describe('Project Restore - GitLab Integration', () => {
         ManageProjectSchema.parse({ action: 'restore', project_id: String(projectId) }),
       )) as Project;
       expect(result.id).toBe(projectId);
+      // The restore response itself should already show the project is no longer
+      // marked for deletion (avoids relying solely on the follow-up GET).
+      expect(result.marked_for_deletion_on ?? null).toBeNull();
       restored = true;
 
       const afterRestore = (await helper.executeTool(

--- a/tests/unit/entities/core/registry.test.ts
+++ b/tests/unit/entities/core/registry.test.ts
@@ -2008,6 +2008,16 @@ describe('Core Registry', () => {
           'GitLab API error: 404 Not Found',
         );
       });
+
+      it('should reject a malformed restore response that lacks a project id', async () => {
+        mockEnhancedFetch.mockResolvedValueOnce({
+          ok: true,
+          json: jest.fn().mockResolvedValue({ unexpected: 'shape' }),
+        } as any);
+
+        const tool = coreToolRegistry.get('manage_project');
+        await expect(tool!.handler({ action: 'restore', project_id: '1' })).rejects.toThrow();
+      });
     });
 
     describe('manage_namespace Handler (update/delete)', () => {

--- a/tests/unit/entities/core/registry.test.ts
+++ b/tests/unit/entities/core/registry.test.ts
@@ -1976,6 +1976,38 @@ describe('Core Registry', () => {
           tool!.handler({ action: 'transfer', project_id: '1', namespace: 'invalid' }),
         ).rejects.toThrow('GitLab API error: 400 Bad Request');
       });
+
+      it('should restore a soft-deleted project', async () => {
+        mockEnhancedFetch.mockResolvedValueOnce({
+          ok: true,
+          json: jest.fn().mockResolvedValue({ id: 1, marked_for_deletion_on: null }),
+        } as any);
+
+        const tool = coreToolRegistry.get('manage_project');
+        const result = await tool!.handler({
+          action: 'restore',
+          project_id: 'my-group/my-project',
+        });
+
+        expect(mockEnhancedFetch).toHaveBeenCalledWith(
+          'https://gitlab.example.com/api/v4/projects/my-group%2Fmy-project/restore',
+          expect.objectContaining({ method: 'POST' }),
+        );
+        expect(result).toEqual({ id: 1, marked_for_deletion_on: null });
+      });
+
+      it('should surface a 404 when the project is purged or not found', async () => {
+        mockEnhancedFetch.mockResolvedValueOnce({
+          ok: false,
+          status: 404,
+          statusText: 'Not Found',
+        } as any);
+
+        const tool = coreToolRegistry.get('manage_project');
+        await expect(tool!.handler({ action: 'restore', project_id: '1' })).rejects.toThrow(
+          'GitLab API error: 404 Not Found',
+        );
+      });
     });
 
     describe('manage_namespace Handler (update/delete)', () => {

--- a/tests/unit/entities/core/registry.test.ts
+++ b/tests/unit/entities/core/registry.test.ts
@@ -2016,7 +2016,9 @@ describe('Core Registry', () => {
         } as any);
 
         const tool = coreToolRegistry.get('manage_project');
-        await expect(tool!.handler({ action: 'restore', project_id: '1' })).rejects.toThrow();
+        await expect(tool!.handler({ action: 'restore', project_id: '1' })).rejects.toThrow(
+          'GitLab API error: unexpected restore response shape',
+        );
       });
     });
 


### PR DESCRIPTION
## Summary

Adds a `restore` action to `manage_project` so soft-deleted projects can be recovered within their deletion cooldown window (default 7 days), before the project is permanently purged.

- **`manage_project` action `restore`** - calls `POST /projects/:id/restore`.
- Permission: project Owner OR instance Administrator (intentionally NOT gated admin-only - an Owner can restore their own project).
- Returns the project on success; a 404 surfaces when the project does not exist or the cooldown window has passed (already purged).
- Pairs with `browse_projects` `include_deleted` for discovery: list deleted projects, then restore by id.

## Changes

- **`entities/core/schema.ts`** - new `RestoreProjectSchema` added to the `manage_project` discriminated union.
- **`entities/core/registry.ts`** - new `restore` case in the handler (POST to the restore endpoint, returns the project JSON); tool description updated to mention restore.
- No version/tier gate on the action: action-level requirements are not enforced for filtering in this codebase (only tool-default and parameter requirements are), so an inert gate is avoided. GitLab returns the appropriate error on instances/tiers where restore is unavailable.

## Testing

- Unit: restore success (POSTs to `/projects/:id/restore`, returns the project) and the purged/not-found 404 path.
- Integration: create a project, soft-delete it, then restore and assert it is no longer marked for deletion. The test adapts to the instance - if the deployment purges immediately (adjourned deletion disabled) or will not delete the project, it skips the restore assertion rather than failing on an environment difference.
- Full unit suite green (5015 tests); `yarn lint` and `yarn build` clean.

Closes #432
