### PR TITLE
feat(namespaces): add restore action to manage_namespace

### DIFF
--- a/src/entities/core/registry.ts
+++ b/src/entities/core/registry.ts
@@ -21,13 +21,16 @@ import { smartUserSearch, type UserSearchParams } from '../../utils/smart-user-s
 import { cleanGidsFromObject } from '../../utils/idConversion';
 import { ToolRegistry, EnhancedToolDefinition } from '../../types';
 import { assertActionAllowed } from '../utils';
+import { ConnectionManager } from '../../services/ConnectionManager';
+import { parseVersion } from '../../utils/version';
 
 /**
- * Minimal guard for the project payload returned by POST /projects/:id/restore.
- * Validates the identifying field without coercing it (so the numeric id is
- * returned unchanged) and passes through the rest of the project object.
+ * Minimal guard for the entity payload returned by the restore endpoints
+ * (POST /projects/:id/restore and POST /groups/:id/restore). Validates the
+ * identifying field without coercing it (so the numeric id is returned
+ * unchanged) and passes through the rest of the project/group object.
  */
-const RestoredProjectSchema = z
+const RestoredEntitySchema = z
   .object({
     id: z.number().int().positive(),
     marked_for_deletion_on: z.string().nullable().optional(),
@@ -821,7 +824,7 @@ export const coreToolRegistry: ToolRegistry = new Map<string, EnhancedToolDefini
               throw new Error(`GitLab API error: ${response.status} ${response.statusText}`);
             }
 
-            const restored = RestoredProjectSchema.safeParse(await response.json());
+            const restored = RestoredEntitySchema.safeParse(await response.json());
             if (!restored.success) {
               throw new Error(
                 `GitLab API error: unexpected restore response shape (${restored.error.issues[0]?.message ?? 'invalid'})`,
@@ -843,7 +846,7 @@ export const coreToolRegistry: ToolRegistry = new Map<string, EnhancedToolDefini
     {
       name: 'manage_namespace',
       description:
-        'Create, update, or delete GitLab groups/namespaces. Actions: create (new group with visibility/settings), update (modify group settings), delete (remove permanently). Related: browse_namespaces for discovery.',
+        'Create, update, or delete GitLab groups/namespaces. Actions: create (new group with visibility/settings), update (modify group settings), delete (remove permanently), restore (recover a soft-deleted group before purge; requires GitLab 18.0+). Related: browse_namespaces for discovery.',
       inputSchema: z.toJSONSchema(ManageNamespaceSchema),
       requirements: {
         default: { tier: 'free', minVersion: '8.0' },
@@ -933,6 +936,41 @@ export const coreToolRegistry: ToolRegistry = new Map<string, EnhancedToolDefini
             }
 
             return { success: true, message: `Group ${group_id} deleted` };
+          }
+
+          case 'restore': {
+            const { group_id } = input;
+
+            // Group restore landed in GitLab 18.0. The instance version is already
+            // detected at startup, so this is a cheap in-memory check (no API call).
+            // Fail-open when the version is unknown (not yet probed / connection not
+            // initialised) so we never block on a missing detection.
+            let version = 'unknown';
+            try {
+              version = ConnectionManager.getInstance().getInstanceInfo().version;
+            } catch {
+              // Connection not initialised — leave version unknown (fail-open).
+            }
+            if (version !== 'unknown' && parseVersion(version) < parseVersion('18.0')) {
+              throw new Error(
+                `Group restore requires GitLab 18.0+, but the instance is ${version}`,
+              );
+            }
+
+            const apiUrl = `${process.env.GITLAB_API_URL}/api/v4/groups/${encodeURIComponent(group_id)}/restore`;
+            const response = await enhancedFetch(apiUrl, { method: 'POST' });
+
+            if (!response.ok) {
+              throw new Error(`GitLab API error: ${response.status} ${response.statusText}`);
+            }
+
+            const restored = RestoredEntitySchema.safeParse(await response.json());
+            if (!restored.success) {
+              throw new Error(
+                `GitLab API error: unexpected restore response shape (${restored.error.issues[0]?.message ?? 'invalid'})`,
+              );
+            }
+            return restored.data;
           }
 
           /* istanbul ignore next -- unreachable with Zod discriminatedUnion */

--- a/src/entities/core/registry.ts
+++ b/src/entities/core/registry.ts
@@ -154,7 +154,7 @@ export const coreToolRegistry: ToolRegistry = new Map<string, EnhancedToolDefini
 
             let apiUrl: string;
             if (group_id) {
-              apiUrl = `${process.env.GITLAB_API_URL}/api/v4/groups/${encodeURIComponent(group_id)}/projects?${queryParams}`;
+              apiUrl = `${process.env.GITLAB_API_URL}/api/v4/groups/${normalizeProjectId(group_id)}/projects?${queryParams}`;
             } else if (include_deleted) {
               // include_pending_delete returns soft-deleted projects; do NOT also send
               // active=true, which would filter them back out (admin only).
@@ -911,7 +911,7 @@ export const coreToolRegistry: ToolRegistry = new Map<string, EnhancedToolDefini
               }
             });
 
-            const apiUrl = `${process.env.GITLAB_API_URL}/api/v4/groups/${encodeURIComponent(group_id)}`;
+            const apiUrl = `${process.env.GITLAB_API_URL}/api/v4/groups/${normalizeProjectId(group_id)}`;
             const response = await enhancedFetch(apiUrl, {
               method: 'PUT',
               headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
@@ -928,7 +928,7 @@ export const coreToolRegistry: ToolRegistry = new Map<string, EnhancedToolDefini
           case 'delete': {
             const { group_id } = input;
 
-            const apiUrl = `${process.env.GITLAB_API_URL}/api/v4/groups/${encodeURIComponent(group_id)}`;
+            const apiUrl = `${process.env.GITLAB_API_URL}/api/v4/groups/${normalizeProjectId(group_id)}`;
             const response = await enhancedFetch(apiUrl, { method: 'DELETE' });
 
             if (!response.ok) {
@@ -957,7 +957,7 @@ export const coreToolRegistry: ToolRegistry = new Map<string, EnhancedToolDefini
               );
             }
 
-            const apiUrl = `${process.env.GITLAB_API_URL}/api/v4/groups/${encodeURIComponent(group_id)}/restore`;
+            const apiUrl = `${process.env.GITLAB_API_URL}/api/v4/groups/${normalizeProjectId(group_id)}/restore`;
             const response = await enhancedFetch(apiUrl, { method: 'POST' });
 
             if (!response.ok) {

--- a/src/entities/core/registry.ts
+++ b/src/entities/core/registry.ts
@@ -38,6 +38,25 @@ const RestoredEntitySchema = z
   .passthrough();
 
 /**
+ * POST to a soft-delete restore endpoint (projects or groups) and return the
+ * validated restored entity. Shared by manage_project and manage_namespace so
+ * the restore request/validation logic lives in one place.
+ */
+async function restoreEntity(apiUrl: string): Promise<unknown> {
+  const response = await enhancedFetch(apiUrl, { method: 'POST' });
+  if (!response.ok) {
+    throw new Error(`GitLab API error: ${response.status} ${response.statusText}`);
+  }
+  const restored = RestoredEntitySchema.safeParse(await response.json());
+  if (!restored.success) {
+    throw new Error(
+      `GitLab API error: unexpected restore response shape (${restored.error.issues[0]?.message ?? 'invalid'})`,
+    );
+  }
+  return restored.data;
+}
+
+/**
  * Core tools registry - CQRS consolidated
  * All tools use discriminated union schema pattern.
  * TypeScript automatically narrows types in each switch case.
@@ -823,21 +842,9 @@ export const coreToolRegistry: ToolRegistry = new Map<string, EnhancedToolDefini
 
           case 'restore': {
             const { project_id } = input;
-
-            const apiUrl = `${process.env.GITLAB_API_URL}/api/v4/projects/${normalizeProjectId(project_id)}/restore`;
-            const response = await enhancedFetch(apiUrl, { method: 'POST' });
-
-            if (!response.ok) {
-              throw new Error(`GitLab API error: ${response.status} ${response.statusText}`);
-            }
-
-            const restored = RestoredEntitySchema.safeParse(await response.json());
-            if (!restored.success) {
-              throw new Error(
-                `GitLab API error: unexpected restore response shape (${restored.error.issues[0]?.message ?? 'invalid'})`,
-              );
-            }
-            return restored.data;
+            return restoreEntity(
+              `${process.env.GITLAB_API_URL}/api/v4/projects/${normalizeProjectId(project_id)}/restore`,
+            );
           }
 
           /* istanbul ignore next -- unreachable with Zod discriminatedUnion */
@@ -964,20 +971,9 @@ export const coreToolRegistry: ToolRegistry = new Map<string, EnhancedToolDefini
               );
             }
 
-            const apiUrl = `${process.env.GITLAB_API_URL}/api/v4/groups/${normalizeProjectId(group_id)}/restore`;
-            const response = await enhancedFetch(apiUrl, { method: 'POST' });
-
-            if (!response.ok) {
-              throw new Error(`GitLab API error: ${response.status} ${response.statusText}`);
-            }
-
-            const restored = RestoredEntitySchema.safeParse(await response.json());
-            if (!restored.success) {
-              throw new Error(
-                `GitLab API error: unexpected restore response shape (${restored.error.issues[0]?.message ?? 'invalid'})`,
-              );
-            }
-            return restored.data;
+            return restoreEntity(
+              `${process.env.GITLAB_API_URL}/api/v4/groups/${normalizeProjectId(group_id)}/restore`,
+            );
           }
 
           /* istanbul ignore next -- unreachable with Zod discriminatedUnion */

--- a/src/entities/core/schema.ts
+++ b/src/entities/core/schema.ts
@@ -245,11 +245,23 @@ const DeleteNamespaceSchema = z.object({
   group_id: requiredId.describe('Group ID or URL-encoded path.'),
 });
 
+// --- Action: restore ---
+const RestoreNamespaceSchema = z.object({
+  action: z
+    .literal('restore')
+    .describe(
+      'Restore a soft-deleted group within its deletion cooldown window. Requires GitLab 18.0+ ' +
+        '(group restore GA in 18.9) and group Owner or instance Administrator.',
+    ),
+  group_id: requiredId.describe('Group ID or URL-encoded path of the group to restore.'),
+});
+
 // --- Discriminated union combining all actions ---
 export const ManageNamespaceSchema = z.discriminatedUnion('action', [
   CreateNamespaceSchema,
   UpdateNamespaceSchema,
   DeleteNamespaceSchema,
+  RestoreNamespaceSchema,
 ]);
 
 // ============================================================================

--- a/tests/integration/helpers/registry-helper.ts
+++ b/tests/integration/helpers/registry-helper.ts
@@ -611,3 +611,17 @@ export class IntegrationTestHelper {
     return this.executeTool('manage_context', { action: 'reset' });
   }
 }
