### PR TITLE
feat(projects): support 'active' filter on browse_projects list

### DIFF
--- a/src/entities/core/registry.ts
+++ b/src/entities/core/registry.ts
@@ -196,9 +196,14 @@ export const coreToolRegistry: ToolRegistry = new Map<string, EnhancedToolDefini
             }
             const applyActiveFilter = (value: boolean): void => {
               if (activeFilterSupported) {
+                // active wins over an explicit archived filter: drop archived so the
+                // request never sends both (which would make precedence ambiguous).
+                queryParams.delete('archived');
                 queryParams.set('active', String(value));
               } else {
-                // active wins over an explicit archived filter on older instances.
+                // No native active filter; translate to archived and drop any active
+                // hint so the two never coexist.
+                queryParams.delete('active');
                 queryParams.set('archived', String(!value));
               }
             };

--- a/src/entities/core/registry.ts
+++ b/src/entities/core/registry.ts
@@ -145,6 +145,7 @@ export const coreToolRegistry: ToolRegistry = new Map<string, EnhancedToolDefini
               with_shared,
               include_deleted,
               marked_for_deletion_on,
+              active,
               visibility,
               archived,
               order_by,
@@ -178,15 +179,44 @@ export const coreToolRegistry: ToolRegistry = new Map<string, EnhancedToolDefini
             if (!queryParams.has('simple')) queryParams.set('simple', 'true');
             if (!queryParams.has('per_page')) queryParams.set('per_page', '20');
 
+            // The native `active` query parameter landed in GitLab 18.5. On older
+            // instances translate it to the long-standing `archived` filter
+            // (active=true => archived=false), which is server-side and therefore
+            // pagination-safe. Projects pending deletion are already hidden from
+            // default listings, so this mapping matches `active` semantics. The
+            // instance version is detected at startup, so this is a cheap in-memory
+            // read; an unknown version fails open to the native parameter.
+            let activeFilterSupported = true;
+            try {
+              const version = ConnectionManager.getInstance().getInstanceInfo().version;
+              activeFilterSupported =
+                version === 'unknown' || parseVersion(version) >= parseVersion('18.5');
+            } catch {
+              // Connection not initialised — assume supported (fail-open).
+            }
+            const applyActiveFilter = (value: boolean): void => {
+              if (activeFilterSupported) {
+                queryParams.set('active', String(value));
+              } else {
+                // active wins over an explicit archived filter on older instances.
+                queryParams.set('archived', String(!value));
+              }
+            };
+
             let apiUrl: string;
             if (group_id) {
+              if (active !== undefined) applyActiveFilter(active);
               apiUrl = `${process.env.GITLAB_API_URL}/api/v4/groups/${normalizeProjectId(group_id)}/projects?${queryParams}`;
             } else if (include_deleted) {
               // include_pending_delete returns soft-deleted projects; do NOT also send
               // active=true, which would filter them back out (admin only).
               queryParams.set('include_pending_delete', 'true');
               apiUrl = `${process.env.GITLAB_API_URL}/api/v4/projects?${queryParams}`;
+            } else if (active !== undefined) {
+              applyActiveFilter(active);
+              apiUrl = `${process.env.GITLAB_API_URL}/api/v4/projects?${queryParams}`;
             } else {
+              // Default: list active projects (historical behaviour, unchanged).
               queryParams.set('active', 'true');
               apiUrl = `${process.env.GITLAB_API_URL}/api/v4/projects?${queryParams}`;
             }

