### PR TITLE
chore(ci): disable CodeRabbit ESLint tool

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+reviews:
+  tools:
+    # Disabled: CodeRabbit cannot install ESLint in its sandbox for this repo
+    # (engines.node >=24, ESLint 10, and Yarn 4 without a package-lock), which
+    # surfaces a recurring "ESLint install failed" warning. ESLint still runs
+    # locally (yarn lint) and in CI before merge, so nothing is lost here.
+    eslint:
+      enabled: false


### PR DESCRIPTION
## Summary

Disables CodeRabbit's ESLint tool, which cannot install in CodeRabbit's sandbox for this repo and surfaces a recurring `ESLint install failed` warning on every PR walkthrough.

## Root cause

CodeRabbit runs ESLint by installing the repo's tooling in its own environment. The install fails because of the combination:

- `package.json` `engines.node: ">=24"` — CodeRabbit's runner uses an older Node, hitting `EBADENGINE`.
- ESLint **v10** (bumped in #321) requires Node 20.19+/22.13+ and has stricter peer deps.
- Yarn 4 (Berry) with only `yarn.lock` (no `package-lock.json`) — CodeRabbit's npm-based install can't resolve the tree.

This affects only CodeRabbit's redundant automated ESLint pass. ESLint still runs locally (`yarn lint`) and in CI before merge, so coverage is unchanged.

## Changes

- Add `.coderabbit.yaml` with `reviews.tools.eslint.enabled: false` (CodeRabbit's own recommended fix for unrecoverable tool errors), plus a comment explaining why.

Closes #466


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code review configuration to disable ESLint tool validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->