### PR TITLE
test(integration): fix flaky release and pipeline setup

### DIFF
--- a/tests/integration/data-lifecycle.test.ts
+++ b/tests/integration/data-lifecycle.test.ts
@@ -14,7 +14,13 @@
  * - All other test files import this shared data
  */
 
-import { GITLAB_TOKEN, GITLAB_API_URL, updateTestData, getTestData } from '../setup/testConfig';
+import {
+  GITLAB_TOKEN,
+  GITLAB_API_URL,
+  updateTestData,
+  getTestData,
+  buildCiConfigBase64,
+} from '../setup/testConfig';
 import { GraphQLClient } from '../../src/graphql/client';
 import { ConnectionManager } from '../../src/services/ConnectionManager';
 import { getWorkItemTypes } from '../../src/utils/workItemTypes';
@@ -166,12 +172,12 @@ describe('🔄 Data Lifecycle - Complete Infrastructure Setup', () => {
         { path: 'src/main.js', content: 'Y29uc29sZS5sb2coImhlbGxvIik=', message: 'Add main.js' },
         { path: 'docs/guide.md', content: 'IyBHdWlkZQ==', message: 'Add documentation' },
         { path: '.gitignore', content: 'bm9kZV9tb2R1bGVzLw==', message: 'Add gitignore' },
-        // CI config with spec.inputs for pipeline inputs testing (GitLab 15.5+)
-        // rules: when: manual - prevents auto-triggering pipelines on every commit
+        // CI config with spec.inputs for pipeline inputs testing (GitLab 15.5+).
+        // Content is built by buildCiConfigBase64() so the valid format (spec
+        // header as a separate `---` document) lives in one place.
         {
           path: '.gitlab-ci.yml',
-          content:
-            'c3BlYzoKICBpbnB1dHM6CiAgICBlbnZpcm9ubWVudDoKICAgICAgdHlwZTogc3RyaW5nCiAgICAgIGRlZmF1bHQ6IHRlc3QKICAgIGRlYnVnOgogICAgICB0eXBlOiBib29sZWFuCiAgICAgIGRlZmF1bHQ6IGZhbHNlCiAgICBjb3VudDoKICAgICAgdHlwZTogbnVtYmVyCiAgICAgIGRlZmF1bHQ6IDEKCnRlc3Qtam9iOgogIHNjcmlwdDoKICAgIC0gZWNobyAiRW52aXJvbm1lbnQ6ICRbWyBpbnB1dHMuZW52aXJvbm1lbnQgXV0iCiAgICAtIGVjaG8gIkRlYnVnOiAkW1sgaW5wdXRzLmRlYnVnIF1dIgogICAgLSBlY2hvICJDb3VudDogJFtbIGlucHV0cy5jb3VudCBdXSIKICBydWxlczoKICAgIC0gd2hlbjogbWFudWFsCg==',
+          content: buildCiConfigBase64(),
           message: 'Add CI config with inputs spec',
         },
       ];

--- a/tests/integration/data-lifecycle.test.ts
+++ b/tests/integration/data-lifecycle.test.ts
@@ -193,6 +193,10 @@ describe('🔄 Data Lifecycle - Complete Infrastructure Setup', () => {
             },
             body: JSON.stringify({
               branch: 'main',
+              // All initialFiles carry base64 content; without encoding GitLab
+              // defaults to "text" and stores the base64 string verbatim instead
+              // of the decoded file (e.g. an unparseable .gitlab-ci.yml).
+              encoding: 'base64',
               content: file.content,
               commit_message: file.message,
             }),

--- a/tests/integration/schemas/manage-pipeline.test.ts
+++ b/tests/integration/schemas/manage-pipeline.test.ts
@@ -26,25 +26,16 @@ async function createPipelineAndAssert(
   params: unknown,
   label: string,
 ): Promise<void> {
-  try {
-    const pipeline = (await helper.executeTool('manage_pipeline', params)) as Record<
-      string,
-      unknown
-    >;
-    expect(pipeline).toHaveProperty('id');
-    expect(pipeline).toHaveProperty('status');
-    expect(pipeline).toHaveProperty('ref', 'main');
-    console.log(`✅ Created pipeline with ${label}: ${pipeline.id} (status: ${pipeline.status})`);
-  } catch (error) {
-    // Typed inputs require GitLab 15.5+. Skip only that specific gate; any other
-    // failure is a real error and must surface.
-    const errorMsg = error instanceof Error ? error.message : String(error);
-    if (errorMsg.includes('inputs') || errorMsg.includes('15.5')) {
-      console.log(`⚠️ Pipeline inputs not supported on this GitLab version: ${errorMsg}`);
-    } else {
-      throw error;
-    }
-  }
+  // No error swallowing: beforeAll re-seeds a valid spec:inputs .gitlab-ci.yml and
+  // the test instance is GitLab 15.5+, so creation must succeed. A failure here is
+  // a real regression and must surface. (Typed inputs require 15.5+, documented in
+  // the file header; on older GitLab the CI config fails to parse, which correctly
+  // signals the unmet prerequisite rather than being silently skipped.)
+  const pipeline = (await helper.executeTool('manage_pipeline', params)) as Record<string, unknown>;
+  expect(pipeline).toHaveProperty('id');
+  expect(pipeline).toHaveProperty('status');
+  expect(pipeline).toHaveProperty('ref', 'main');
+  console.log(`✅ Created pipeline with ${label}: ${pipeline.id} (status: ${pipeline.status})`);
 }
 
 describe('manage_pipeline - GitLab Integration (CQRS)', () => {

--- a/tests/integration/schemas/manage-pipeline.test.ts
+++ b/tests/integration/schemas/manage-pipeline.test.ts
@@ -13,7 +13,7 @@
 
 import { ManagePipelineSchema } from '../../../src/entities/pipelines/schema';
 import { IntegrationTestHelper } from '../helpers/registry-helper';
-import { getTestData } from '../../setup/testConfig';
+import { getTestData, buildCiConfigBase64 } from '../../setup/testConfig';
 
 describe('manage_pipeline - GitLab Integration (CQRS)', () => {
   let helper: IntegrationTestHelper;
@@ -27,6 +27,26 @@ describe('manage_pipeline - GitLab Integration (CQRS)', () => {
     helper = new IntegrationTestHelper();
     await helper.initialize();
     console.log('Integration test helper initialized for manage_pipeline testing');
+
+    // Ensure the shared test project has a valid .gitlab-ci.yml on main before
+    // creating pipelines. The cross-file test data may point at a project seeded
+    // by an earlier run whose CI config predates the current format, so re-seed
+    // it here (overwrite=true) to keep pipeline creation deterministic instead of
+    // depending on test-file ordering. A unique marker guarantees the overwrite
+    // always commits a change.
+    const project = getTestData().project as { id: number } | undefined;
+    if (project?.id) {
+      await helper.executeTool('manage_files', {
+        action: 'single',
+        project_id: project.id.toString(),
+        file_path: '.gitlab-ci.yml',
+        branch: 'main',
+        content: buildCiConfigBase64(`manage_pipeline fixture ${Date.now()}`),
+        encoding: 'base64',
+        commit_message: 'Refresh CI config for pipeline tests',
+        overwrite: true,
+      });
+    }
   });
 
   describe('ManagePipelineSchema - create action', () => {
@@ -70,23 +90,18 @@ describe('manage_pipeline - GitLab Integration (CQRS)', () => {
         expect(schemaResult.success).toBe(true);
 
         if (schemaResult.success) {
-          try {
-            const pipeline = (await helper.executeTool(
-              'manage_pipeline',
-              schemaResult.data,
-            )) as Record<string, unknown>;
+          const pipeline = (await helper.executeTool(
+            'manage_pipeline',
+            schemaResult.data,
+          )) as Record<string, unknown>;
 
-            expect(pipeline).toHaveProperty('id');
-            expect(pipeline).toHaveProperty('status');
-            expect(pipeline).toHaveProperty('ref', 'main');
+          expect(pipeline).toHaveProperty('id');
+          expect(pipeline).toHaveProperty('status');
+          expect(pipeline).toHaveProperty('ref', 'main');
 
-            console.log(
-              `✅ Created pipeline with variables: ${pipeline.id} (status: ${pipeline.status})`,
-            );
-          } catch (error) {
-            // Pipeline creation may fail if no runners or CI disabled - that's OK for schema test
-            console.log(`⚠️ Pipeline creation failed (expected if no CI): ${error}`);
-          }
+          console.log(
+            `✅ Created pipeline with variables: ${pipeline.id} (status: ${pipeline.status})`,
+          );
         }
       });
     });
@@ -190,16 +205,13 @@ describe('manage_pipeline - GitLab Integration (CQRS)', () => {
               `✅ Created pipeline with inputs: ${pipeline.id} (status: ${pipeline.status})`,
             );
           } catch (error) {
-            // GitLab < 15.5 or invalid inputs spec will fail - log and continue
+            // Typed inputs require GitLab 15.5+. Skip only that specific gate;
+            // any other failure is a real error and must surface.
             const errorMsg = error instanceof Error ? error.message : String(error);
-            if (
-              errorMsg.includes('inputs') ||
-              errorMsg.includes('spec') ||
-              errorMsg.includes('15.5')
-            ) {
+            if (errorMsg.includes('inputs') || errorMsg.includes('15.5')) {
               console.log(`⚠️ Pipeline inputs not supported on this GitLab version: ${errorMsg}`);
             } else {
-              console.log(`⚠️ Pipeline creation failed: ${errorMsg}`);
+              throw error;
             }
           }
         }
@@ -265,8 +277,14 @@ describe('manage_pipeline - GitLab Integration (CQRS)', () => {
               `✅ Created pipeline with variables+inputs: ${pipeline.id} (status: ${pipeline.status})`,
             );
           } catch (error) {
+            // Typed inputs require GitLab 15.5+. Skip only that specific gate;
+            // any other failure is a real error and must surface.
             const errorMsg = error instanceof Error ? error.message : String(error);
-            console.log(`⚠️ Pipeline creation failed: ${errorMsg}`);
+            if (errorMsg.includes('inputs') || errorMsg.includes('15.5')) {
+              console.log(`⚠️ Pipeline inputs not supported on this GitLab version: ${errorMsg}`);
+            } else {
+              throw error;
+            }
           }
         }
       });

--- a/tests/integration/schemas/manage-pipeline.test.ts
+++ b/tests/integration/schemas/manage-pipeline.test.ts
@@ -15,6 +15,38 @@ import { ManagePipelineSchema } from '../../../src/entities/pipelines/schema';
 import { IntegrationTestHelper } from '../helpers/registry-helper';
 import { getTestData, buildCiConfigBase64 } from '../../setup/testConfig';
 
+/**
+ * Create a pipeline via manage_pipeline and assert the returned shape. Typed
+ * inputs require GitLab 15.5+; that specific version gate is tolerated (logged
+ * and skipped), while any other failure surfaces. Shared by the create tests so
+ * the assert/version-gate logic lives in one place.
+ */
+async function createPipelineAndAssert(
+  helper: IntegrationTestHelper,
+  params: unknown,
+  label: string,
+): Promise<void> {
+  try {
+    const pipeline = (await helper.executeTool('manage_pipeline', params)) as Record<
+      string,
+      unknown
+    >;
+    expect(pipeline).toHaveProperty('id');
+    expect(pipeline).toHaveProperty('status');
+    expect(pipeline).toHaveProperty('ref', 'main');
+    console.log(`✅ Created pipeline with ${label}: ${pipeline.id} (status: ${pipeline.status})`);
+  } catch (error) {
+    // Typed inputs require GitLab 15.5+. Skip only that specific gate; any other
+    // failure is a real error and must surface.
+    const errorMsg = error instanceof Error ? error.message : String(error);
+    if (errorMsg.includes('inputs') || errorMsg.includes('15.5')) {
+      console.log(`⚠️ Pipeline inputs not supported on this GitLab version: ${errorMsg}`);
+    } else {
+      throw error;
+    }
+  }
+}
+
 describe('manage_pipeline - GitLab Integration (CQRS)', () => {
   let helper: IntegrationTestHelper;
 
@@ -90,18 +122,7 @@ describe('manage_pipeline - GitLab Integration (CQRS)', () => {
         expect(schemaResult.success).toBe(true);
 
         if (schemaResult.success) {
-          const pipeline = (await helper.executeTool(
-            'manage_pipeline',
-            schemaResult.data,
-          )) as Record<string, unknown>;
-
-          expect(pipeline).toHaveProperty('id');
-          expect(pipeline).toHaveProperty('status');
-          expect(pipeline).toHaveProperty('ref', 'main');
-
-          console.log(
-            `✅ Created pipeline with variables: ${pipeline.id} (status: ${pipeline.status})`,
-          );
+          await createPipelineAndAssert(helper, schemaResult.data, 'variables');
         }
       });
     });
@@ -191,29 +212,7 @@ describe('manage_pipeline - GitLab Integration (CQRS)', () => {
         expect(schemaResult.success).toBe(true);
 
         if (schemaResult.success) {
-          try {
-            const pipeline = (await helper.executeTool(
-              'manage_pipeline',
-              schemaResult.data,
-            )) as Record<string, unknown>;
-
-            expect(pipeline).toHaveProperty('id');
-            expect(pipeline).toHaveProperty('status');
-            expect(pipeline).toHaveProperty('ref', 'main');
-
-            console.log(
-              `✅ Created pipeline with inputs: ${pipeline.id} (status: ${pipeline.status})`,
-            );
-          } catch (error) {
-            // Typed inputs require GitLab 15.5+. Skip only that specific gate;
-            // any other failure is a real error and must surface.
-            const errorMsg = error instanceof Error ? error.message : String(error);
-            if (errorMsg.includes('inputs') || errorMsg.includes('15.5')) {
-              console.log(`⚠️ Pipeline inputs not supported on this GitLab version: ${errorMsg}`);
-            } else {
-              throw error;
-            }
-          }
+          await createPipelineAndAssert(helper, schemaResult.data, 'inputs');
         }
       });
     });
@@ -264,28 +263,7 @@ describe('manage_pipeline - GitLab Integration (CQRS)', () => {
         expect(schemaResult.success).toBe(true);
 
         if (schemaResult.success) {
-          try {
-            const pipeline = (await helper.executeTool(
-              'manage_pipeline',
-              schemaResult.data,
-            )) as Record<string, unknown>;
-
-            expect(pipeline).toHaveProperty('id');
-            expect(pipeline).toHaveProperty('status');
-
-            console.log(
-              `✅ Created pipeline with variables+inputs: ${pipeline.id} (status: ${pipeline.status})`,
-            );
-          } catch (error) {
-            // Typed inputs require GitLab 15.5+. Skip only that specific gate;
-            // any other failure is a real error and must surface.
-            const errorMsg = error instanceof Error ? error.message : String(error);
-            if (errorMsg.includes('inputs') || errorMsg.includes('15.5')) {
-              console.log(`⚠️ Pipeline inputs not supported on this GitLab version: ${errorMsg}`);
-            } else {
-              throw error;
-            }
-          }
+          await createPipelineAndAssert(helper, schemaResult.data, 'variables+inputs');
         }
       });
     });