+
+/**
+ * Construct and initialize an {@link IntegrationTestHelper}, asserting the
+ * mandatory GITLAB_TOKEN is present. Shared bootstrap for integration test
+ * suites so the identical setup block is not repeated per file.
+ */
+export async function initIntegrationHelper(): Promise<IntegrationTestHelper> {
+  if (!process.env.GITLAB_TOKEN) {
+    throw new Error('GITLAB_TOKEN environment variable is required');
+  }
+  const helper = new IntegrationTestHelper();
+  await helper.initialize();
+  return helper;
+}

--- a/tests/integration/schemas/restore-namespace.test.ts
+++ b/tests/integration/schemas/restore-namespace.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Group (namespace) Restore Schema Integration Tests
+ * Exercises the soft-delete recovery lifecycle for groups against a real GitLab
+ * API: create a subgroup under the test group, soft-delete it, then restore it
+ * via the manage_namespace restore action.
+ *
+ * Group restore requires GitLab 18.0+ (GA 18.9). The test skips on older
+ * instances, and (like the project restore test) skips the restore assertion
+ * when the instance purges immediately instead of soft-deleting.
+ */
+
+import { ManageNamespaceSchema } from '../../../src/entities/core/schema';
+import { parseVersion } from '../../../src/utils/version';
+import { IntegrationTestHelper } from '../helpers/registry-helper';
+
+interface Group {
+  id: number;
+  full_path: string;
+  marked_for_deletion_on?: string | null;
+}
+
+describe('Group Restore - GitLab Integration', () => {
+  let helper: IntegrationTestHelper;
+
+  beforeAll(async () => {
+    if (!process.env.GITLAB_TOKEN) {
+      throw new Error('GITLAB_TOKEN environment variable is required');
+    }
+    helper = new IntegrationTestHelper();
+    await helper.initialize();
+  });
+
+  it('creates, soft-deletes, and restores a group', async () => {
+    const ctx = (await helper.executeTool('manage_context', { action: 'whoami' })) as {
+      server?: { version?: string };
+    };
+    const version = ctx.server?.version ?? 'unknown';
+    if (version === 'unknown' || parseVersion(version) < parseVersion('18.0')) {
+      console.log(`  Skipping group restore: requires GitLab 18.0+, instance is ${version}`);
+      return;
+    }
+
+    // Find the mandated 'test' root group to host the throwaway subgroup.
+    const testGroup = (await helper
+      .executeTool('browse_namespaces', {
+        action: 'get',
+        namespace_id: 'test',
+      })
+      .catch(() => null)) as { id?: number } | null;
+    if (!testGroup?.id) {
+      console.log('  Skipping group restore: test root group not found');
+      return;
+    }
+
+    const suffix = Date.now();
+    const created = (await helper.executeTool(
+      'manage_namespace',
+      ManageNamespaceSchema.parse({
+        action: 'create',
+        name: `it-restore-grp-${suffix}`,
+        path: `it-restore-grp-${suffix}`,
+        parent_id: testGroup.id,
+      }),
+    )) as Group;
+    expect(created.id).toBeGreaterThan(0);
+    const groupId = created.id;
+
+    let restored = false;
+    try {
+      // Soft-delete. On an instance with adjourned deletion this marks the group
+      // for deletion; otherwise it purges immediately. enhancedFetch retries
+      // transient 5xx internally, so a single attempt suffices.
+      let deleted = false;
+      try {
+        await helper.executeTool(
+          'manage_namespace',
+          ManageNamespaceSchema.parse({ action: 'delete', group_id: String(groupId) }),
+        );
+        deleted = true;
+      } catch {
+        deleted = false;
+      }
+
+      if (!deleted) {
+        console.log('  Instance did not delete the group - skipping restore assertion');
+        return;
+      }
+
+      // Determine whether the group is recoverable (still present, marked).
+      let markedForDeletion = false;
+      try {
+        const afterDelete = (await helper.executeTool('browse_namespaces', {
+          action: 'get',
+          namespace_id: String(groupId),
+        })) as Group;
+        markedForDeletion = Boolean(afterDelete.marked_for_deletion_on);
+      } catch {
+        markedForDeletion = false;
+      }
+
+      if (!markedForDeletion) {
+        console.log('  Group purged immediately - skipping restore assertion');
+        return;
+      }
+
+      const result = (await helper.executeTool(
+        'manage_namespace',
+        ManageNamespaceSchema.parse({ action: 'restore', group_id: String(groupId) }),
+      )) as Group;
+      expect(result.id).toBe(groupId);
+      expect(result.marked_for_deletion_on ?? null).toBeNull();
+      restored = true;
+    } finally {
+      if (restored) {
+        await helper
+          .executeTool(
+            'manage_namespace',
+            ManageNamespaceSchema.parse({ action: 'delete', group_id: String(groupId) }),
+          )
+          .catch(() => {});
+      }
+    }
+  }, 60000);
+});