--- a/src/entities/core/schema-readonly.ts
+++ b/src/entities/core/schema-readonly.ts
@@ -111,6 +111,14 @@ const ListProjectsSchema = z.object({
       'Filter projects scheduled for deletion on this exact date (YYYY-MM-DD). Premium/Ultimate ' +
         'only. Combine with include_deleted to review projects purging on a given day. Ignored for group_id scope.',
     ),
+  active: flexibleBoolean
+    .optional()
+    .describe(
+      'Filter by active status. true = exclude archived AND pending-deletion projects; ' +
+        'false = only archived/pending-deletion. Uses the native GitLab 18.5+ filter; on older ' +
+        'instances it falls back to the archived filter (pending-deletion projects are already ' +
+        'hidden from default listings). When omitted, active projects are listed as before.',
+    ),
   visibility: projectVisibilityField,
   archived: projectArchivedField,
   order_by: projectOrderByField,

--- a/tests/integration/schemas/list-projects.test.ts
+++ b/tests/integration/schemas/list-projects.test.ts
@@ -203,6 +203,40 @@ describe('BrowseProjectsSchema - GitLab 18.3 Integration', () => {
       console.log('✅ BrowseProjectsSchema validates advanced filtering parameters');
     });
 
+    it('should validate the active filter parameter', async () => {
+      for (const active of [true, false]) {
+        const result = BrowseProjectsSchema.safeParse({ action: 'list' as const, active });
+        expect(result.success).toBe(true);
+        if (result.success && result.data.action === 'list') {
+          expect(result.data.active).toBe(active);
+        }
+      }
+      console.log('✅ BrowseProjectsSchema validates the active filter parameter');
+    });
+
+    it('should list active projects end-to-end (active=true)', async () => {
+      // The test instance is GitLab 18.5+, so this exercises the native `active`
+      // query parameter. The sub-18.5 archived-translation fallback cannot run
+      // against a modern live instance and is covered by unit tests.
+      const projects = await listAndAssertProjectShapes({
+        action: 'list' as const,
+        active: true,
+        per_page: 5,
+      });
+      console.log(`  active=true returned ${projects.length} projects`);
+    }, 15000);
+
+    it('should accept active=false for archived/pending-delete projects', async () => {
+      // Whether any archived/pending-delete project exists is environment-specific,
+      // so assert the result shape rather than a count.
+      const projects = await listAndAssertProjectShapes({
+        action: 'list' as const,
+        active: false,
+        per_page: 5,
+      });
+      console.log(`  active=false returned ${projects.length} projects`);
+    }, 15000);
+
     it('should handle optional parameters correctly', async () => {
       // Test with minimal required parameters (only action)
       const minimalParams = {

--- a/tests/unit/entities/core/registry.test.ts
+++ b/tests/unit/entities/core/registry.test.ts
@@ -33,6 +33,29 @@ const okJson = (payload: unknown) =>
   ({ ok: true, status: 200, json: jest.fn().mockResolvedValue(payload) }) as unknown as Response;
 const mockIsActionDenied = isActionDenied as jest.MockedFunction<typeof isActionDenied>;
 
+/** Run browse_projects `list` with the given args and return the fetched URL. */
+async function browseProjectsListUrl(args: Record<string, unknown>): Promise<string> {
+  mockEnhancedFetch.mockResolvedValueOnce(okJson([{ id: 1, name: 'project1' }]));
+  const tool = coreToolRegistry.get('browse_projects');
+  await tool!.handler({ action: 'list', ...args });
+  return mockEnhancedFetch.mock.calls[0][0];
+}
+
+/** Same as {@link browseProjectsListUrl} but with a mocked detected instance version. */
+async function browseProjectsListUrlAtVersion(
+  args: Record<string, unknown>,
+  version: string,
+): Promise<string> {
+  const spy = jest
+    .spyOn(ConnectionManager.getInstance(), 'getInstanceInfo')
+    .mockReturnValue({ version, tier: 'free' } as GitLabInstanceInfo);
+  try {
+    return await browseProjectsListUrl(args);
+  } finally {
+    spy.mockRestore();
+  }
+}
+
 // Mock environment variables
 const originalEnv = process.env;
 
@@ -453,115 +476,55 @@ describe('Core Registry', () => {
       it('sends the native active filter on GitLab 18.5+ (active=false)', async () => {
         // Version unknown / uninitialised fails open to the native parameter,
         // so the explicit active=false must reach the API verbatim.
-        mockEnhancedFetch.mockResolvedValueOnce(okJson([{ id: 1, name: 'archived-project' }]));
-
-        const tool = coreToolRegistry.get('browse_projects');
-        await tool!.handler({ action: 'list', active: false });
-
-        const calledUrl = mockEnhancedFetch.mock.calls[0][0];
-        expect(calledUrl).toContain('active=false');
-        expect(calledUrl).not.toContain('archived=');
+        const url = await browseProjectsListUrl({ active: false });
+        expect(url).toContain('active=false');
+        expect(url).not.toContain('archived=');
       });
 
       it('falls back to the archived filter on GitLab below 18.5', async () => {
         // active=true => archived=false, sent server-side so pagination stays correct.
-        const spy = jest
-          .spyOn(ConnectionManager.getInstance(), 'getInstanceInfo')
-          .mockReturnValue({ version: '18.0.0', tier: 'free' } as GitLabInstanceInfo);
-        try {
-          mockEnhancedFetch.mockResolvedValueOnce(okJson([{ id: 1, name: 'project1' }]));
-
-          const tool = coreToolRegistry.get('browse_projects');
-          await tool!.handler({ action: 'list', active: true });
-
-          const calledUrl = mockEnhancedFetch.mock.calls[0][0];
-          expect(calledUrl).toContain('archived=false');
-          expect(calledUrl).not.toContain('active=');
-        } finally {
-          spy.mockRestore();
-        }
+        const url = await browseProjectsListUrlAtVersion({ active: true }, '18.0.0');
+        expect(url).toContain('archived=false');
+        expect(url).not.toContain('active=');
       });
 
       it('translates active=false to archived=true on GitLab below 18.5', async () => {
-        const spy = jest
-          .spyOn(ConnectionManager.getInstance(), 'getInstanceInfo')
-          .mockReturnValue({ version: '18.0.0', tier: 'free' } as GitLabInstanceInfo);
-        try {
-          mockEnhancedFetch.mockResolvedValueOnce(okJson([{ id: 1, name: 'archived-project' }]));
-
-          const tool = coreToolRegistry.get('browse_projects');
-          await tool!.handler({ action: 'list', active: false });
-
-          const calledUrl = mockEnhancedFetch.mock.calls[0][0];
-          expect(calledUrl).toContain('archived=true');
-          expect(calledUrl).not.toContain('active=');
-        } finally {
-          spy.mockRestore();
-        }
+        const url = await browseProjectsListUrlAtVersion({ active: false }, '18.0.0');
+        expect(url).toContain('archived=true');
+        expect(url).not.toContain('active=');
       });
 
       it('applies the active filter to group-scoped listing', async () => {
-        mockEnhancedFetch.mockResolvedValueOnce(okJson([{ id: 1, name: 'group-project' }]));
-
-        const tool = coreToolRegistry.get('browse_projects');
-        await tool!.handler({ action: 'list', group_id: 'my-group', active: true });
-
-        const calledUrl = mockEnhancedFetch.mock.calls[0][0];
-        expect(calledUrl).toContain('/api/v4/groups/my-group/projects?');
-        expect(calledUrl).toContain('active=true');
+        const url = await browseProjectsListUrl({ group_id: 'my-group', active: true });
+        expect(url).toContain('/api/v4/groups/my-group/projects?');
+        expect(url).toContain('active=true');
       });
 
       it('keeps the historical active=true default when active is omitted', async () => {
         // Default listing on a sub-18.5 instance must NOT switch to the archived
         // translation; the implicit default is unchanged to avoid a regression.
-        const spy = jest
-          .spyOn(ConnectionManager.getInstance(), 'getInstanceInfo')
-          .mockReturnValue({ version: '18.0.0', tier: 'free' } as GitLabInstanceInfo);
-        try {
-          mockEnhancedFetch.mockResolvedValueOnce(okJson([{ id: 1, name: 'project1' }]));
-
-          const tool = coreToolRegistry.get('browse_projects');
-          await tool!.handler({ action: 'list' });
-
-          const calledUrl = mockEnhancedFetch.mock.calls[0][0];
-          expect(calledUrl).toContain('active=true');
-          expect(calledUrl).not.toContain('archived=');
-        } finally {
-          spy.mockRestore();
-        }
+        const url = await browseProjectsListUrlAtVersion({}, '18.0.0');
+        expect(url).toContain('active=true');
+        expect(url).not.toContain('archived=');
       });
 
       it('lets active override archived when both are passed on GitLab 18.5+', async () => {
         // Native path: sending both active and archived makes precedence ambiguous.
         // active must win, so the conflicting archived param is dropped.
-        mockEnhancedFetch.mockResolvedValueOnce(okJson([{ id: 1, name: 'project1' }]));
-
-        const tool = coreToolRegistry.get('browse_projects');
-        await tool!.handler({ action: 'list', active: false, archived: false });
-
-        const calledUrl = mockEnhancedFetch.mock.calls[0][0];
-        expect(calledUrl).toContain('active=false');
-        expect(calledUrl).not.toContain('archived=');
+        const url = await browseProjectsListUrl({ active: false, archived: false });
+        expect(url).toContain('active=false');
+        expect(url).not.toContain('archived=');
       });
 
       it('lets active override archived on GitLab below 18.5', async () => {
         // Fallback path: active=true => archived=false, overriding an explicit
         // archived=true, and no stray active param is sent.
-        const spy = jest
-          .spyOn(ConnectionManager.getInstance(), 'getInstanceInfo')
-          .mockReturnValue({ version: '18.0.0', tier: 'free' } as GitLabInstanceInfo);
-        try {
-          mockEnhancedFetch.mockResolvedValueOnce(okJson([{ id: 1, name: 'project1' }]));
-
-          const tool = coreToolRegistry.get('browse_projects');
-          await tool!.handler({ action: 'list', active: true, archived: true });
-
-          const calledUrl = mockEnhancedFetch.mock.calls[0][0];
-          expect(calledUrl).toContain('archived=false');
-          expect(calledUrl).not.toContain('active=');
-        } finally {
-          spy.mockRestore();
-        }
+        const url = await browseProjectsListUrlAtVersion(
+          { active: true, archived: true },
+          '18.0.0',
+        );
+        expect(url).toContain('archived=false');
+        expect(url).not.toContain('active=');
       });
 
       it('should get project with action: get', async () => {

--- a/tests/unit/entities/core/registry.test.ts
+++ b/tests/unit/entities/core/registry.test.ts
@@ -450,6 +450,87 @@ describe('Core Registry', () => {
         });
       });
 
+      it('sends the native active filter on GitLab 18.5+ (active=false)', async () => {
+        // Version unknown / uninitialised fails open to the native parameter,
+        // so the explicit active=false must reach the API verbatim.
+        mockEnhancedFetch.mockResolvedValueOnce(okJson([{ id: 1, name: 'archived-project' }]));
+
+        const tool = coreToolRegistry.get('browse_projects');
+        await tool!.handler({ action: 'list', active: false });
+
+        const calledUrl = mockEnhancedFetch.mock.calls[0][0];
+        expect(calledUrl).toContain('active=false');
+        expect(calledUrl).not.toContain('archived=');
+      });
+
+      it('falls back to the archived filter on GitLab below 18.5', async () => {
+        // active=true => archived=false, sent server-side so pagination stays correct.
+        const spy = jest
+          .spyOn(ConnectionManager.getInstance(), 'getInstanceInfo')
+          .mockReturnValue({ version: '18.0.0', tier: 'free' } as GitLabInstanceInfo);
+        try {
+          mockEnhancedFetch.mockResolvedValueOnce(okJson([{ id: 1, name: 'project1' }]));
+
+          const tool = coreToolRegistry.get('browse_projects');
+          await tool!.handler({ action: 'list', active: true });
+
+          const calledUrl = mockEnhancedFetch.mock.calls[0][0];
+          expect(calledUrl).toContain('archived=false');
+          expect(calledUrl).not.toContain('active=');
+        } finally {
+          spy.mockRestore();
+        }
+      });
+
+      it('translates active=false to archived=true on GitLab below 18.5', async () => {
+        const spy = jest
+          .spyOn(ConnectionManager.getInstance(), 'getInstanceInfo')
+          .mockReturnValue({ version: '18.0.0', tier: 'free' } as GitLabInstanceInfo);
+        try {
+          mockEnhancedFetch.mockResolvedValueOnce(okJson([{ id: 1, name: 'archived-project' }]));
+
+          const tool = coreToolRegistry.get('browse_projects');
+          await tool!.handler({ action: 'list', active: false });
+
+          const calledUrl = mockEnhancedFetch.mock.calls[0][0];
+          expect(calledUrl).toContain('archived=true');
+          expect(calledUrl).not.toContain('active=');
+        } finally {
+          spy.mockRestore();
+        }
+      });
+
+      it('applies the active filter to group-scoped listing', async () => {
+        mockEnhancedFetch.mockResolvedValueOnce(okJson([{ id: 1, name: 'group-project' }]));
+
+        const tool = coreToolRegistry.get('browse_projects');
+        await tool!.handler({ action: 'list', group_id: 'my-group', active: true });
+
+        const calledUrl = mockEnhancedFetch.mock.calls[0][0];
+        expect(calledUrl).toContain('/api/v4/groups/my-group/projects?');
+        expect(calledUrl).toContain('active=true');
+      });
+
+      it('keeps the historical active=true default when active is omitted', async () => {
+        // Default listing on a sub-18.5 instance must NOT switch to the archived
+        // translation; the implicit default is unchanged to avoid a regression.
+        const spy = jest
+          .spyOn(ConnectionManager.getInstance(), 'getInstanceInfo')
+          .mockReturnValue({ version: '18.0.0', tier: 'free' } as GitLabInstanceInfo);
+        try {
+          mockEnhancedFetch.mockResolvedValueOnce(okJson([{ id: 1, name: 'project1' }]));
+
+          const tool = coreToolRegistry.get('browse_projects');
+          await tool!.handler({ action: 'list' });
+
+          const calledUrl = mockEnhancedFetch.mock.calls[0][0];
+          expect(calledUrl).toContain('active=true');
+          expect(calledUrl).not.toContain('archived=');
+        } finally {
+          spy.mockRestore();
+        }
+      });
+
       it('should get project with action: get', async () => {
         const mockApiResponse = {
           id: 123,

--- a/tests/unit/entities/core/registry.test.ts
+++ b/tests/unit/entities/core/registry.test.ts
@@ -531,6 +531,39 @@ describe('Core Registry', () => {
         }
       });
 
+      it('lets active override archived when both are passed on GitLab 18.5+', async () => {
+        // Native path: sending both active and archived makes precedence ambiguous.
+        // active must win, so the conflicting archived param is dropped.
+        mockEnhancedFetch.mockResolvedValueOnce(okJson([{ id: 1, name: 'project1' }]));
+
+        const tool = coreToolRegistry.get('browse_projects');
+        await tool!.handler({ action: 'list', active: false, archived: false });
+
+        const calledUrl = mockEnhancedFetch.mock.calls[0][0];
+        expect(calledUrl).toContain('active=false');
+        expect(calledUrl).not.toContain('archived=');
+      });
+
+      it('lets active override archived on GitLab below 18.5', async () => {
+        // Fallback path: active=true => archived=false, overriding an explicit
+        // archived=true, and no stray active param is sent.
+        const spy = jest
+          .spyOn(ConnectionManager.getInstance(), 'getInstanceInfo')
+          .mockReturnValue({ version: '18.0.0', tier: 'free' } as GitLabInstanceInfo);
+        try {
+          mockEnhancedFetch.mockResolvedValueOnce(okJson([{ id: 1, name: 'project1' }]));
+
+          const tool = coreToolRegistry.get('browse_projects');
+          await tool!.handler({ action: 'list', active: true, archived: true });
+
+          const calledUrl = mockEnhancedFetch.mock.calls[0][0];
+          expect(calledUrl).toContain('archived=false');
+          expect(calledUrl).not.toContain('active=');
+        } finally {
+          spy.mockRestore();
+        }
+      });
+
       it('should get project with action: get', async () => {
         const mockApiResponse = {
           id: 123,


### PR DESCRIPTION
## Summary

Adds an optional `active` filter to the `browse_projects` `list` action. GitLab 18.5 introduced a native `active` query parameter that returns only non-archived, non-pending-deletion projects in one shot.

- New optional `active?: boolean` param on the list action schema.
- **GitLab 18.5+** (or unknown version, fail-open): sends the native `active=true|false`.
- **Older instances**: falls back to the long-standing `archived` filter server-side (`active=true` -> `archived=false`), which is **pagination-safe** (no client-side row dropping). Projects pending deletion are already excluded from default listings, so this matches `active` semantics for the common case.
- Version is read from the cached instance info (`ConnectionManager`), so the gate is a cheap in-memory check.
- Omitting the parameter preserves the existing active-by-default listing (no behaviour change).

## Why server-side fallback instead of client-side filtering
Filtering a fetched page client-side breaks pagination (off-by-one), which the issue itself calls out. Translating to the `archived` query parameter keeps filtering on the server across all versions.

## Testing
- Unit (`registry.test.ts`): native `active=true|false` on 18.5+, archived fallback on <18.5 (both directions), group-scoped filter, and unchanged default when omitted.
- Integration (`list-projects.test.ts`): schema validation + end-to-end `active=true`/`active=false` against the live instance.
- `yarn test` (unit): 5028 passed. Lint + build clean.

Closes #435

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional "active" filter for project listings that respects GitLab version capabilities and falls back to legacy archived semantics when needed; when both filters are supplied, "active" takes precedence.
* **Tests**
  * Extended unit and integration tests to cover "active" behavior across GitLab versions, group-scoped listings, defaults, and precedence scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->