--- a/tests/integration/schemas/manage-pipeline.test.ts
+++ b/tests/integration/schemas/manage-pipeline.test.ts
@@ -11,15 +11,21 @@
  * - GitLab 15.5+ for inputs support
  */
 
+import { z } from 'zod';
 import { ManagePipelineSchema } from '../../../src/entities/pipelines/schema';
 import { IntegrationTestHelper } from '../helpers/registry-helper';
 import { getTestData, buildCiConfigBase64 } from '../../setup/testConfig';
 
+// Validate the created pipeline shape instead of casting the tool's external output.
+const PipelineResponseSchema = z.object({
+  id: z.number(),
+  status: z.string(),
+  ref: z.string(),
+});
+
 /**
- * Create a pipeline via manage_pipeline and assert the returned shape. Typed
- * inputs require GitLab 15.5+; that specific version gate is tolerated (logged
- * and skipped), while any other failure surfaces. Shared by the create tests so
- * the assert/version-gate logic lives in one place.
+ * Create a pipeline via manage_pipeline and assert the returned shape. Shared by
+ * the create tests so the validate/assert logic lives in one place.
  */
 async function createPipelineAndAssert(
   helper: IntegrationTestHelper,
@@ -31,10 +37,10 @@ async function createPipelineAndAssert(
   // a real regression and must surface. (Typed inputs require 15.5+, documented in
   // the file header; on older GitLab the CI config fails to parse, which correctly
   // signals the unmet prerequisite rather than being silently skipped.)
-  const pipeline = (await helper.executeTool('manage_pipeline', params)) as Record<string, unknown>;
-  expect(pipeline).toHaveProperty('id');
-  expect(pipeline).toHaveProperty('status');
-  expect(pipeline).toHaveProperty('ref', 'main');
+  const pipeline = PipelineResponseSchema.parse(
+    await helper.executeTool('manage_pipeline', params),
+  );
+  expect(pipeline.ref).toBe('main');
   console.log(`✅ Created pipeline with ${label}: ${pipeline.id} (status: ${pipeline.status})`);
 }
 

--- a/tests/integration/schemas/releases.test.ts
+++ b/tests/integration/schemas/releases.test.ts
@@ -433,10 +433,11 @@ describe('Releases Schema - GitLab Integration', () => {
         console.log(`Created test release: ${result.tag_name}`);
       } catch (error) {
         const errorMsg = error instanceof Error ? error.message : String(error);
-        // Skip gracefully when the environment can't provide a usable ref. The
-        // known flaky text is "Target <ref> is invalid" (empty repo / missing
-        // branch), alongside the older 404/ref/branch wording.
-        if (/(404|ref|branch|target|invalid)/i.test(errorMsg)) {
+        // Skip ONLY the specific "Target <ref> is invalid" failure, which means the
+        // chosen project's ref doesn't exist (empty repo / branch removed between
+        // selection and create) - an environment precondition, not a code defect.
+        // Any other error surfaces so real regressions aren't masked.
+        if (/target\b.+\bis invalid/i.test(errorMsg)) {
           console.log(`Could not create release for ref "${testProjectRef}": ${errorMsg}`);
           return;
         }

--- a/tests/integration/schemas/releases.test.ts
+++ b/tests/integration/schemas/releases.test.ts
@@ -3,10 +3,24 @@
  * Tests schemas using handler functions with real GitLab API
  */
 
+import { z } from 'zod';
 import { BrowseReleasesSchema } from '../../../src/entities/releases/schema-readonly';
 import { ManageReleaseSchema } from '../../../src/entities/releases/schema';
 import { IntegrationTestHelper } from '../helpers/registry-helper';
 import { getTestData } from '../../setup/testConfig';
+
+// Validate the project payloads we depend on instead of casting raw JSON, so a
+// malformed shape fails loudly here rather than surfacing as a confusing error later.
+const SeededProjectSchema = z.object({
+  id: z.number(),
+  default_branch: z.string().nullable().optional(),
+});
+const DiscoveredProjectSchema = z.object({
+  id: z.number(),
+  path_with_namespace: z.string(),
+  name: z.string(),
+  default_branch: z.string().nullable(),
+});
 
 describe('Releases Schema - GitLab Integration', () => {
   let helper: IntegrationTestHelper;
@@ -30,14 +44,12 @@ describe('Releases Schema - GitLab Integration', () => {
     // commit on `main`, so a release can be tagged against it deterministically.
     // Picking an arbitrary "test" project is unreliable - many are empty repos
     // whose `main` ref does not exist, producing "Target main is invalid".
-    const seeded = getTestData().project as
-      | { id: number; default_branch?: string | null }
-      | undefined;
-    if (seeded?.id) {
-      testProjectId = seeded.id.toString();
+    const seeded = SeededProjectSchema.safeParse(getTestData().project);
+    if (seeded.success) {
+      testProjectId = seeded.data.id.toString();
       // The project record is captured at creation time (empty repo), so
       // default_branch is usually null; the lifecycle suite commits to `main`.
-      testProjectRef = seeded.default_branch || 'main';
+      testProjectRef = seeded.data.default_branch || 'main';
       console.log(
         `Using seeded project ${testProjectId} (ref: ${testProjectRef}) for releases testing`,
       );
@@ -47,16 +59,9 @@ describe('Releases Schema - GitLab Integration', () => {
     // Fallback: discover a test project that reports a default branch (non-empty
     // repository). simple=false surfaces default_branch, which is null for empty
     // repos; a release can only be tagged against an existing ref.
-    const projects = (await helper.listProjects({
-      search: 'test',
-      per_page: 20,
-      simple: false,
-    })) as {
-      id: number;
-      path_with_namespace: string;
-      name: string;
-      default_branch: string | null;
-    }[];
+    const projects = z
+      .array(DiscoveredProjectSchema)
+      .parse(await helper.listProjects({ search: 'test', per_page: 20, simple: false }));
 
     const usable = projects.filter((p) => Boolean(p.default_branch));
     const selectedProject =
@@ -68,7 +73,7 @@ describe('Releases Schema - GitLab Integration', () => {
     }
 
     testProjectId = selectedProject.id.toString();
-    testProjectRef = selectedProject.default_branch as string;
+    testProjectRef = selectedProject.default_branch || 'main';
     console.log(
       `Using project: ${selectedProject.path_with_namespace} (ID: ${testProjectId}, ref: ${testProjectRef}) for releases testing`,
     );
@@ -428,9 +433,11 @@ describe('Releases Schema - GitLab Integration', () => {
         console.log(`Created test release: ${result.tag_name}`);
       } catch (error) {
         const errorMsg = error instanceof Error ? error.message : String(error);
-        // If ref doesn't exist, skip the test gracefully
-        if (errorMsg.includes('404') || errorMsg.includes('ref') || errorMsg.includes('branch')) {
-          console.log('Could not create release: main branch may not exist or ref issue');
+        // Skip gracefully when the environment can't provide a usable ref. The
+        // known flaky text is "Target <ref> is invalid" (empty repo / missing
+        // branch), alongside the older 404/ref/branch wording.
+        if (/(404|ref|branch|target|invalid)/i.test(errorMsg)) {
+          console.log(`Could not create release for ref "${testProjectRef}": ${errorMsg}`);
           return;
         }
         throw error;

--- a/tests/integration/schemas/releases.test.ts
+++ b/tests/integration/schemas/releases.test.ts
@@ -6,10 +6,15 @@
 import { BrowseReleasesSchema } from '../../../src/entities/releases/schema-readonly';
 import { ManageReleaseSchema } from '../../../src/entities/releases/schema';
 import { IntegrationTestHelper } from '../helpers/registry-helper';
+import { getTestData } from '../../setup/testConfig';
 
 describe('Releases Schema - GitLab Integration', () => {
   let helper: IntegrationTestHelper;
   let testProjectId: string;
+  // Real branch to tag the release against. Hardcoding 'main' fails with
+  // "Target main is invalid" on projects whose default branch differs or whose
+  // repository is empty, so we seed this from the chosen project's default_branch.
+  let testProjectRef: string;
 
   beforeAll(async () => {
     const GITLAB_TOKEN = process.env.GITLAB_TOKEN;
@@ -21,25 +26,51 @@ describe('Releases Schema - GitLab Integration', () => {
     await helper.initialize();
     console.log('Integration test helper initialized for releases testing');
 
-    // Get a test project - preferably from the test group
-    const projects = (await helper.listProjects({ search: 'test', per_page: 5 })) as {
-      id: number;
-      path_with_namespace: string;
-      name: string;
-    }[];
-
-    if (projects.length === 0) {
-      console.log('No projects available for releases testing');
+    // Prefer the project seeded by the data-lifecycle suite: it has a known
+    // commit on `main`, so a release can be tagged against it deterministically.
+    // Picking an arbitrary "test" project is unreliable - many are empty repos
+    // whose `main` ref does not exist, producing "Target main is invalid".
+    const seeded = getTestData().project as
+      | { id: number; default_branch?: string | null }
+      | undefined;
+    if (seeded?.id) {
+      testProjectId = seeded.id.toString();
+      // The project record is captured at creation time (empty repo), so
+      // default_branch is usually null; the lifecycle suite commits to `main`.
+      testProjectRef = seeded.default_branch || 'main';
+      console.log(
+        `Using seeded project ${testProjectId} (ref: ${testProjectRef}) for releases testing`,
+      );
       return;
     }
 
-    // Prefer a project in the 'test' group
-    const testGroupProject = projects.find((p) => p.path_with_namespace.startsWith('test/'));
-    const selectedProject = testGroupProject ?? projects[0];
+    // Fallback: discover a test project that reports a default branch (non-empty
+    // repository). simple=false surfaces default_branch, which is null for empty
+    // repos; a release can only be tagged against an existing ref.
+    const projects = (await helper.listProjects({
+      search: 'test',
+      per_page: 20,
+      simple: false,
+    })) as {
+      id: number;
+      path_with_namespace: string;
+      name: string;
+      default_branch: string | null;
+    }[];
+
+    const usable = projects.filter((p) => Boolean(p.default_branch));
+    const selectedProject =
+      usable.find((p) => p.path_with_namespace.startsWith('test/')) ?? usable[0];
+
+    if (!selectedProject) {
+      console.log('No test project with a default branch available for releases testing');
+      return;
+    }
 
     testProjectId = selectedProject.id.toString();
+    testProjectRef = selectedProject.default_branch as string;
     console.log(
-      `Using project: ${selectedProject.path_with_namespace} (ID: ${testProjectId}) for releases testing`,
+      `Using project: ${selectedProject.path_with_namespace} (ID: ${testProjectId}, ref: ${testProjectRef}) for releases testing`,
     );
   });
 
@@ -383,7 +414,7 @@ describe('Releases Schema - GitLab Integration', () => {
           tag_name: testTagName,
           name: `Test Release ${testTagName}`,
           description: 'Integration test release - will be deleted',
-          ref: 'main', // Create new tag from main branch
+          ref: testProjectRef, // Create new tag from the project's real default branch
         })) as {
           tag_name: string;
           name: string;

--- a/tests/setup/testConfig.ts
+++ b/tests/setup/testConfig.ts
@@ -113,3 +113,36 @@ export const getTestGroup = () => {
   const data = requireTestData();
   return data.group;
 };
+
+/**
+ * Build a valid `.gitlab-ci.yml` (base64-encoded) used to seed test projects for
+ * pipeline tests. The `spec:inputs` header MUST be its own YAML document,
+ * separated from the job config by a `---` document separator; without it GitLab
+ * rejects the file with "Invalid configuration format". The job runs for
+ * API-triggered pipelines (so `manage_pipeline create` produces a runnable
+ * pipeline) and is manual otherwise (so commits do not auto-trigger pipelines).
+ *
+ * @param marker optional trailing comment so an overwrite always commits a change
+ *   (avoids "file unchanged" when re-seeding an already-valid project).
+ */
+export const buildCiConfigBase64 = (marker = ''): string => {
+  const yaml = `spec:
+  inputs:
+    environment:
+      type: string
+      default: test
+    debug:
+      type: boolean
+      default: false
+    count:
+      type: number
+      default: 1
+---
+test-job:
+  script: echo "Environment is $[[ inputs.environment ]]"
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "api"'
+    - when: manual
+${marker ? `# ${marker}\n` : ''}`;
+  return Buffer.from(yaml).toString('base64');
+};


### PR DESCRIPTION
## Summary

Fixes two long-standing flaky/masked integration tests against the live GitLab instance.

### Release lifecycle (`releases.test.ts`)
The `should create a new release` test hardcoded `ref: 'main'` and picked an arbitrary "test" project. On projects whose default branch differs, or whose repository is empty, GitLab rejects the tag with `400 - Target main is invalid`, so the lifecycle chain failed.

- Use the project seeded by the data-lifecycle suite (it has a known commit on `main`).
- Fall back to discovering a project that reports a `default_branch` (non-empty repo) and tag against that branch.

### Pipeline creation (`manage-pipeline.test.ts` + `data-lifecycle.test.ts`)
The seeded `.gitlab-ci.yml` omitted the `---` document separator after the `spec:inputs` header, so GitLab rejected it with `Invalid configuration format`. The pipeline tests then swallowed the error in a catch, so creation was never actually verified.

- Move the CI config into a shared `buildCiConfigBase64()` builder with the correct format (spec header as its own `---` document; job runs on API-triggered pipelines, manual otherwise).
- Re-seed the CI file before the pipeline tests via `manage_files`, so creation no longer depends on stale cross-run test data or test-file ordering.
- Remove the error-swallowing; assert the pipeline is actually created. Only the GitLab < 15.5 inputs version-gate is skipped explicitly.

## Testing
- `yarn test:integration` — 410 passed, 34 suites, 0 `Invalid configuration format` / `Target main is invalid`.
- `yarn test` (unit) — 5023 passed.

Closes #454

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a helper to generate base64-encoded CI config content and use it when seeding projects.
  * Ensure repository files are written with base64 encoding so CI config is interpreted correctly.
  * Introduced a shared pipeline-creation helper and tightened assertions (failures now surface).
  * Select test project refs from seeded data when available and refine release/pipeline error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->