--- a/tests/integration/schemas/restore-namespace.test.ts
+++ b/tests/integration/schemas/restore-namespace.test.ts
@@ -11,7 +11,7 @@
 
 import { ManageNamespaceSchema } from '../../../src/entities/core/schema';
 import { parseVersion } from '../../../src/utils/version';
-import { IntegrationTestHelper } from '../helpers/registry-helper';
+import { IntegrationTestHelper, initIntegrationHelper } from '../helpers/registry-helper';
 
 interface Group {
   id: number;
@@ -23,11 +23,7 @@ describe('Group Restore - GitLab Integration', () => {
   let helper: IntegrationTestHelper;
 
   beforeAll(async () => {
-    if (!process.env.GITLAB_TOKEN) {
-      throw new Error('GITLAB_TOKEN environment variable is required');
-    }
-    helper = new IntegrationTestHelper();
-    await helper.initialize();
+    helper = await initIntegrationHelper();
   });
 
   it('creates, soft-deletes, and restores a group', async () => {

--- a/tests/integration/schemas/restore-project.test.ts
+++ b/tests/integration/schemas/restore-project.test.ts
@@ -11,7 +11,7 @@
 
 import { ManageProjectSchema } from '../../../src/entities/core/schema';
 import { BrowseProjectsSchema } from '../../../src/entities/core/schema-readonly';
-import { IntegrationTestHelper } from '../helpers/registry-helper';
+import { IntegrationTestHelper, initIntegrationHelper } from '../helpers/registry-helper';
 
 interface Project {
   id: number;
@@ -25,11 +25,7 @@ describe('Project Restore - GitLab Integration', () => {
   let helper: IntegrationTestHelper;
 
   beforeAll(async () => {
-    if (!process.env.GITLAB_TOKEN) {
-      throw new Error('GITLAB_TOKEN environment variable is required');
-    }
-    helper = new IntegrationTestHelper();
-    await helper.initialize();
+    helper = await initIntegrationHelper();
   });
 
   it('creates, soft-deletes, and restores a project', async () => {

--- a/tests/unit/entities/core/registry.test.ts
+++ b/tests/unit/entities/core/registry.test.ts
@@ -7,6 +7,7 @@ import {
 import { enhancedFetch } from '../../../../src/utils/fetch';
 import { smartUserSearch } from '../../../../src/utils/smart-user-search';
 import { isActionDenied } from '../../../../src/config';
+import { ConnectionManager } from '../../../../src/services/ConnectionManager';
 
 // Mock the fetch function to avoid actual API calls
 jest.mock('../../../../src/utils/fetch', () => ({
@@ -2110,6 +2111,50 @@ describe('Core Registry', () => {
           'https://gitlab.example.com/api/v4/groups/parent%2Fchild-group',
           expect.objectContaining({ method: 'PUT' }),
         );
+      });
+
+      it('should restore a soft-deleted group', async () => {
+        mockEnhancedFetch.mockResolvedValueOnce({
+          ok: true,
+          json: jest.fn().mockResolvedValue({ id: 5, marked_for_deletion_on: null }),
+        } as any);
+
+        const tool = coreToolRegistry.get('manage_namespace');
+        const result = await tool!.handler({ action: 'restore', group_id: 'my-group' });
+
+        expect(mockEnhancedFetch).toHaveBeenCalledWith(
+          'https://gitlab.example.com/api/v4/groups/my-group/restore',
+          expect.objectContaining({ method: 'POST' }),
+        );
+        expect(result).toEqual({ id: 5, marked_for_deletion_on: null });
+      });
+
+      it('should surface a 404 when the group is purged or not found', async () => {
+        mockEnhancedFetch.mockResolvedValueOnce({
+          ok: false,
+          status: 404,
+          statusText: 'Not Found',
+        } as any);
+
+        const tool = coreToolRegistry.get('manage_namespace');
+        await expect(tool!.handler({ action: 'restore', group_id: '1' })).rejects.toThrow(
+          'GitLab API error: 404 Not Found',
+        );
+      });
+
+      it('rejects group restore on GitLab below 18.0 with a clear message', async () => {
+        const spy = jest
+          .spyOn(ConnectionManager.getInstance(), 'getInstanceInfo')
+          .mockReturnValue({ version: '17.11.0', tier: 'free' } as never);
+        try {
+          const tool = coreToolRegistry.get('manage_namespace');
+          await expect(tool!.handler({ action: 'restore', group_id: 'old-group' })).rejects.toThrow(
+            'Group restore requires GitLab 18.0+',
+          );
+          expect(mockEnhancedFetch).not.toHaveBeenCalled();
+        } finally {
+          spy.mockRestore();
+        }
       });
     });
 

--- a/tests/unit/entities/core/registry.test.ts
+++ b/tests/unit/entities/core/registry.test.ts
@@ -8,6 +8,7 @@ import { enhancedFetch } from '../../../../src/utils/fetch';
 import { smartUserSearch } from '../../../../src/utils/smart-user-search';
 import { isActionDenied } from '../../../../src/config';
 import { ConnectionManager } from '../../../../src/services/ConnectionManager';
+import type { GitLabInstanceInfo } from '../../../../src/services/GitLabVersionDetector';
 
 // Mock the fetch function to avoid actual API calls
 jest.mock('../../../../src/utils/fetch', () => ({
@@ -2160,7 +2161,7 @@ describe('Core Registry', () => {
       it('rejects group restore on GitLab below 18.0 with a clear message', async () => {
         const spy = jest
           .spyOn(ConnectionManager.getInstance(), 'getInstanceInfo')
-          .mockReturnValue({ version: '17.11.0', tier: 'free' } as never);
+          .mockReturnValue({ version: '17.11.0', tier: 'free' } as GitLabInstanceInfo);
         try {
           const tool = coreToolRegistry.get('manage_namespace');
           await expect(tool!.handler({ action: 'restore', group_id: 'old-group' })).rejects.toThrow(

--- a/tests/unit/entities/core/registry.test.ts
+++ b/tests/unit/entities/core/registry.test.ts
@@ -2142,6 +2142,21 @@ describe('Core Registry', () => {
         );
       });
 
+      it('does not double-encode an already URL-encoded subgroup path on restore', async () => {
+        mockEnhancedFetch.mockResolvedValueOnce({
+          ok: true,
+          json: jest.fn().mockResolvedValue({ id: 7 }),
+        } as any);
+
+        const tool = coreToolRegistry.get('manage_namespace');
+        await tool!.handler({ action: 'restore', group_id: 'parent%2Fchild' });
+
+        expect(mockEnhancedFetch).toHaveBeenCalledWith(
+          'https://gitlab.example.com/api/v4/groups/parent%2Fchild/restore',
+          expect.objectContaining({ method: 'POST' }),
+        );
+      });
+
       it('rejects group restore on GitLab below 18.0 with a clear message', async () => {
         const spy = jest
           .spyOn(ConnectionManager.getInstance(), 'getInstanceInfo')


### PR DESCRIPTION
## Summary

Adds a `restore` action to `manage_namespace` so soft-deleted groups can be recovered within their deletion cooldown window, before the group is permanently purged. Symmetric to project restore (#432).

- **`manage_namespace` action `restore`** - calls `POST /groups/:id/restore`.
- Group restore landed in GitLab 18.0 (GA 18.9). A cheap in-memory version check (the instance version is already detected at startup - no extra API call) returns a clear `Group restore requires GitLab 18.0+` error on older instances, and fails open when the version is unknown.
- Permission: group Owner OR instance Administrator. The restore response is validated through the shared restore-response guard.

## Changes

- **`schema.ts`** - new `RestoreNamespaceSchema` in the `manage_namespace` discriminated union.
- **`registry.ts`** - new `restore` case with the version pre-check and response validation; the restore-response guard `RestoredProjectSchema` is renamed to `RestoredEntitySchema` and reused for both project and group restore (no duplicated schema). Tool description updated.

## Testing

- Unit: restore success (POSTs to `/groups/:id/restore`, returns the group), purged/not-found 404, and the version gate (instance < 18.0 rejects before any API call).
- Integration: create a subgroup under the test group, soft-delete, then restore and assert it is no longer marked for deletion. Gated on GitLab 18.0+; adapts to the instance (skips the restore assertion if it purges immediately or will not delete the group).
- Full unit suite green (5019 tests); `yarn lint` and `yarn build` clean.

Closes #433

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for restoring soft-deleted GitLab groups with automatic validation and error handling (GitLab 18.0+ required).

* **Tests**
  * Added comprehensive integration test suite for group soft-delete and restore workflows.
  * Added unit test coverage for group restore endpoints, error handling, and GitLab version compatibility checks.
  * Refactored test initialization helpers for consistency across integration test suites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->