### PR TITLE
docs(readme): lead with CQRS differentiator

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 [![npm version](https://img.shields.io/npm/v/@structured-world/gitlab-mcp)](https://www.npmjs.com/package/@structured-world/gitlab-mcp) [![npm downloads](https://img.shields.io/npm/dm/@structured-world/gitlab-mcp)](https://www.npmjs.com/package/@structured-world/gitlab-mcp) [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE) [![Release](https://github.com/structured-world/gitlab-mcp/workflows/Release/badge.svg)](https://github.com/structured-world/gitlab-mcp/actions) [![Coverage](https://codecov.io/gh/structured-world/gitlab-mcp/graph/badge.svg)](https://codecov.io/gh/structured-world/gitlab-mcp) [![Coverage Report](https://img.shields.io/badge/Coverage-Live%20Report-brightgreen?logo=github)](https://gitlab-mcp.sw.foundation/coverage/)
 
-Advanced GitLab MCP server — 44 tools across 18 entity types with CQRS architecture, OAuth 2.1, and multiple transport modes.
+Advanced GitLab MCP server — 50 CQRS tools exposing 193 GitLab operations across 21 entity types. The tool catalog and parameters are filtered to each instance's GitLab version, tier, and token scopes, so the agent sees only what the connected instance actually supports.
 
-[![Install in Claude Desktop](https://img.shields.io/badge/Claude_Desktop-Install_Extension-F97316?style=for-the-badge)](https://gitlab-mcp.sw.foundation/downloads/gitlab-mcp-6.62.2.mcpb)
+[![Install in Claude Desktop](https://img.shields.io/badge/Claude_Desktop-Install_Extension-F97316?style=for-the-badge)](https://gitlab-mcp.sw.foundation/downloads/gitlab-mcp-7.6.0.mcpb)
 [![Install in VS Code](https://img.shields.io/badge/VS_Code-Install_MCP_Server-007ACC?style=for-the-badge&logo=visualstudiocode&logoColor=white)](vscode:mcp/install?%7B%22name%22%3A%22gitlab-mcp%22%2C%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22%40structured-world%2Fgitlab-mcp%22%5D%7D)
 [![Install in VS Code Insiders](https://img.shields.io/badge/VS_Code_Insiders-Install_MCP_Server-24bfa5?style=for-the-badge&logo=visualstudiocode&logoColor=white)](vscode-insiders:mcp/install?%7B%22name%22%3A%22gitlab-mcp%22%2C%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22%40structured-world%2Fgitlab-mcp%22%5D%7D)
 
@@ -29,16 +29,37 @@ Advanced GitLab MCP server — 44 tools across 18 entity types with CQRS archite
 
 ## Highlights
 
-- **44 tools** across 18 entity types — projects, merge requests, pipelines, work items, wiki, and more
+- **50 tools** across 21 entity types — projects, merge requests, pipelines, work items, wiki, and more
 - **CQRS architecture** — `browse_*` for queries, `manage_*` for commands
 - **Connection resilience** — Bounded startup, auto-reconnect with exponential backoff, disconnected mode when GitLab is unreachable
-- **Multi-instance support** — Connect to multiple GitLab instances with per-instance OAuth and rate limiting
+- **Multi-instance support** — Connect to GitLab.com, self-managed, and self-hosted instances with per-instance OAuth and rate limiting
 - **Multiple transports** — stdio, SSE, StreamableHTTP
 - **OAuth 2.1** — Per-user authentication via Claude Custom Connector
 - **Read-only mode** — Safe operation for production environments
 - **Auto-discovery** — Detects GitLab config from git remotes
 - **Fine-grained control** — Enable/disable tool groups, filter actions, customize descriptions
 - **Docker support** — `ghcr.io/structured-world/gitlab-mcp:latest`
+
+## Tool model
+
+GitLab exposes hundreds of API operations. Giving each its own MCP tool floods an
+agent's context; a thin API wrapper pushes that complexity back onto the agent. This
+server takes a third path: 50 CQRS tools, each holding several typed
+actions, expose 193 operations across 21 entity types.
+
+- `browse_*` tools are read-only queries; `manage_*` tools are writes.
+- Sub-resources fold into actions rather than new tools — `browse_pipelines` covers
+  pipelines, jobs, and logs in a single tool.
+- The tool list, actions, and parameters are resolved at schema-generation time
+  against GitLab version, tier, token scopes, admin-mode, feature flags, and profiles.
+
+Examples:
+
+- `browse_pipelines` — list, get, jobs, job, logs, triggers
+- `manage_pipeline` — create, retry, cancel
+- `browse_environments` — list, get, list_deployments
+- `manage_environment` — create, update, stop, delete, update_deployment_status
+- `browse_deploy_keys` / `manage_deploy_key` — list, get / add, enable, update, delete
 
 ## Documentation
 
@@ -49,7 +70,7 @@ Full documentation is available at **[gitlab-mcp.sw.foundation](https://gitlab-m
 | [Installation](https://gitlab-mcp.sw.foundation/guide/installation/npm) | npm, Docker, VS Code, Codex |
 | [Configuration](https://gitlab-mcp.sw.foundation/guide/configuration) | Environment variables, feature flags |
 | [Multi-Instance](https://gitlab-mcp.sw.foundation/guide/multi-instance) | Connect to multiple GitLab instances |
-| [Tool Reference](https://gitlab-mcp.sw.foundation/tools/) | All 44 tools with parameters |
+| [Tool Reference](https://gitlab-mcp.sw.foundation/tools/) | All 50 tools with parameters |
 | [OAuth Setup](https://gitlab-mcp.sw.foundation/security/oauth) | Team authentication with Claude |
 | [TLS/HTTPS](https://gitlab-mcp.sw.foundation/advanced/tls) | Production deployment with SSL |
 | [Customization](https://gitlab-mcp.sw.foundation/advanced/customization) | Tool descriptions, action filtering |
@@ -124,6 +145,12 @@ The server handles GitLab connectivity issues gracefully:
 | `USE_SEARCH` | `true` | Cross-project search |
 | `USE_ITERATIONS` | `true` | Iteration planning (sprints) |
 | `USE_CI_TOKENS` | `true` | CI access credentials: job token scope and deploy keys |
+| `USE_ENVIRONMENTS` | `true` | Environments and deployments |
+| `USE_RUNNERS` | `true` | CI runner management |
+| `USE_REGISTRY` | `true` | Container registry repositories and tags |
+| `USE_ACCESS_TOKENS` | `true` | Project/group/personal access token management |
+| `USE_AUDIT_EVENTS` | `true` | Audit events (Premium+) |
+| `USE_VULNERABILITIES` | `true` | Vulnerability management (Ultimate) |
 
 ## Contributing
 

--- a/README.md.in
+++ b/README.md.in
@@ -2,7 +2,7 @@
 
 [![npm version](https://img.shields.io/npm/v/@structured-world/gitlab-mcp)](https://www.npmjs.com/package/@structured-world/gitlab-mcp) [![npm downloads](https://img.shields.io/npm/dm/@structured-world/gitlab-mcp)](https://www.npmjs.com/package/@structured-world/gitlab-mcp) [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE) [![Release](https://github.com/structured-world/gitlab-mcp/workflows/Release/badge.svg)](https://github.com/structured-world/gitlab-mcp/actions) [![Coverage](https://codecov.io/gh/structured-world/gitlab-mcp/graph/badge.svg)](https://codecov.io/gh/structured-world/gitlab-mcp) [![Coverage Report](https://img.shields.io/badge/Coverage-Live%20Report-brightgreen?logo=github)](https://gitlab-mcp.sw.foundation/coverage/)
 
-Advanced GitLab MCP server — __TOOL_COUNT__ tools across __ENTITY_COUNT__ entity types with CQRS architecture, OAuth 2.1, and multiple transport modes.
+Advanced GitLab MCP server — __TOOL_COUNT__ CQRS tools exposing __ACTION_COUNT__ GitLab operations across __ENTITY_COUNT__ entity types. The tool catalog and parameters are filtered to each instance's GitLab version, tier, and token scopes, so the agent sees only what the connected instance actually supports.
 
 [![Install in Claude Desktop](https://img.shields.io/badge/Claude_Desktop-Install_Extension-F97316?style=for-the-badge)](https://gitlab-mcp.sw.foundation/downloads/gitlab-mcp-__VERSION__.mcpb)
 [![Install in VS Code](https://img.shields.io/badge/VS_Code-Install_MCP_Server-007ACC?style=for-the-badge&logo=visualstudiocode&logoColor=white)](vscode:mcp/install?%7B%22name%22%3A%22gitlab-mcp%22%2C%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22%40structured-world%2Fgitlab-mcp%22%5D%7D)
@@ -32,13 +32,34 @@ Advanced GitLab MCP server — __TOOL_COUNT__ tools across __ENTITY_COUNT__ enti
 - **__TOOL_COUNT__ tools** across __ENTITY_COUNT__ entity types — projects, merge requests, pipelines, work items, wiki, and more
 - **CQRS architecture** — `browse_*` for queries, `manage_*` for commands
 - **Connection resilience** — Bounded startup, auto-reconnect with exponential backoff, disconnected mode when GitLab is unreachable
-- **Multi-instance support** — Connect to multiple GitLab instances with per-instance OAuth and rate limiting
+- **Multi-instance support** — Connect to GitLab.com, self-managed, and self-hosted instances with per-instance OAuth and rate limiting
 - **Multiple transports** — stdio, SSE, StreamableHTTP
 - **OAuth 2.1** — Per-user authentication via Claude Custom Connector
 - **Read-only mode** — Safe operation for production environments
 - **Auto-discovery** — Detects GitLab config from git remotes
 - **Fine-grained control** — Enable/disable tool groups, filter actions, customize descriptions
 - **Docker support** — `ghcr.io/structured-world/gitlab-mcp:latest`
+
+## Tool model
+
+GitLab exposes hundreds of API operations. Giving each its own MCP tool floods an
+agent's context; a thin API wrapper pushes that complexity back onto the agent. This
+server takes a third path: __TOOL_COUNT__ CQRS tools, each holding several typed
+actions, expose __ACTION_COUNT__ operations across __ENTITY_COUNT__ entity types.
+
+- `browse_*` tools are read-only queries; `manage_*` tools are writes.
+- Sub-resources fold into actions rather than new tools — `browse_pipelines` covers
+  pipelines, jobs, and logs in a single tool.
+- The tool list, actions, and parameters are resolved at schema-generation time
+  against GitLab version, tier, token scopes, admin-mode, feature flags, and profiles.
+
+Examples:
+
+- `browse_pipelines` — list, get, jobs, job, logs, triggers
+- `manage_pipeline` — create, retry, cancel
+- `browse_environments` — list, get, list_deployments
+- `manage_environment` — create, update, stop, delete, update_deployment_status
+- `browse_deploy_keys` / `manage_deploy_key` — list, get / add, enable, update, delete
 
 ## Documentation
 

--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -29,7 +29,13 @@ if [ -z "$ENTITY_COUNT" ]; then ENTITY_COUNT=18; echo "WARNING: Using fallback E
 READONLY_TOOL_COUNT=$(node -e 'const r=require("./dist/src/registry-manager.js");const t=r.RegistryManager.getInstance().getAllToolDefinitionsUnfiltered();console.log(t.filter(x=>x.name.startsWith("browse_")||x.name==="manage_context").length)' 2>/dev/null)
 if [ -z "$READONLY_TOOL_COUNT" ]; then READONLY_TOOL_COUNT=24; echo "WARNING: Using fallback READONLY_TOOL_COUNT=$READONLY_TOOL_COUNT" >&2; fi
 
-echo "prepare-release: v${VERSION}, ${TOOL_COUNT} tools (${READONLY_TOOL_COUNT} read-only), ${ENTITY_COUNT} entities"
+# Total typed actions across all CQRS tools (discriminated-union oneOf branches
+# with an action const, or a flat action enum). Mirrors extractActions() in
+# src/cli/inject-tool-refs.ts so README and docs report the same operation count.
+ACTION_COUNT=$(node -e 'const r=require("./dist/src/registry-manager.js");const t=r.RegistryManager.getInstance().getAllToolDefinitionsUnfiltered();let n=0;for(const x of t){const s=x.inputSchema;if(Array.isArray(s.oneOf)){for(const b of s.oneOf){if(b.properties&&b.properties.action&&typeof b.properties.action.const==="string")n++;}}else if(s.properties&&s.properties.action&&Array.isArray(s.properties.action.enum)){n+=s.properties.action.enum.filter(v=>typeof v==="string").length;}}console.log(n)' 2>/dev/null)
+if [ -z "$ACTION_COUNT" ]; then ACTION_COUNT=193; echo "WARNING: Using fallback ACTION_COUNT=$ACTION_COUNT" >&2; fi
+
+echo "prepare-release: v${VERSION}, ${TOOL_COUNT} tools (${READONLY_TOOL_COUNT} read-only, ${ACTION_COUNT} actions), ${ENTITY_COUNT} entities"
 
 # Update server.json: version + description
 # Note: set -e ensures script exits on jq failure; leftover server.tmp is benign
@@ -44,6 +50,7 @@ if [ ! -f "README.md.in" ]; then
   exit 1
 fi
 sed -e "s/__TOOL_COUNT__/${TOOL_COUNT}/g" \
+    -e "s/__ACTION_COUNT__/${ACTION_COUNT}/g" \
     -e "s/__ENTITY_COUNT__/${ENTITY_COUNT}/g" \
     -e "s/__READONLY_TOOL_COUNT__/${READONLY_TOOL_COUNT}/g" \
     -e "s/__VERSION__/${VERSION}/g" \

--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -21,18 +21,18 @@ VERSION="${1:?Usage: prepare-release.sh <version>}"
 # is worse than aborting and rebuilding dist. ENTITY_COUNT reads the source tree
 # (not dist), so it keeps a warn+fallback.
 TOOL_COUNT=$(node -e 'const r=require("./dist/src/registry-manager.js");console.log(r.RegistryManager.getInstance().getAllToolDefinitionsUnfiltered().length)' 2>/dev/null)
-if [ -z "$TOOL_COUNT" ]; then
+if [[ -z "$TOOL_COUNT" ]]; then
   echo "ERROR: Failed to compute TOOL_COUNT from dist/ registry; rebuild and re-run" >&2
   exit 1
 fi
 
 ENTITY_COUNT=$(node -e 'const fs=require("fs"),p=require("path");const d=p.join(process.cwd(),"src","entities");console.log(fs.readdirSync(d,{withFileTypes:true}).filter(e=>e.isDirectory()&&fs.existsSync(p.join(d,e.name,"registry.ts"))).length)' 2>/dev/null)
-if [ -z "$ENTITY_COUNT" ]; then ENTITY_COUNT=18; echo "WARNING: Using fallback ENTITY_COUNT=$ENTITY_COUNT" >&2; fi
+if [[ -z "$ENTITY_COUNT" ]]; then ENTITY_COUNT=18; echo "WARNING: Using fallback ENTITY_COUNT=$ENTITY_COUNT" >&2; fi
 
 # Read-only tools: browse_* (queries) + manage_context (read-only despite manage_ prefix)
 # Same pattern used in inject-tool-refs.ts for consistency
 READONLY_TOOL_COUNT=$(node -e 'const r=require("./dist/src/registry-manager.js");const t=r.RegistryManager.getInstance().getAllToolDefinitionsUnfiltered();console.log(t.filter(x=>x.name.startsWith("browse_")||x.name==="manage_context").length)' 2>/dev/null)
-if [ -z "$READONLY_TOOL_COUNT" ]; then
+if [[ -z "$READONLY_TOOL_COUNT" ]]; then
   echo "ERROR: Failed to compute READONLY_TOOL_COUNT from dist/ registry; rebuild and re-run" >&2
   exit 1
 fi
@@ -41,7 +41,7 @@ fi
 # with an action const, or a flat action enum). Mirrors extractActions() in
 # src/cli/inject-tool-refs.ts so README and docs report the same operation count.
 ACTION_COUNT=$(node -e 'const r=require("./dist/src/registry-manager.js");const t=r.RegistryManager.getInstance().getAllToolDefinitionsUnfiltered();let n=0;for(const x of t){const s=x.inputSchema;if(Array.isArray(s.oneOf)){for(const b of s.oneOf){if(b.properties&&b.properties.action&&typeof b.properties.action.const==="string")n++;}}else if(s.properties&&s.properties.action&&Array.isArray(s.properties.action.enum)){n+=s.properties.action.enum.filter(v=>typeof v==="string").length;}}console.log(n)' 2>/dev/null)
-if [ -z "$ACTION_COUNT" ]; then
+if [[ -z "$ACTION_COUNT" ]]; then
   echo "ERROR: Failed to compute ACTION_COUNT from dist/ registry; rebuild and re-run" >&2
   exit 1
 fi
@@ -56,7 +56,7 @@ jq --arg v "$VERSION" --arg tc "$TOOL_COUNT" \
   server.json > server.tmp && mv server.tmp server.json
 
 # Generate README.md from template (replaces fragile regex patterns)
-if [ ! -f "README.md.in" ]; then
+if [[ ! -f "README.md.in" ]]; then
   echo "ERROR: README.md.in not found" >&2
   exit 1
 fi

--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -14,12 +14,17 @@ set -euo pipefail
 
 VERSION="${1:?Usage: prepare-release.sh <version>}"
 
-# Get dynamic tool counts from built registry
+# Get dynamic tool counts from the built registry.
 # Design: stderr is redirected to suppress noisy Node.js errors (module resolution, etc.)
-# If the node command fails, result is empty → triggers fallback with WARNING to stderr.
-# This ensures clean stdout for release output while surfacing fallback usage in CI logs.
+# so stdout stays clean for release output. Counts derived from dist/ FAIL the
+# release if they can't be computed — publishing stale hardcoded metrics silently
+# is worse than aborting and rebuilding dist. ENTITY_COUNT reads the source tree
+# (not dist), so it keeps a warn+fallback.
 TOOL_COUNT=$(node -e 'const r=require("./dist/src/registry-manager.js");console.log(r.RegistryManager.getInstance().getAllToolDefinitionsUnfiltered().length)' 2>/dev/null)
-if [ -z "$TOOL_COUNT" ]; then TOOL_COUNT=44; echo "WARNING: Using fallback TOOL_COUNT=$TOOL_COUNT" >&2; fi
+if [ -z "$TOOL_COUNT" ]; then
+  echo "ERROR: Failed to compute TOOL_COUNT from dist/ registry; rebuild and re-run" >&2
+  exit 1
+fi
 
 ENTITY_COUNT=$(node -e 'const fs=require("fs"),p=require("path");const d=p.join(process.cwd(),"src","entities");console.log(fs.readdirSync(d,{withFileTypes:true}).filter(e=>e.isDirectory()&&fs.existsSync(p.join(d,e.name,"registry.ts"))).length)' 2>/dev/null)
 if [ -z "$ENTITY_COUNT" ]; then ENTITY_COUNT=18; echo "WARNING: Using fallback ENTITY_COUNT=$ENTITY_COUNT" >&2; fi
@@ -27,13 +32,19 @@ if [ -z "$ENTITY_COUNT" ]; then ENTITY_COUNT=18; echo "WARNING: Using fallback E
 # Read-only tools: browse_* (queries) + manage_context (read-only despite manage_ prefix)
 # Same pattern used in inject-tool-refs.ts for consistency
 READONLY_TOOL_COUNT=$(node -e 'const r=require("./dist/src/registry-manager.js");const t=r.RegistryManager.getInstance().getAllToolDefinitionsUnfiltered();console.log(t.filter(x=>x.name.startsWith("browse_")||x.name==="manage_context").length)' 2>/dev/null)
-if [ -z "$READONLY_TOOL_COUNT" ]; then READONLY_TOOL_COUNT=24; echo "WARNING: Using fallback READONLY_TOOL_COUNT=$READONLY_TOOL_COUNT" >&2; fi
+if [ -z "$READONLY_TOOL_COUNT" ]; then
+  echo "ERROR: Failed to compute READONLY_TOOL_COUNT from dist/ registry; rebuild and re-run" >&2
+  exit 1
+fi
 
 # Total typed actions across all CQRS tools (discriminated-union oneOf branches
 # with an action const, or a flat action enum). Mirrors extractActions() in
 # src/cli/inject-tool-refs.ts so README and docs report the same operation count.
 ACTION_COUNT=$(node -e 'const r=require("./dist/src/registry-manager.js");const t=r.RegistryManager.getInstance().getAllToolDefinitionsUnfiltered();let n=0;for(const x of t){const s=x.inputSchema;if(Array.isArray(s.oneOf)){for(const b of s.oneOf){if(b.properties&&b.properties.action&&typeof b.properties.action.const==="string")n++;}}else if(s.properties&&s.properties.action&&Array.isArray(s.properties.action.enum)){n+=s.properties.action.enum.filter(v=>typeof v==="string").length;}}console.log(n)' 2>/dev/null)
-if [ -z "$ACTION_COUNT" ]; then ACTION_COUNT=193; echo "WARNING: Using fallback ACTION_COUNT=$ACTION_COUNT" >&2; fi
+if [ -z "$ACTION_COUNT" ]; then
+  echo "ERROR: Failed to compute ACTION_COUNT from dist/ registry; rebuild and re-run" >&2
+  exit 1
+fi
 
 echo "prepare-release: v${VERSION}, ${TOOL_COUNT} tools (${READONLY_TOOL_COUNT} read-only, ${ACTION_COUNT} actions), ${ENTITY_COUNT} entities"
 

--- a/src/cli/inject-tool-refs.ts
+++ b/src/cli/inject-tool-refs.ts
@@ -190,17 +190,19 @@ interface Placeholders {
   toolCount: number;
   entityCount: number;
   readonlyToolCount: number;
+  actionCount: number;
   version: string;
 }
 
 /**
- * Replace __TOOL_COUNT__, __ENTITY_COUNT__, __READONLY_TOOL_COUNT__, and __VERSION__ placeholders.
- * Returns true if file was modified.
+ * Replace __TOOL_COUNT__, __ENTITY_COUNT__, __READONLY_TOOL_COUNT__, __ACTION_COUNT__,
+ * and __VERSION__ placeholders. Returns true if file was modified.
  */
 function replacePlaceholders(filePath: string, placeholders: Placeholders): boolean {
   const content = fs.readFileSync(filePath, 'utf8');
   const result = content
     .replace(/__TOOL_COUNT__/g, String(placeholders.toolCount))
+    .replace(/__ACTION_COUNT__/g, String(placeholders.actionCount))
     .replace(/__ENTITY_COUNT__/g, String(placeholders.entityCount))
     .replace(/__READONLY_TOOL_COUNT__/g, String(placeholders.readonlyToolCount))
     .replace(/__VERSION__/g, placeholders.version);
@@ -284,12 +286,21 @@ export function main(): void {
   const readonlyToolCount = allTools.filter(
     (t) => t.name.startsWith('browse_') || t.name === 'manage_context',
   ).length;
+  // Total typed actions across all CQRS tools — the real count of GitLab
+  // operations behind the compact tool list.
+  const actionCount = allTools.reduce((sum, t) => sum + extractActions(t.inputSchema).length, 0);
   const version = getVersion(projectRoot);
   console.log(
-    `  Tool count: ${toolCount}, Entity count: ${entityCount}, Read-only: ${readonlyToolCount}, Version: ${version}`,
+    `  Tool count: ${toolCount}, Entity count: ${entityCount}, Read-only: ${readonlyToolCount}, Actions: ${actionCount}, Version: ${version}`,
   );
 
-  const placeholders: Placeholders = { toolCount, entityCount, readonlyToolCount, version };
+  const placeholders: Placeholders = {
+    toolCount,
+    entityCount,
+    readonlyToolCount,
+    actionCount,
+    version,
+  };
 
   // Generate docs from .in templates (*.md.in -> *.md, *.txt.in -> *.txt)
   const docsDir = path.join(projectRoot, 'docs');

--- a/tests/unit/cli/inject-tool-refs.test.ts
+++ b/tests/unit/cli/inject-tool-refs.test.ts
@@ -799,10 +799,11 @@ describe('inject-tool-refs', () => {
         toolCount: 44,
         entityCount: 18,
         readonlyToolCount: 24,
+        actionCount: 193,
         version: '6.43.0',
       };
       mockedFs.readFileSync.mockReturnValue(
-        'We have __TOOL_COUNT__ tools, __ENTITY_COUNT__ entities, __READONLY_TOOL_COUNT__ read-only. Version: __VERSION__',
+        'We have __TOOL_COUNT__ tools (__ACTION_COUNT__ actions), __ENTITY_COUNT__ entities, __READONLY_TOOL_COUNT__ read-only. Version: __VERSION__',
       );
       mockedFs.writeFileSync.mockImplementation(() => undefined);
 
@@ -811,7 +812,7 @@ describe('inject-tool-refs', () => {
       expect(result).toBe(true);
       expect(mockedFs.writeFileSync).toHaveBeenCalledWith(
         '/some/file.md',
-        'We have 44 tools, 18 entities, 24 read-only. Version: 6.43.0',
+        'We have 44 tools (193 actions), 18 entities, 24 read-only. Version: 6.43.0',
         'utf8',
       );
     });
@@ -821,6 +822,7 @@ describe('inject-tool-refs', () => {
         toolCount: 44,
         entityCount: 18,
         readonlyToolCount: 24,
+        actionCount: 193,
         version: '1.0.0',
       };
       mockedFs.readFileSync.mockReturnValue('No placeholders here.');
@@ -836,6 +838,7 @@ describe('inject-tool-refs', () => {
         toolCount: 44,
         entityCount: 18,
         readonlyToolCount: 24,
+        actionCount: 193,
         version: '6.43.0',
       };
       mockedFs.readFileSync.mockReturnValue(

--- a/tests/unit/cli/inject-tool-refs.test.ts
+++ b/tests/unit/cli/inject-tool-refs.test.ts
@@ -1214,7 +1214,7 @@ describe('inject-tool-refs', () => {
       });
 
       const templateContent =
-        '# Home\n\nWe have __TOOL_COUNT__ tools across __ENTITY_COUNT__ entities (__READONLY_TOOL_COUNT__ read-only). Version: __VERSION__';
+        '# Home\n\nWe have __TOOL_COUNT__ tools (__ACTION_COUNT__ operations) across __ENTITY_COUNT__ entities (__READONLY_TOOL_COUNT__ read-only). Version: __VERSION__';
 
       mockedFs.readFileSync.mockImplementation((filePath: fs.PathOrFileDescriptor) => {
         const pathStr = filePath.toString();
@@ -1240,10 +1240,12 @@ describe('inject-tool-refs', () => {
       expect(writeCall).toBeDefined();
       const generatedContent = writeCall![1] as string;
       expect(generatedContent).toContain('2 tools');
+      expect(generatedContent).toContain('2 operations');
       expect(generatedContent).toContain('2 entities');
       expect(generatedContent).toContain('1 read-only');
       expect(generatedContent).toContain('6.43.0');
       expect(generatedContent).not.toContain('__TOOL_COUNT__');
+      expect(generatedContent).not.toContain('__ACTION_COUNT__');
       expect(generatedContent).not.toContain('__ENTITY_COUNT__');
       expect(generatedContent).not.toContain('__READONLY_TOOL_COUNT__');
       expect(generatedContent).not.toContain('__VERSION__');
@@ -1294,7 +1296,7 @@ describe('inject-tool-refs', () => {
       });
 
       const mdTemplate =
-        '**__TOOL_COUNT__ tools** across __ENTITY_COUNT__ entity types. Version: __VERSION__';
+        '**__TOOL_COUNT__ tools** (__ACTION_COUNT__ operations) across __ENTITY_COUNT__ entity types. Version: __VERSION__';
       const txtTemplate =
         '> Provides __TOOL_COUNT__ tools (__READONLY_TOOL_COUNT__ read-only). Version: __VERSION__';
 
@@ -1325,7 +1327,7 @@ describe('inject-tool-refs', () => {
       );
 
       expect(mdWrite).toBeDefined();
-      expect(mdWrite![1]).toBe('**3 tools** across 1 entity types. Version: 1.0.0');
+      expect(mdWrite![1]).toBe('**3 tools** (3 operations) across 1 entity types. Version: 1.0.0');
 
       expect(txtWrite).toBeDefined();
       expect(txtWrite![1]).toBe('> Provides 3 tools (2 read-only). Version: 1.0.0');


### PR DESCRIPTION
## Summary

Makes the README state the project's actual differentiator from the first paragraph, factually and without marketing framing.

### Opening line
Before: "50 tools across 21 entity types with CQRS architecture, OAuth 2.1, and multiple transport modes."
After: leads with the measurable differentiator — a compact, capability-aware CQRS catalog (**50 tools**) exposing the full GitLab surface (**193 operations** across 21 entity types), filtered to each instance's version, tier, and token scopes so the agent sees only what the connected instance supports.

### New `Tool model` section
Explains the typed-action model that keeps the tool list small while covering a broad API surface, contrasting the two common approaches (tool-per-operation vs thin wrapper) without naming or disparaging other servers. Includes verified action examples for pipelines, environments, and deploy keys.

### Drift-safe operation count
Adds an `__ACTION_COUNT__` placeholder to both generation paths (`src/cli/inject-tool-refs.ts` for docs, `scripts/prepare-release.sh` for the root README), computed from the tool schemas. The README operation count now updates automatically each release instead of being hardcoded. Both paths verified to produce the same value (193).

### Other
- Note GitLab.com / self-managed / self-hosted in the multi-instance highlight (search visibility).
- Regenerate `README.md` from the template (also refreshes the stale 44-tool / v6.62.2 values to current 50 / v7.6.0).
- No new "Enterprise readiness" block: it would duplicate the existing Highlights, Connection Resilience, and Feature Flags sections.

## Testing
- `yarn lint` clean, `yarn build` clean.
- `inject-tool-refs` unit tests: 59 passed (includes the new placeholder).
- Verified both generators emit ACTION_COUNT=193 and no `__PLACEHOLDER__` literals remain in the rendered README.

Closes #473

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated README to reflect expanded scope: 50 CQRS tools exposing 193 operations across 21 entity types.
  * Clarified multi-instance support (GitLab.com, self-managed/self-hosted) and expanded tool model with CQRS semantics and examples.
  * Updated documentation table to list all 50 tools with parameters.

* **New Features**
  * Added support for environments, runners, registry, access tokens, audit events, and vulnerabilities.

* **Tests**
  * Updated docs-generation tests to validate the new operations count placeholder.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->