### PR TITLE
feat(container-registry): expose Container Registry via GraphQL

### DIFF
--- a/src/entities/container_registry/registry.ts
+++ b/src/entities/container_registry/registry.ts
@@ -144,24 +144,31 @@ export const containerRegistryToolRegistry: ToolRegistry = new Map<string, Enhan
           }
 
           case 'get_tag': {
-            // The tags `name` filter is a substring match, so fetch candidates and
-            // select the exact name.
-            const res = await client.request(LIST_CONTAINER_REPOSITORY_TAGS, {
-              id: repositoryGid(input.repository_id),
-              name: input.tag_name,
-              first: 100,
-              after: null,
-            });
-            if (!res.containerRepository) {
-              throw new Error(`Container repository ${input.repository_id} not found`);
+            // The tags `name` filter is a substring match, so the exact tag can sit
+            // on any page of the filtered results — page through until it's found.
+            const gid = repositoryGid(input.repository_id);
+            let after: string | null = null;
+            for (;;) {
+              // Explicit type: `after` is both an input var and assigned from the
+              // result below, which defeats generic inference (circular).
+              const res: ListTagsResult = await client.request(LIST_CONTAINER_REPOSITORY_TAGS, {
+                id: gid,
+                name: input.tag_name,
+                first: 100,
+                after,
+              });
+              if (!res.containerRepository) {
+                throw new Error(`Container repository ${input.repository_id} not found`);
+              }
+              const conn = res.containerRepository.tags;
+              const tag = conn.nodes.find((t) => t.name === input.tag_name);
+              if (tag) return cleanGidsFromObject(tag);
+              if (!conn.pageInfo.hasNextPage || !conn.pageInfo.endCursor) break;
+              after = conn.pageInfo.endCursor;
             }
-            const tag = res.containerRepository.tags.nodes.find((t) => t.name === input.tag_name);
-            if (!tag) {
-              throw new Error(
-                `Tag "${input.tag_name}" not found in container repository ${input.repository_id}`,
-              );
-            }
-            return cleanGidsFromObject(tag);
+            throw new Error(
+              `Tag "${input.tag_name}" not found in container repository ${input.repository_id}`,
+            );
           }
 
           /* istanbul ignore next -- unreachable with Zod discriminatedUnion */
@@ -237,8 +244,12 @@ export const containerRegistryToolRegistry: ToolRegistry = new Map<string, Enhan
                 first: 100,
                 after,
               });
-              const conn = page.containerRepository?.tags;
-              if (!conn) break;
+              // A null repository means the ID is invalid / inaccessible; fail
+              // rather than reporting a misleading deleted_count: 0 success.
+              if (!page.containerRepository) {
+                throw new Error(`Container repository ${input.repository_id} not found`);
+              }
+              const conn = page.containerRepository.tags;
               tags.push(...conn.nodes);
               if (tags.length >= BULK_TAG_SCAN_CAP) {
                 tags.length = BULK_TAG_SCAN_CAP;

--- a/src/entities/container_registry/registry.ts
+++ b/src/entities/container_registry/registry.ts
@@ -1,0 +1,298 @@
+import * as z from 'zod';
+import { BrowseRegistrySchema } from './schema-readonly';
+import { ManageRegistrySchema } from './schema';
+import { ToolRegistry, EnhancedToolDefinition } from '../../types';
+import { assertActionAllowed } from '../utils';
+import { ConnectionManager } from '../../services/ConnectionManager';
+import { cleanGidsFromObject } from '../../utils/idConversion';
+import {
+  LIST_CONTAINER_REPOSITORIES,
+  GET_CONTAINER_REPOSITORY,
+  LIST_CONTAINER_REPOSITORY_TAGS,
+  DESTROY_CONTAINER_REPOSITORY,
+  DESTROY_CONTAINER_REPOSITORY_TAGS,
+  type ContainerTagNode,
+  type ListTagsResult,
+} from '../../graphql/containerRegistry';
+
+/**
+ * Container Registry tools registry - 2 CQRS tools
+ *
+ * browse_registry (Query): list_repositories, get_repository, list_tags, get_tag
+ * manage_registry (Command): delete_repository, delete_tag, delete_tags_bulk
+ *
+ * Backed by the GitLab GraphQL Container Registry API. GraphQL has no native
+ * regex/keep_n/older_than bulk-delete mutation, so delete_tags_bulk lists tags,
+ * filters client-side, and calls destroyContainerRepositoryTags. Gated behind
+ * USE_REGISTRY. Free tier (writes require the write_registry scope).
+ */
+
+const REPOSITORY_GID_PREFIX = 'gid://gitlab/ContainerRepository/';
+const repositoryGid = (id: number): string => `${REPOSITORY_GID_PREFIX}${id}`;
+
+// GitLab caps destroyContainerRepositoryTags at 20 tag names per call.
+const DESTROY_TAGS_BATCH = 20;
+// Safety cap when paginating tags for bulk cleanup, so a huge repository can't
+// spin forever. Surfaced in the result when hit (never silently truncated).
+const BULK_TAG_SCAN_CAP = 1000;
+
+const OLDER_THAN_UNIT_MS: Record<string, number> = {
+  s: 1000,
+  m: 60_000,
+  h: 3_600_000,
+  d: 86_400_000,
+};
+
+/** Parse a duration like "7d"/"12h" into milliseconds (validated by the schema). */
+function durationToMs(older_than: string): number {
+  const match = /^(\d+)(s|m|h|d)$/.exec(older_than);
+  /* istanbul ignore next -- schema regex guarantees a match */
+  if (!match) throw new Error(`Invalid duration: ${older_than}`);
+  return parseInt(match[1], 10) * OLDER_THAN_UNIT_MS[match[2]];
+}
+
+/**
+ * Resolve which tag names a bulk cleanup should delete, mirroring GitLab's own
+ * cleanup-policy order: match name_regex_delete, drop anything matching
+ * name_regex_keep, keep the newest keep_n, then of the remainder keep only those
+ * older than older_than.
+ */
+function resolveBulkDeleteTags(
+  tags: ContainerTagNode[],
+  opts: {
+    name_regex_delete: string;
+    name_regex_keep?: string;
+    keep_n?: number;
+    older_than?: string;
+  },
+): string[] {
+  const deleteRe = new RegExp(opts.name_regex_delete);
+  const keepRe = opts.name_regex_keep ? new RegExp(opts.name_regex_keep) : null;
+
+  let candidates = tags.filter((t) => deleteRe.test(t.name) && !keepRe?.test(t.name));
+
+  // Newest first by creation date (tags without a date sort last).
+  candidates.sort((a, b) => (b.createdAt ?? '').localeCompare(a.createdAt ?? ''));
+
+  if (opts.keep_n !== undefined) {
+    candidates = candidates.slice(opts.keep_n);
+  }
+
+  if (opts.older_than !== undefined) {
+    const cutoff = Date.now() - durationToMs(opts.older_than);
+    candidates = candidates.filter((t) => t.createdAt !== null && Date.parse(t.createdAt) < cutoff);
+  }
+
+  return candidates.map((t) => t.name);
+}
+
+export const containerRegistryToolRegistry: ToolRegistry = new Map<string, EnhancedToolDefinition>([
+  // ============================================================================
+  // browse_registry - CQRS Query Tool (discriminated union schema)
+  // ============================================================================
+  [
+    'browse_registry',
+    {
+      name: 'browse_registry',
+      description:
+        "Inspect the GitLab Container Registry. Actions: list_repositories (a project's image repositories), get_repository (single repository by ID), list_tags (tags of a repository), get_tag (single tag with manifest digest, size, and timestamps). Related: manage_registry to delete repositories and tags (including regex bulk cleanup).",
+      inputSchema: z.toJSONSchema(BrowseRegistrySchema),
+      requirements: { default: { tier: 'free', minVersion: '12.0' } },
+      gate: { envVar: 'USE_REGISTRY', defaultValue: true },
+      handler: async (args: unknown): Promise<unknown> => {
+        const input = BrowseRegistrySchema.parse(args);
+
+        assertActionAllowed('browse_registry', input.action);
+
+        const client = ConnectionManager.getInstance().getClient();
+
+        switch (input.action) {
+          case 'list_repositories': {
+            const res = await client.request(LIST_CONTAINER_REPOSITORIES, {
+              fullPath: input.project_id,
+              name: input.name ?? null,
+              first: input.first ?? 20,
+              after: input.after ?? null,
+            });
+            if (!res.project) {
+              throw new Error(`Project "${input.project_id}" not found or not accessible`);
+            }
+            return cleanGidsFromObject(res.project.containerRepositories);
+          }
+
+          case 'get_repository': {
+            const res = await client.request(GET_CONTAINER_REPOSITORY, {
+              id: repositoryGid(input.repository_id),
+            });
+            if (!res.containerRepository) {
+              throw new Error(`Container repository ${input.repository_id} not found`);
+            }
+            return cleanGidsFromObject(res.containerRepository);
+          }
+
+          case 'list_tags': {
+            const res = await client.request(LIST_CONTAINER_REPOSITORY_TAGS, {
+              id: repositoryGid(input.repository_id),
+              name: input.name ?? null,
+              first: input.first ?? 20,
+              after: input.after ?? null,
+            });
+            if (!res.containerRepository) {
+              throw new Error(`Container repository ${input.repository_id} not found`);
+            }
+            return cleanGidsFromObject(res.containerRepository.tags);
+          }
+
+          case 'get_tag': {
+            // The tags `name` filter is a substring match, so fetch candidates and
+            // select the exact name.
+            const res = await client.request(LIST_CONTAINER_REPOSITORY_TAGS, {
+              id: repositoryGid(input.repository_id),
+              name: input.tag_name,
+              first: 100,
+              after: null,
+            });
+            if (!res.containerRepository) {
+              throw new Error(`Container repository ${input.repository_id} not found`);
+            }
+            const tag = res.containerRepository.tags.nodes.find((t) => t.name === input.tag_name);
+            if (!tag) {
+              throw new Error(
+                `Tag "${input.tag_name}" not found in container repository ${input.repository_id}`,
+              );
+            }
+            return cleanGidsFromObject(tag);
+          }
+
+          /* istanbul ignore next -- unreachable with Zod discriminatedUnion */
+          default:
+            throw new Error(`Unknown action: ${(input as { action: string }).action}`);
+        }
+      },
+    },
+  ],
+
+  // ============================================================================
+  // manage_registry - CQRS Command Tool (discriminated union schema)
+  // ============================================================================
+  [
+    'manage_registry',
+    {
+      name: 'manage_registry',
+      description:
+        'Delete GitLab Container Registry repositories and tags. Actions: delete_repository (remove a whole repository), delete_tag (remove one tag), delete_tags_bulk (regex cleanup with keep_n/older_than retention - destructive). Related: browse_registry to inspect before deleting.',
+      inputSchema: z.toJSONSchema(ManageRegistrySchema),
+      requirements: { default: { tier: 'free', minVersion: '12.0' } },
+      gate: { envVar: 'USE_REGISTRY', defaultValue: true },
+      handler: async (args: unknown): Promise<unknown> => {
+        const input = ManageRegistrySchema.parse(args);
+
+        assertActionAllowed('manage_registry', input.action);
+
+        const client = ConnectionManager.getInstance().getClient();
+        const gid = repositoryGid(input.repository_id);
+
+        switch (input.action) {
+          case 'delete_repository': {
+            const res = await client.request(DESTROY_CONTAINER_REPOSITORY, { id: gid });
+            const errors = res.destroyContainerRepository?.errors ?? [];
+            if (errors.length > 0) {
+              throw new Error(`GitLab API error: ${errors.join(', ')}`);
+            }
+            return {
+              deleted: true,
+              repository_id: input.repository_id,
+              status: res.destroyContainerRepository?.containerRepository?.status ?? null,
+            };
+          }
+
+          case 'delete_tag': {
+            const res = await client.request(DESTROY_CONTAINER_REPOSITORY_TAGS, {
+              id: gid,
+              tagNames: [input.tag_name],
+            });
+            const errors = res.destroyContainerRepositoryTags?.errors ?? [];
+            if (errors.length > 0) {
+              throw new Error(`GitLab API error: ${errors.join(', ')}`);
+            }
+            return {
+              deleted: true,
+              repository_id: input.repository_id,
+              tag_name: input.tag_name,
+            };
+          }
+
+          case 'delete_tags_bulk': {
+            // Page through tags (up to BULK_TAG_SCAN_CAP) so the regex/keep_n/
+            // older_than filtering happens over the full set.
+            const tags: ContainerTagNode[] = [];
+            let capped = false;
+            let after: string | null = null;
+            for (;;) {
+              // Explicit result type: `after` is both an input var and assigned
+              // from the result below, which defeats generic inference (circular).
+              const page: ListTagsResult = await client.request(LIST_CONTAINER_REPOSITORY_TAGS, {
+                id: gid,
+                name: null,
+                first: 100,
+                after,
+              });
+              const conn = page.containerRepository?.tags;
+              if (!conn) break;
+              tags.push(...conn.nodes);
+              if (tags.length >= BULK_TAG_SCAN_CAP) {
+                tags.length = BULK_TAG_SCAN_CAP;
+                capped = true;
+                break;
+              }
+              if (!conn.pageInfo.hasNextPage || !conn.pageInfo.endCursor) break;
+              after = conn.pageInfo.endCursor;
+            }
+
+            const toDelete = resolveBulkDeleteTags(tags, {
+              name_regex_delete: input.name_regex_delete,
+              name_regex_keep: input.name_regex_keep,
+              keep_n: input.keep_n,
+              older_than: input.older_than,
+            });
+
+            const deleted: string[] = [];
+            for (let i = 0; i < toDelete.length; i += DESTROY_TAGS_BATCH) {
+              const batch = toDelete.slice(i, i + DESTROY_TAGS_BATCH);
+              const res = await client.request(DESTROY_CONTAINER_REPOSITORY_TAGS, {
+                id: gid,
+                tagNames: batch,
+              });
+              const errors = res.destroyContainerRepositoryTags?.errors ?? [];
+              if (errors.length > 0) {
+                throw new Error(`GitLab API error: ${errors.join(', ')}`);
+              }
+              deleted.push(...batch);
+            }
+
+            return {
+              deleted: true,
+              repository_id: input.repository_id,
+              deleted_count: deleted.length,
+              deleted_tags: deleted,
+              // true when the repository had more than BULK_TAG_SCAN_CAP tags and
+              // only the first page-set was considered; re-run to continue.
+              scan_capped: capped,
+            };
+          }
+
+          /* istanbul ignore next -- unreachable with Zod discriminatedUnion */
+          default:
+            throw new Error(`Unknown action: ${(input as { action: string }).action}`);
+        }
+      },
+    },
+  ],
+]);
+
+/**
+ * Get read-only tool names from the registry
+ */
+export function getContainerRegistryReadOnlyToolNames(): string[] {
+  return ['browse_registry'];
+}

--- a/src/entities/container_registry/schema-readonly.ts
+++ b/src/entities/container_registry/schema-readonly.ts
@@ -1,0 +1,89 @@
+import { z } from 'zod';
+import { requiredId } from '../utils';
+
+// ============================================================================
+// browse_registry - CQRS Query Tool (discriminated union schema)
+// Actions: list_repositories, get_repository, list_tags, get_tag
+// Backed by the GitLab GraphQL Container Registry API. Tags fold in as actions
+// rather than a separate CQRS pair. Gated behind USE_REGISTRY. Free tier.
+// ============================================================================
+
+// --- Shared fields ---
+// list_repositories resolves the project via the GraphQL `project(fullPath:)`
+// field, so it needs the project PATH (numeric IDs are not accepted there).
+const projectPathField = requiredId.describe(
+  "Project full path (e.g., 'my-group/my-project') - required by the GraphQL project lookup",
+);
+// Other actions address the repository directly by its numeric ID (as returned
+// by list_repositories); it is expanded to a global ID internally.
+const repositoryIdField = z.coerce
+  .number()
+  .int()
+  .positive()
+  .describe('Numeric ID of the container repository (from list_repositories)');
+const tagNameField = z
+  .string()
+  .min(1)
+  .describe('Container image tag name (e.g., "latest", "v1.2.0")');
+const firstField = z.coerce
+  .number()
+  .int()
+  .positive()
+  .max(100)
+  .optional()
+  .describe('Max number of items to return (cursor pagination, default 20, max 100)');
+const afterField = z
+  .string()
+  .optional()
+  .describe('Cursor for the next page (endCursor from a previous response)');
+
+// --- Action: list_repositories ---
+const ListRepositoriesSchema = z.object({
+  action: z
+    .literal('list_repositories')
+    .describe("List a project's container registry repositories"),
+  project_id: projectPathField,
+  name: z.string().optional().describe('Filter repositories by name (substring match)'),
+  first: firstField,
+  after: afterField,
+});
+
+// --- Action: get_repository ---
+const GetRepositorySchema = z.object({
+  action: z
+    .literal('get_repository')
+    .describe('Get a single container repository by its numeric ID'),
+  repository_id: repositoryIdField,
+});
+
+// --- Action: list_tags ---
+const ListTagsSchema = z.object({
+  action: z.literal('list_tags').describe('List tags of a container repository'),
+  repository_id: repositoryIdField,
+  name: z.string().optional().describe('Filter tags by name (substring match)'),
+  first: firstField,
+  after: afterField,
+});
+
+// --- Action: get_tag ---
+const GetTagSchema = z.object({
+  action: z
+    .literal('get_tag')
+    .describe('Get a single tag with its manifest digest, size, and timestamps'),
+  repository_id: repositoryIdField,
+  tag_name: tagNameField,
+});
+
+// --- Discriminated union combining all actions ---
+export const BrowseRegistrySchema = z.discriminatedUnion('action', [
+  ListRepositoriesSchema,
+  GetRepositorySchema,
+  ListTagsSchema,
+  GetTagSchema,
+]);
+
+// ============================================================================
+// Type exports
+// ============================================================================
+
+export type BrowseRegistryInput = z.infer<typeof BrowseRegistrySchema>;

--- a/src/entities/container_registry/schema.ts
+++ b/src/entities/container_registry/schema.ts
@@ -1,0 +1,81 @@
+import { z } from 'zod';
+
+// ============================================================================
+// manage_registry - CQRS Command Tool (discriminated union schema)
+// Actions: delete_repository, delete_tag, delete_tags_bulk
+// Backed by the GitLab GraphQL Container Registry mutations
+// (destroyContainerRepository, destroyContainerRepositoryTags). GraphQL has no
+// native regex bulk-delete, so delete_tags_bulk is composed in the handler:
+// list tags, filter by regex/keep_n/older_than, then destroy the resolved names.
+// Gated behind USE_REGISTRY. Writes require the write_registry token scope.
+// ============================================================================
+
+// --- Shared fields ---
+// Mutations address the repository directly by its numeric ID (as returned by
+// browse_registry list_repositories); it is expanded to a global ID internally.
+const repositoryIdField = z.coerce
+  .number()
+  .int()
+  .positive()
+  .describe('Numeric ID of the container repository (from browse_registry list_repositories)');
+const tagNameField = z.string().min(1).describe('Container image tag name to delete');
+
+// --- Action: delete_repository ---
+const DeleteRepositorySchema = z.object({
+  action: z
+    .literal('delete_repository')
+    .describe('Delete a container repository (queued as a background operation)'),
+  repository_id: repositoryIdField,
+});
+
+// --- Action: delete_tag ---
+const DeleteTagSchema = z.object({
+  action: z.literal('delete_tag').describe('Delete a single tag from a container repository'),
+  repository_id: repositoryIdField,
+  tag_name: tagNameField,
+});
+
+// --- Action: delete_tags_bulk ---
+const DeleteTagsBulkSchema = z.object({
+  action: z
+    .literal('delete_tags_bulk')
+    .describe(
+      'Bulk-delete tags by regex with optional retention rules. Destructive and irreversible. ' +
+        'Tags are resolved client-side (regex match, keep the newest keep_n, drop only those older ' +
+        'than older_than) and then deleted. Always pair name_regex_delete with keep_n and/or ' +
+        'older_than to avoid deleting more than intended.',
+    ),
+  repository_id: repositoryIdField,
+  name_regex_delete: z
+    .string()
+    .min(1)
+    .describe('Regex for tag names to delete (e.g., ".*" for all, "^v.+" for version tags)'),
+  name_regex_keep: z
+    .string()
+    .optional()
+    .describe('Regex for tag names to always keep (takes precedence over name_regex_delete)'),
+  keep_n: z.coerce
+    .number()
+    .int()
+    .positive()
+    .optional()
+    .describe('Keep the N most recently created matching tags'),
+  older_than: z
+    .string()
+    .regex(/^\d+(s|m|h|d)$/, 'Duration like "30m", "2h", "7d" (seconds/minutes/hours/days)')
+    .optional()
+    .describe('Only delete tags created longer ago than this duration (e.g., "7d", "12h")'),
+});
+
+// --- Discriminated union combining all actions ---
+export const ManageRegistrySchema = z.discriminatedUnion('action', [
+  DeleteRepositorySchema,
+  DeleteTagSchema,
+  DeleteTagsBulkSchema,
+]);
+
+// ============================================================================
+// Type exports
+// ============================================================================
+
+export type ManageRegistryInput = z.infer<typeof ManageRegistrySchema>;

--- a/src/entities/container_registry/schema.ts
+++ b/src/entities/container_registry/schema.ts
@@ -10,6 +10,16 @@ import { z } from 'zod';
 // Gated behind USE_REGISTRY. Writes require the write_registry token scope.
 // ============================================================================
 
+/** True when the string compiles as a regular expression (fail fast at parse). */
+const isValidRegex = (pattern: string): boolean => {
+  try {
+    new RegExp(pattern);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
 // --- Shared fields ---
 // Mutations address the repository directly by its numeric ID (as returned by
 // browse_registry list_repositories); it is expanded to a global ID internally.
@@ -49,9 +59,11 @@ const DeleteTagsBulkSchema = z.object({
   name_regex_delete: z
     .string()
     .min(1)
+    .refine(isValidRegex, 'Must be a valid regular expression')
     .describe('Regex for tag names to delete (e.g., ".*" for all, "^v.+" for version tags)'),
   name_regex_keep: z
     .string()
+    .refine(isValidRegex, 'Must be a valid regular expression')
     .optional()
     .describe('Regex for tag names to always keep (takes precedence over name_regex_delete)'),
   keep_n: z.coerce

--- a/src/graphql/containerRegistry.ts
+++ b/src/graphql/containerRegistry.ts
@@ -1,0 +1,215 @@
+import { gql } from 'graphql-tag';
+import { TypedDocumentNode } from '@graphql-typed-document-node/core';
+
+/**
+ * GraphQL documents for the Container Registry.
+ *
+ * Verified against a live GitLab 19.x instance via schema introspection:
+ * - Queries: `project.containerRepositories`, `containerRepository(id)` with a
+ *   `tags(name, sort, first, after)` connection.
+ * - Mutations: `destroyContainerRepository(input:{id})`,
+ *   `destroyContainerRepositoryTags(input:{id, tagNames})`.
+ *
+ * GitLab has no native regex/keep_n/older_than bulk-delete mutation, so bulk
+ * cleanup is composed in the handler: list tags, filter, then
+ * destroyContainerRepositoryTags with the resolved names.
+ */
+
+// --- Shared GraphQL fragments of fields we surface ---
+// The `containerRepositories` connection yields `ContainerRepository` nodes,
+// which expose fewer fields than the `ContainerRepositoryDetails` returned by the
+// single-repository query (e.g., lastPublishedAt/size are Details-only).
+const REPOSITORY_LIST_FIELDS = `
+  id
+  name
+  path
+  location
+  status
+  tagsCount
+  createdAt
+  updatedAt
+`;
+const REPOSITORY_DETAIL_FIELDS = `
+  ${REPOSITORY_LIST_FIELDS}
+  lastPublishedAt
+`;
+
+const TAG_FIELDS = `
+  name
+  path
+  location
+  digest
+  revision
+  shortRevision
+  totalSize
+  createdAt
+  publishedAt
+  mediaType
+`;
+
+export interface ContainerRepositoryNode {
+  id: string;
+  name: string | null;
+  path: string;
+  location: string;
+  status: string | null;
+  tagsCount: number;
+  createdAt: string;
+  updatedAt: string;
+  // Details-only (single-repository query); absent in list results.
+  lastPublishedAt?: string | null;
+}
+
+export interface ContainerTagNode {
+  name: string;
+  path: string;
+  location: string;
+  digest: string | null;
+  revision: string | null;
+  shortRevision: string | null;
+  totalSize: string | null;
+  createdAt: string | null;
+  publishedAt: string | null;
+  mediaType: string | null;
+}
+
+interface PageInfo {
+  hasNextPage: boolean;
+  endCursor: string | null;
+}
+
+// --- Query: list a project's container repositories ---
+export interface ListRepositoriesResult {
+  project: {
+    containerRepositories: {
+      nodes: ContainerRepositoryNode[];
+      pageInfo: PageInfo;
+    };
+  } | null;
+}
+export interface ListRepositoriesVars {
+  fullPath: string;
+  name?: string | null;
+  first?: number | null;
+  after?: string | null;
+}
+export const LIST_CONTAINER_REPOSITORIES: TypedDocumentNode<
+  ListRepositoriesResult,
+  ListRepositoriesVars
+> = gql`
+  query ListContainerRepositories($fullPath: ID!, $name: String, $first: Int, $after: String) {
+    project(fullPath: $fullPath) {
+      containerRepositories(name: $name, first: $first, after: $after) {
+        nodes {
+          ${REPOSITORY_LIST_FIELDS}
+        }
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+      }
+    }
+  }
+`;
+
+// --- Query: a single container repository ---
+export interface GetRepositoryResult {
+  containerRepository: ContainerRepositoryNode | null;
+}
+export interface GetRepositoryVars {
+  id: string;
+}
+export const GET_CONTAINER_REPOSITORY: TypedDocumentNode<GetRepositoryResult, GetRepositoryVars> =
+  gql`
+    query GetContainerRepository($id: ContainerRepositoryID!) {
+      containerRepository(id: $id) {
+        ${REPOSITORY_DETAIL_FIELDS}
+      }
+    }
+  `;
+
+// --- Query: tags of a container repository ---
+export interface ListTagsResult {
+  containerRepository: {
+    id: string;
+    tags: {
+      nodes: ContainerTagNode[];
+      pageInfo: PageInfo;
+    };
+  } | null;
+}
+export interface ListTagsVars {
+  id: string;
+  name?: string | null;
+  first?: number | null;
+  after?: string | null;
+}
+export const LIST_CONTAINER_REPOSITORY_TAGS: TypedDocumentNode<ListTagsResult, ListTagsVars> = gql`
+  query ListContainerRepositoryTags(
+    $id: ContainerRepositoryID!
+    $name: String
+    $first: Int
+    $after: String
+  ) {
+    containerRepository(id: $id) {
+      id
+      tags(name: $name, first: $first, after: $after) {
+        nodes {
+          ${TAG_FIELDS}
+        }
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+      }
+    }
+  }
+`;
+
+// --- Mutation: delete a repository ---
+export interface DestroyRepositoryResult {
+  destroyContainerRepository: {
+    containerRepository: { id: string; status: string | null } | null;
+    errors: string[];
+  } | null;
+}
+export interface DestroyRepositoryVars {
+  id: string;
+}
+export const DESTROY_CONTAINER_REPOSITORY: TypedDocumentNode<
+  DestroyRepositoryResult,
+  DestroyRepositoryVars
+> = gql`
+  mutation DestroyContainerRepository($id: ContainerRepositoryID!) {
+    destroyContainerRepository(input: { id: $id }) {
+      containerRepository {
+        id
+        status
+      }
+      errors
+    }
+  }
+`;
+
+// --- Mutation: delete tags by explicit name list ---
+export interface DestroyTagsResult {
+  destroyContainerRepositoryTags: {
+    deletedTagNames: string[];
+    errors: string[];
+  } | null;
+}
+export interface DestroyTagsVars {
+  id: string;
+  tagNames: string[];
+}
+export const DESTROY_CONTAINER_REPOSITORY_TAGS: TypedDocumentNode<
+  DestroyTagsResult,
+  DestroyTagsVars
+> = gql`
+  mutation DestroyContainerRepositoryTags($id: ContainerRepositoryID!, $tagNames: [String!]!) {
+    destroyContainerRepositoryTags(input: { id: $id, tagNames: $tagNames }) {
+      deletedTagNames
+      errors
+    }
+  }
+`;

--- a/src/registry-manager.ts
+++ b/src/registry-manager.ts
@@ -48,6 +48,10 @@ import {
   getEnvironmentsReadOnlyToolNames,
 } from './entities/environments/registry';
 import {
+  containerRegistryToolRegistry,
+  getContainerRegistryReadOnlyToolNames,
+} from './entities/container_registry/registry';
+import {
   GITLAB_BASE_URL,
   GITLAB_READ_ONLY_MODE,
   GITLAB_DENIED_TOOLS_REGEX,
@@ -70,6 +74,7 @@ import {
   USE_ITERATIONS,
   USE_CI_TOKENS,
   USE_ENVIRONMENTS,
+  USE_REGISTRY,
   getToolDescriptionOverrides,
 } from './config';
 import { isToolAvailable, getRestrictedParameters } from './services/InstanceCapabilities';
@@ -214,6 +219,10 @@ class RegistryManager {
       this.registries.set('environments', environmentsToolRegistry);
     }
 
+    if (USE_REGISTRY) {
+      this.registries.set('registry', containerRegistryToolRegistry);
+    }
+
     // All entity registries have been migrated to the new pattern!
   }
 
@@ -315,6 +324,10 @@ class RegistryManager {
 
     if (USE_ENVIRONMENTS) {
       readOnlyTools.push(...getEnvironmentsReadOnlyToolNames());
+    }
+
+    if (USE_REGISTRY) {
+      readOnlyTools.push(...getContainerRegistryReadOnlyToolNames());
     }
 
     return readOnlyTools;
@@ -744,6 +757,7 @@ class RegistryManager {
     const useIterations = process.env.USE_ITERATIONS !== 'false';
     const useCiTokens = process.env.USE_CI_TOKENS !== 'false';
     const useEnvironments = process.env.USE_ENVIRONMENTS !== 'false';
+    const useRegistry = process.env.USE_REGISTRY !== 'false';
 
     // Build registries map based on dynamic feature flags
     const registriesToUse = new Map<string, ToolRegistry>();
@@ -776,6 +790,7 @@ class RegistryManager {
       registriesToUse.set('deploy-keys', deployKeysToolRegistry);
     }
     if (useEnvironments) registriesToUse.set('environments', environmentsToolRegistry);
+    if (useRegistry) registriesToUse.set('registry', containerRegistryToolRegistry);
 
     // Dynamically load description overrides
     const descOverrides = getToolDescriptionOverrides();
@@ -877,6 +892,7 @@ class RegistryManager {
       jobTokenScopeToolRegistry,
       deployKeysToolRegistry,
       environmentsToolRegistry,
+      containerRegistryToolRegistry,
     ];
 
     for (const registry of allRegistries) {

--- a/src/services/TokenScopeDetector.ts
+++ b/src/services/TokenScopeDetector.ts
@@ -139,6 +139,10 @@ const TOOL_SCOPE_REQUIREMENTS: Record<string, GitLabScope[]> = {
   browse_deploy_keys: ['api', 'read_api'],
   manage_deploy_key: ['api'],
 
+  // Container registry
+  browse_registry: ['api', 'read_api', 'read_registry'],
+  manage_registry: ['api', 'write_registry'],
+
   // Wiki
   browse_wiki: ['api', 'read_api'],
   manage_wiki: ['api'],

--- a/tests/integration/schemas/container-registry.test.ts
+++ b/tests/integration/schemas/container-registry.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Container Registry Schema Integration Tests
+ *
+ * Backed by the GitLab GraphQL Container Registry API. The test instance usually
+ * has no pushed images, so the lifecycle (tags, deletes) is environment-adaptive:
+ * it exercises list_repositories end-to-end and only drills into a repository when
+ * one actually exists. Destructive actions are never run against real data here.
+ */
+
+import { BrowseRegistrySchema } from '../../../src/entities/container_registry/schema-readonly';
+import { ManageRegistrySchema } from '../../../src/entities/container_registry/schema';
+import { IntegrationTestHelper } from '../helpers/registry-helper';
+
+describe('Container Registry Schema - GitLab Integration', () => {
+  let helper: IntegrationTestHelper;
+  let testProjectPath: string | undefined;
+
+  beforeAll(async () => {
+    if (!process.env.GITLAB_TOKEN) {
+      throw new Error('GITLAB_TOKEN environment variable is required');
+    }
+    helper = new IntegrationTestHelper();
+    await helper.initialize();
+
+    const projects = (await helper.listProjects({ search: 'test', per_page: 5 })) as {
+      path_with_namespace: string;
+    }[];
+    const inTestGroup = projects.find((p) => p.path_with_namespace.startsWith('test/'));
+    testProjectPath = (inTestGroup ?? projects[0])?.path_with_namespace;
+  });
+
+  describe('schema validation', () => {
+    it('validates browse_registry actions', () => {
+      for (const params of [
+        { action: 'list_repositories', project_id: 'g/p', first: 10 },
+        { action: 'get_repository', repository_id: 1 },
+        { action: 'list_tags', repository_id: 1, name: 'v' },
+        { action: 'get_tag', repository_id: 1, tag_name: 'latest' },
+      ]) {
+        expect(BrowseRegistrySchema.safeParse(params).success).toBe(true);
+      }
+    });
+
+    it('validates manage_registry actions', () => {
+      for (const params of [
+        { action: 'delete_repository', repository_id: 1 },
+        { action: 'delete_tag', repository_id: 1, tag_name: 'old' },
+        {
+          action: 'delete_tags_bulk',
+          repository_id: 1,
+          name_regex_delete: '.*',
+          keep_n: 5,
+          older_than: '7d',
+        },
+      ]) {
+        expect(ManageRegistrySchema.safeParse(params).success).toBe(true);
+      }
+    });
+
+    it('rejects a malformed older_than duration', () => {
+      const result = ManageRegistrySchema.safeParse({
+        action: 'delete_tags_bulk',
+        repository_id: 1,
+        name_regex_delete: '.*',
+        older_than: '7days',
+      });
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('list_repositories (end-to-end)', () => {
+    it('returns a repository connection for a real project', async () => {
+      if (!testProjectPath) {
+        console.log('No test project available; skipping');
+        return;
+      }
+
+      const result = (await helper.executeTool('browse_registry', {
+        action: 'list_repositories',
+        project_id: testProjectPath,
+        first: 5,
+      })) as { nodes: { id: number; name: string | null }[]; pageInfo: { hasNextPage: boolean } };
+
+      expect(Array.isArray(result.nodes)).toBe(true);
+      expect(result.pageInfo).toBeDefined();
+      console.log(`  ${testProjectPath} has ${result.nodes.length} container repositories`);
+    }, 15000);
+
+    it('drills into a repository and its tags when one exists', async () => {
+      if (!testProjectPath) {
+        console.log('No test project available; skipping');
+        return;
+      }
+
+      const list = (await helper.executeTool('browse_registry', {
+        action: 'list_repositories',
+        project_id: testProjectPath,
+        first: 1,
+      })) as { nodes: { id: number }[] };
+
+      if (list.nodes.length === 0) {
+        console.log('  No container images pushed; skipping repository/tags drill-down');
+        return;
+      }
+
+      const repoId = list.nodes[0].id;
+      const repo = (await helper.executeTool('browse_registry', {
+        action: 'get_repository',
+        repository_id: repoId,
+      })) as { id: number };
+      expect(repo.id).toBe(repoId);
+
+      const tags = (await helper.executeTool('browse_registry', {
+        action: 'list_tags',
+        repository_id: repoId,
+        first: 5,
+      })) as { nodes: unknown[] };
+      expect(Array.isArray(tags.nodes)).toBe(true);
+      console.log(`  repository ${repoId} has ${tags.nodes.length} tags`);
+    }, 20000);
+  });
+});

--- a/tests/unit/entities/container_registry/registry.test.ts
+++ b/tests/unit/entities/container_registry/registry.test.ts
@@ -21,6 +21,33 @@ jest.mock('../../../../src/services/ConnectionManager', () => ({
 const browse = () => containerRegistryToolRegistry.get('browse_registry')!;
 const manage = () => containerRegistryToolRegistry.get('manage_registry')!;
 
+// --- Response builders (keep mock setup DRY across cases) ---
+const REPO_GID = 'gid://gitlab/ContainerRepository/5';
+const tag = (name: string, createdAt = '2026-01-01T00:00:00Z') => ({ name, createdAt });
+const tagsPage = (nodes: unknown[], hasNextPage = false, endCursor: string | null = null) => ({
+  containerRepository: { id: REPO_GID, tags: { nodes, pageInfo: { hasNextPage, endCursor } } },
+});
+const destroyTagsOk = () => ({
+  destroyContainerRepositoryTags: { deletedTagNames: [], errors: [] },
+});
+const destroyTagsError = (msg: string) => ({
+  destroyContainerRepositoryTags: { deletedTagNames: [], errors: [msg] },
+});
+
+/** Run delete_tags_bulk; first request resolves to the given tag pages, the rest to destroy-ok. */
+async function runBulk(
+  params: Record<string, unknown>,
+  pages: ReturnType<typeof tagsPage>[],
+): Promise<{ deleted_count: number; deleted_tags: string[]; scan_capped: boolean }> {
+  for (const p of pages) mockClient.request.mockResolvedValueOnce(p);
+  mockClient.request.mockResolvedValue(destroyTagsOk());
+  return (await manage().handler({
+    action: 'delete_tags_bulk',
+    repository_id: 5,
+    ...params,
+  })) as { deleted_count: number; deleted_tags: string[]; scan_capped: boolean };
+}
+
 beforeEach(() => {
   mockClient.request.mockReset();
 });
@@ -38,10 +65,7 @@ describe('container registry registry', () => {
     it('list_repositories queries the project by full path', async () => {
       mockClient.request.mockResolvedValueOnce({
         project: {
-          containerRepositories: {
-            nodes: [{ id: 'gid://gitlab/ContainerRepository/7' }],
-            pageInfo: { hasNextPage: false, endCursor: null },
-          },
+          containerRepositories: { nodes: [], pageInfo: { hasNextPage: false, endCursor: null } },
         },
       });
 
@@ -83,37 +107,28 @@ describe('container registry registry', () => {
     });
 
     it('list_tags queries tags by repository global ID', async () => {
-      mockClient.request.mockResolvedValueOnce({
-        containerRepository: {
-          id: 'gid://gitlab/ContainerRepository/3',
-          tags: { nodes: [], pageInfo: { hasNextPage: false, endCursor: null } },
-        },
-      });
+      mockClient.request.mockResolvedValueOnce(tagsPage([]));
 
-      await browse().handler({ action: 'list_tags', repository_id: 3 });
+      await browse().handler({ action: 'list_tags', repository_id: 5 });
 
       const [doc, vars] = mockClient.request.mock.calls[0];
       expect(doc).toBe(LIST_CONTAINER_REPOSITORY_TAGS);
-      expect(vars).toMatchObject({ id: 'gid://gitlab/ContainerRepository/3' });
+      expect(vars).toMatchObject({ id: REPO_GID });
+    });
+
+    it('list_tags throws when the repository is not found', async () => {
+      mockClient.request.mockResolvedValueOnce({ containerRepository: null });
+      await expect(browse().handler({ action: 'list_tags', repository_id: 5 })).rejects.toThrow(
+        'Container repository 5 not found',
+      );
     });
 
     it('get_tag selects the exact tag among substring matches', async () => {
-      mockClient.request.mockResolvedValueOnce({
-        containerRepository: {
-          id: 'gid://gitlab/ContainerRepository/3',
-          tags: {
-            nodes: [
-              { name: 'v1.0.0-rc', digest: 'sha256:a' },
-              { name: 'v1.0.0', digest: 'sha256:b' },
-            ],
-            pageInfo: { hasNextPage: false, endCursor: null },
-          },
-        },
-      });
+      mockClient.request.mockResolvedValueOnce(tagsPage([tag('v1.0.0-rc'), tag('v1.0.0')]));
 
       const result = (await browse().handler({
         action: 'get_tag',
-        repository_id: 3,
+        repository_id: 5,
         tag_name: 'v1.0.0',
       })) as { name: string };
 
@@ -121,15 +136,17 @@ describe('container registry registry', () => {
     });
 
     it('get_tag throws when the exact tag is absent', async () => {
-      mockClient.request.mockResolvedValueOnce({
-        containerRepository: {
-          id: 'gid://gitlab/ContainerRepository/3',
-          tags: { nodes: [{ name: 'latest' }], pageInfo: { hasNextPage: false, endCursor: null } },
-        },
-      });
+      mockClient.request.mockResolvedValueOnce(tagsPage([tag('latest')]));
       await expect(
-        browse().handler({ action: 'get_tag', repository_id: 3, tag_name: 'v9' }),
+        browse().handler({ action: 'get_tag', repository_id: 5, tag_name: 'v9' }),
       ).rejects.toThrow('Tag "v9" not found');
+    });
+
+    it('get_tag throws when the repository is not found', async () => {
+      mockClient.request.mockResolvedValueOnce({ containerRepository: null });
+      await expect(
+        browse().handler({ action: 'get_tag', repository_id: 5, tag_name: 'v1' }),
+      ).rejects.toThrow('Container repository 5 not found');
     });
   });
 
@@ -152,7 +169,7 @@ describe('container registry registry', () => {
 
       const [doc, vars] = mockClient.request.mock.calls[0];
       expect(doc).toBe(DESTROY_CONTAINER_REPOSITORY);
-      expect(vars).toEqual({ id: 'gid://gitlab/ContainerRepository/5' });
+      expect(vars).toEqual({ id: REPO_GID });
       expect(result.deleted).toBe(true);
       expect(result.status).toBe('DELETE_SCHEDULED');
     });
@@ -175,98 +192,87 @@ describe('container registry registry', () => {
 
       const [doc, vars] = mockClient.request.mock.calls[0];
       expect(doc).toBe(DESTROY_CONTAINER_REPOSITORY_TAGS);
-      expect(vars).toEqual({ id: 'gid://gitlab/ContainerRepository/5', tagNames: ['old'] });
+      expect(vars).toEqual({ id: REPO_GID, tagNames: ['old'] });
+    });
+
+    it('delete_tag surfaces GraphQL payload errors', async () => {
+      mockClient.request.mockResolvedValueOnce(destroyTagsError('tag protected'));
+      await expect(
+        manage().handler({ action: 'delete_tag', repository_id: 5, tag_name: 'prod' }),
+      ).rejects.toThrow('GitLab API error: tag protected');
     });
 
     it('delete_tags_bulk applies regex + keep_n, then destroys the rest', async () => {
-      // 4 version tags newest-first by createdAt; keep_n=1 keeps the newest, the
-      // "latest" tag is excluded by the regex.
-      mockClient.request
-        .mockResolvedValueOnce({
-          containerRepository: {
-            id: 'gid://gitlab/ContainerRepository/5',
-            tags: {
-              nodes: [
-                { name: 'v4', createdAt: '2026-04-04T00:00:00Z' },
-                { name: 'v3', createdAt: '2026-03-03T00:00:00Z' },
-                { name: 'v2', createdAt: '2026-02-02T00:00:00Z' },
-                { name: 'v1', createdAt: '2026-01-01T00:00:00Z' },
-                { name: 'latest', createdAt: '2026-05-05T00:00:00Z' },
-              ],
-              pageInfo: { hasNextPage: false, endCursor: null },
-            },
-          },
-        })
-        .mockResolvedValueOnce({
-          destroyContainerRepositoryTags: { deletedTagNames: [], errors: [] },
-        });
+      const result = await runBulk({ name_regex_delete: '^v\\d+$', keep_n: 1 }, [
+        tagsPage([
+          tag('v4', '2026-04-04T00:00:00Z'),
+          tag('v3', '2026-03-03T00:00:00Z'),
+          tag('v2', '2026-02-02T00:00:00Z'),
+          tag('v1', '2026-01-01T00:00:00Z'),
+          tag('latest', '2026-05-05T00:00:00Z'),
+        ]),
+      ]);
 
-      const result = (await manage().handler({
-        action: 'delete_tags_bulk',
-        repository_id: 5,
-        name_regex_delete: '^v\\d+$',
-        keep_n: 1,
-      })) as { deleted_count: number; deleted_tags: string[] };
-
-      // newest matching (v4) kept; v3, v2, v1 deleted; "latest" never matched.
+      // newest matching (v4) kept; v3,v2,v1 deleted; "latest" never matched.
       expect(result.deleted_tags).toEqual(['v3', 'v2', 'v1']);
       expect(result.deleted_count).toBe(3);
       const destroyCall = mockClient.request.mock.calls[1];
       expect(destroyCall[0]).toBe(DESTROY_CONTAINER_REPOSITORY_TAGS);
-      expect(destroyCall[1]).toEqual({
-        id: 'gid://gitlab/ContainerRepository/5',
-        tagNames: ['v3', 'v2', 'v1'],
-      });
+      expect(destroyCall[1]).toEqual({ id: REPO_GID, tagNames: ['v3', 'v2', 'v1'] });
     });
 
     it('delete_tags_bulk with name_regex_keep protects matching tags', async () => {
-      mockClient.request
-        .mockResolvedValueOnce({
-          containerRepository: {
-            id: 'gid://gitlab/ContainerRepository/5',
-            tags: {
-              nodes: [
-                { name: 'v1', createdAt: '2026-01-01T00:00:00Z' },
-                { name: 'v2-keep', createdAt: '2026-02-01T00:00:00Z' },
-              ],
-              pageInfo: { hasNextPage: false, endCursor: null },
-            },
-          },
-        })
-        .mockResolvedValueOnce({
-          destroyContainerRepositoryTags: { deletedTagNames: [], errors: [] },
-        });
-
-      const result = (await manage().handler({
-        action: 'delete_tags_bulk',
-        repository_id: 5,
-        name_regex_delete: '.*',
-        name_regex_keep: 'keep',
-      })) as { deleted_tags: string[] };
-
+      const result = await runBulk({ name_regex_delete: '.*', name_regex_keep: 'keep' }, [
+        tagsPage([tag('v1'), tag('v2-keep', '2026-02-01T00:00:00Z')]),
+      ]);
       expect(result.deleted_tags).toEqual(['v1']);
     });
 
-    it('delete_tags_bulk deletes nothing when no tag matches', async () => {
-      mockClient.request.mockResolvedValueOnce({
-        containerRepository: {
-          id: 'gid://gitlab/ContainerRepository/5',
-          tags: {
-            nodes: [{ name: 'latest', createdAt: '2026-01-01T00:00:00Z' }],
-            pageInfo: { hasNextPage: false, endCursor: null },
-          },
-        },
-      });
+    it('delete_tags_bulk with older_than deletes only stale tags', async () => {
+      const now = Date.now();
+      const recent = new Date(now - 60_000).toISOString(); // 1 min ago
+      const old = new Date(now - 10 * 86_400_000).toISOString(); // 10 days ago
+      const result = await runBulk({ name_regex_delete: '.*', older_than: '7d' }, [
+        tagsPage([tag('fresh', recent), tag('stale', old)]),
+      ]);
+      expect(result.deleted_tags).toEqual(['stale']);
+    });
 
+    it('delete_tags_bulk paginates across multiple tag pages', async () => {
+      const result = await runBulk({ name_regex_delete: '^v' }, [
+        tagsPage([tag('v1')], true, 'CURSOR1'),
+        tagsPage([tag('v2')], false, null),
+      ]);
+      expect(result.deleted_count).toBe(2);
+      // two list calls (pages) before the destroy call
+      expect(mockClient.request.mock.calls[0][0]).toBe(LIST_CONTAINER_REPOSITORY_TAGS);
+      expect(mockClient.request.mock.calls[1][1]).toMatchObject({ after: 'CURSOR1' });
+    });
+
+    it('delete_tags_bulk caps the tag scan at 1000', async () => {
+      const big = Array.from({ length: 1000 }, (_, i) => tag(`v${i}`));
+      const result = await runBulk({ name_regex_delete: '.*' }, [tagsPage(big, true, 'NEXT')]);
+      expect(result.scan_capped).toBe(true);
+      expect(result.deleted_count).toBe(1000);
+    });
+
+    it('delete_tags_bulk surfaces destroy errors', async () => {
+      mockClient.request.mockResolvedValueOnce(tagsPage([tag('v1')]));
+      mockClient.request.mockResolvedValueOnce(destroyTagsError('rate limited'));
+      await expect(
+        manage().handler({ action: 'delete_tags_bulk', repository_id: 5, name_regex_delete: '.*' }),
+      ).rejects.toThrow('GitLab API error: rate limited');
+    });
+
+    it('delete_tags_bulk deletes nothing when no tag matches', async () => {
+      mockClient.request.mockResolvedValueOnce(tagsPage([tag('latest')]));
       const result = (await manage().handler({
         action: 'delete_tags_bulk',
         repository_id: 5,
         name_regex_delete: '^v\\d+$',
       })) as { deleted_count: number };
-
       expect(result.deleted_count).toBe(0);
-      // only the list call happened; no destroy call.
-      expect(mockClient.request).toHaveBeenCalledTimes(1);
+      expect(mockClient.request).toHaveBeenCalledTimes(1); // only the list call
     });
 
     it('rejects an invalid older_than duration at schema parse', async () => {

--- a/tests/unit/entities/container_registry/registry.test.ts
+++ b/tests/unit/entities/container_registry/registry.test.ts
@@ -1,0 +1,284 @@
+import {
+  containerRegistryToolRegistry,
+  getContainerRegistryReadOnlyToolNames,
+} from '../../../../src/entities/container_registry/registry';
+import {
+  LIST_CONTAINER_REPOSITORIES,
+  GET_CONTAINER_REPOSITORY,
+  LIST_CONTAINER_REPOSITORY_TAGS,
+  DESTROY_CONTAINER_REPOSITORY,
+  DESTROY_CONTAINER_REPOSITORY_TAGS,
+} from '../../../../src/graphql/containerRegistry';
+
+const mockClient = { request: jest.fn() };
+
+jest.mock('../../../../src/services/ConnectionManager', () => ({
+  ConnectionManager: {
+    getInstance: jest.fn(() => ({ getClient: jest.fn(() => mockClient) })),
+  },
+}));
+
+const browse = () => containerRegistryToolRegistry.get('browse_registry')!;
+const manage = () => containerRegistryToolRegistry.get('manage_registry')!;
+
+beforeEach(() => {
+  mockClient.request.mockReset();
+});
+
+describe('container registry registry', () => {
+  it('registers the CQRS pair with browse_registry read-only', () => {
+    expect(containerRegistryToolRegistry.has('browse_registry')).toBe(true);
+    expect(containerRegistryToolRegistry.has('manage_registry')).toBe(true);
+    expect(getContainerRegistryReadOnlyToolNames()).toEqual(['browse_registry']);
+    expect(browse().gate).toEqual({ envVar: 'USE_REGISTRY', defaultValue: true });
+    expect(manage().gate).toEqual({ envVar: 'USE_REGISTRY', defaultValue: true });
+  });
+
+  describe('browse_registry', () => {
+    it('list_repositories queries the project by full path', async () => {
+      mockClient.request.mockResolvedValueOnce({
+        project: {
+          containerRepositories: {
+            nodes: [{ id: 'gid://gitlab/ContainerRepository/7' }],
+            pageInfo: { hasNextPage: false, endCursor: null },
+          },
+        },
+      });
+
+      await browse().handler({
+        action: 'list_repositories',
+        project_id: 'my-group/my-project',
+        first: 5,
+      });
+
+      const [doc, vars] = mockClient.request.mock.calls[0];
+      expect(doc).toBe(LIST_CONTAINER_REPOSITORIES);
+      expect(vars).toMatchObject({ fullPath: 'my-group/my-project', first: 5 });
+    });
+
+    it('list_repositories throws when the project is not found', async () => {
+      mockClient.request.mockResolvedValueOnce({ project: null });
+      await expect(
+        browse().handler({ action: 'list_repositories', project_id: 'missing/project' }),
+      ).rejects.toThrow('not found or not accessible');
+    });
+
+    it('get_repository expands the numeric id to a global ID', async () => {
+      mockClient.request.mockResolvedValueOnce({
+        containerRepository: { id: 'gid://gitlab/ContainerRepository/42', name: 'app' },
+      });
+
+      await browse().handler({ action: 'get_repository', repository_id: 42 });
+
+      const [doc, vars] = mockClient.request.mock.calls[0];
+      expect(doc).toBe(GET_CONTAINER_REPOSITORY);
+      expect(vars).toEqual({ id: 'gid://gitlab/ContainerRepository/42' });
+    });
+
+    it('get_repository throws when missing', async () => {
+      mockClient.request.mockResolvedValueOnce({ containerRepository: null });
+      await expect(
+        browse().handler({ action: 'get_repository', repository_id: 99 }),
+      ).rejects.toThrow('Container repository 99 not found');
+    });
+
+    it('list_tags queries tags by repository global ID', async () => {
+      mockClient.request.mockResolvedValueOnce({
+        containerRepository: {
+          id: 'gid://gitlab/ContainerRepository/3',
+          tags: { nodes: [], pageInfo: { hasNextPage: false, endCursor: null } },
+        },
+      });
+
+      await browse().handler({ action: 'list_tags', repository_id: 3 });
+
+      const [doc, vars] = mockClient.request.mock.calls[0];
+      expect(doc).toBe(LIST_CONTAINER_REPOSITORY_TAGS);
+      expect(vars).toMatchObject({ id: 'gid://gitlab/ContainerRepository/3' });
+    });
+
+    it('get_tag selects the exact tag among substring matches', async () => {
+      mockClient.request.mockResolvedValueOnce({
+        containerRepository: {
+          id: 'gid://gitlab/ContainerRepository/3',
+          tags: {
+            nodes: [
+              { name: 'v1.0.0-rc', digest: 'sha256:a' },
+              { name: 'v1.0.0', digest: 'sha256:b' },
+            ],
+            pageInfo: { hasNextPage: false, endCursor: null },
+          },
+        },
+      });
+
+      const result = (await browse().handler({
+        action: 'get_tag',
+        repository_id: 3,
+        tag_name: 'v1.0.0',
+      })) as { name: string };
+
+      expect(result.name).toBe('v1.0.0');
+    });
+
+    it('get_tag throws when the exact tag is absent', async () => {
+      mockClient.request.mockResolvedValueOnce({
+        containerRepository: {
+          id: 'gid://gitlab/ContainerRepository/3',
+          tags: { nodes: [{ name: 'latest' }], pageInfo: { hasNextPage: false, endCursor: null } },
+        },
+      });
+      await expect(
+        browse().handler({ action: 'get_tag', repository_id: 3, tag_name: 'v9' }),
+      ).rejects.toThrow('Tag "v9" not found');
+    });
+  });
+
+  describe('manage_registry', () => {
+    it('delete_repository runs the destroy mutation by global ID', async () => {
+      mockClient.request.mockResolvedValueOnce({
+        destroyContainerRepository: {
+          containerRepository: { id: 'x', status: 'DELETE_SCHEDULED' },
+          errors: [],
+        },
+      });
+
+      const result = (await manage().handler({
+        action: 'delete_repository',
+        repository_id: 5,
+      })) as {
+        deleted: boolean;
+        status: string;
+      };
+
+      const [doc, vars] = mockClient.request.mock.calls[0];
+      expect(doc).toBe(DESTROY_CONTAINER_REPOSITORY);
+      expect(vars).toEqual({ id: 'gid://gitlab/ContainerRepository/5' });
+      expect(result.deleted).toBe(true);
+      expect(result.status).toBe('DELETE_SCHEDULED');
+    });
+
+    it('delete_repository surfaces GraphQL payload errors', async () => {
+      mockClient.request.mockResolvedValueOnce({
+        destroyContainerRepository: { containerRepository: null, errors: ['Not authorized'] },
+      });
+      await expect(
+        manage().handler({ action: 'delete_repository', repository_id: 5 }),
+      ).rejects.toThrow('GitLab API error: Not authorized');
+    });
+
+    it('delete_tag destroys a single tag by name', async () => {
+      mockClient.request.mockResolvedValueOnce({
+        destroyContainerRepositoryTags: { deletedTagNames: ['old'], errors: [] },
+      });
+
+      await manage().handler({ action: 'delete_tag', repository_id: 5, tag_name: 'old' });
+
+      const [doc, vars] = mockClient.request.mock.calls[0];
+      expect(doc).toBe(DESTROY_CONTAINER_REPOSITORY_TAGS);
+      expect(vars).toEqual({ id: 'gid://gitlab/ContainerRepository/5', tagNames: ['old'] });
+    });
+
+    it('delete_tags_bulk applies regex + keep_n, then destroys the rest', async () => {
+      // 4 version tags newest-first by createdAt; keep_n=1 keeps the newest, the
+      // "latest" tag is excluded by the regex.
+      mockClient.request
+        .mockResolvedValueOnce({
+          containerRepository: {
+            id: 'gid://gitlab/ContainerRepository/5',
+            tags: {
+              nodes: [
+                { name: 'v4', createdAt: '2026-04-04T00:00:00Z' },
+                { name: 'v3', createdAt: '2026-03-03T00:00:00Z' },
+                { name: 'v2', createdAt: '2026-02-02T00:00:00Z' },
+                { name: 'v1', createdAt: '2026-01-01T00:00:00Z' },
+                { name: 'latest', createdAt: '2026-05-05T00:00:00Z' },
+              ],
+              pageInfo: { hasNextPage: false, endCursor: null },
+            },
+          },
+        })
+        .mockResolvedValueOnce({
+          destroyContainerRepositoryTags: { deletedTagNames: [], errors: [] },
+        });
+
+      const result = (await manage().handler({
+        action: 'delete_tags_bulk',
+        repository_id: 5,
+        name_regex_delete: '^v\\d+$',
+        keep_n: 1,
+      })) as { deleted_count: number; deleted_tags: string[] };
+
+      // newest matching (v4) kept; v3, v2, v1 deleted; "latest" never matched.
+      expect(result.deleted_tags).toEqual(['v3', 'v2', 'v1']);
+      expect(result.deleted_count).toBe(3);
+      const destroyCall = mockClient.request.mock.calls[1];
+      expect(destroyCall[0]).toBe(DESTROY_CONTAINER_REPOSITORY_TAGS);
+      expect(destroyCall[1]).toEqual({
+        id: 'gid://gitlab/ContainerRepository/5',
+        tagNames: ['v3', 'v2', 'v1'],
+      });
+    });
+
+    it('delete_tags_bulk with name_regex_keep protects matching tags', async () => {
+      mockClient.request
+        .mockResolvedValueOnce({
+          containerRepository: {
+            id: 'gid://gitlab/ContainerRepository/5',
+            tags: {
+              nodes: [
+                { name: 'v1', createdAt: '2026-01-01T00:00:00Z' },
+                { name: 'v2-keep', createdAt: '2026-02-01T00:00:00Z' },
+              ],
+              pageInfo: { hasNextPage: false, endCursor: null },
+            },
+          },
+        })
+        .mockResolvedValueOnce({
+          destroyContainerRepositoryTags: { deletedTagNames: [], errors: [] },
+        });
+
+      const result = (await manage().handler({
+        action: 'delete_tags_bulk',
+        repository_id: 5,
+        name_regex_delete: '.*',
+        name_regex_keep: 'keep',
+      })) as { deleted_tags: string[] };
+
+      expect(result.deleted_tags).toEqual(['v1']);
+    });
+
+    it('delete_tags_bulk deletes nothing when no tag matches', async () => {
+      mockClient.request.mockResolvedValueOnce({
+        containerRepository: {
+          id: 'gid://gitlab/ContainerRepository/5',
+          tags: {
+            nodes: [{ name: 'latest', createdAt: '2026-01-01T00:00:00Z' }],
+            pageInfo: { hasNextPage: false, endCursor: null },
+          },
+        },
+      });
+
+      const result = (await manage().handler({
+        action: 'delete_tags_bulk',
+        repository_id: 5,
+        name_regex_delete: '^v\\d+$',
+      })) as { deleted_count: number };
+
+      expect(result.deleted_count).toBe(0);
+      // only the list call happened; no destroy call.
+      expect(mockClient.request).toHaveBeenCalledTimes(1);
+    });
+
+    it('rejects an invalid older_than duration at schema parse', async () => {
+      await expect(
+        manage().handler({
+          action: 'delete_tags_bulk',
+          repository_id: 5,
+          name_regex_delete: '.*',
+          older_than: '7days',
+        }),
+      ).rejects.toThrow();
+      expect(mockClient.request).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/unit/entities/container_registry/registry.test.ts
+++ b/tests/unit/entities/container_registry/registry.test.ts
@@ -142,6 +142,22 @@ describe('container registry registry', () => {
       ).rejects.toThrow('Tag "v9" not found');
     });
 
+    it('get_tag paginates past the first page to find the exact tag', async () => {
+      // First page (substring matches) lacks the exact name; it lives on page 2.
+      mockClient.request
+        .mockResolvedValueOnce(tagsPage([tag('v1.0.0-rc1'), tag('v1.0.0-rc2')], true, 'CURSOR1'))
+        .mockResolvedValueOnce(tagsPage([tag('v1.0.0')]));
+
+      const result = (await browse().handler({
+        action: 'get_tag',
+        repository_id: 5,
+        tag_name: 'v1.0.0',
+      })) as { name: string };
+
+      expect(result.name).toBe('v1.0.0');
+      expect(mockClient.request.mock.calls[1][1]).toMatchObject({ after: 'CURSOR1' });
+    });
+
     it('get_tag throws when the repository is not found', async () => {
       mockClient.request.mockResolvedValueOnce({ containerRepository: null });
       await expect(
@@ -273,6 +289,33 @@ describe('container registry registry', () => {
       })) as { deleted_count: number };
       expect(result.deleted_count).toBe(0);
       expect(mockClient.request).toHaveBeenCalledTimes(1); // only the list call
+    });
+
+    it('delete_tags_bulk throws when the repository does not exist', async () => {
+      mockClient.request.mockResolvedValueOnce({ containerRepository: null });
+      await expect(
+        manage().handler({ action: 'delete_tags_bulk', repository_id: 5, name_regex_delete: '.*' }),
+      ).rejects.toThrow('Container repository 5 not found');
+    });
+
+    it('delete_tags_bulk destroys tags in batches of 20', async () => {
+      const many = Array.from({ length: 45 }, (_, i) => tag(`v${i}`));
+      const result = await runBulk({ name_regex_delete: '^v\\d+$' }, [tagsPage(many)]);
+
+      expect(result.deleted_count).toBe(45);
+      const destroyCalls = mockClient.request.mock.calls.filter(
+        (c) => c[0] === DESTROY_CONTAINER_REPOSITORY_TAGS,
+      );
+      expect(destroyCalls.map((c) => (c[1] as { tagNames: string[] }).tagNames.length)).toEqual([
+        20, 20, 5,
+      ]);
+    });
+
+    it('rejects an invalid name_regex_delete at schema parse', async () => {
+      await expect(
+        manage().handler({ action: 'delete_tags_bulk', repository_id: 5, name_regex_delete: '[' }),
+      ).rejects.toThrow();
+      expect(mockClient.request).not.toHaveBeenCalled();
     });
 
     it('rejects an invalid older_than duration at schema parse', async () => {


### PR DESCRIPTION
## Summary

Adds a `browse_registry` / `manage_registry` CQRS pair for the GitLab Container Registry, gated behind `USE_REGISTRY` (Free tier). +2 tools (50 -> 52).

Backed by the **GitLab GraphQL** Container Registry API (verified against the live instance via schema introspection), per the repo's GraphQL-first convention — not REST.

### browse_registry (read-only)
- `list_repositories` — `project.containerRepositories` (needs the project full path)
- `get_repository` — `containerRepository(id)`
- `list_tags` — `containerRepository(id).tags`
- `get_tag` — exact tag from the tags connection (the `name` arg is a substring filter)

### manage_registry (writes, require `write_registry` scope)
- `delete_repository` — `destroyContainerRepository`
- `delete_tag` — `destroyContainerRepositoryTags` (single name)
- `delete_tags_bulk` — regex cleanup with retention

### Why bulk is composed client-side
GitLab's GraphQL has **no** native regex/keep_n/older_than bulk-tag mutation (only `destroyContainerRepositoryTags` with an explicit name list). So `delete_tags_bulk` pages through tags, filters in the handler (match `name_regex_delete`, drop `name_regex_keep`, keep the newest `keep_n`, then of the rest keep only those older than `older_than`) — mirroring GitLab's own cleanup-policy order — and destroys the resolved names in batches of 20. Tag scan is capped at 1000 with a `scan_capped` flag (never silently truncated).

### Details
- Numeric repository IDs are expanded to `gid://gitlab/ContainerRepository/N` internally; responses run through `cleanGidsFromObject` so output IDs stay numeric.
- Wired into all three registry enumerations (constructor map, tierless, unfiltered) + read-only list; `browse_registry`/`manage_registry` added to the token-scope map (`read_registry`/`write_registry`).
- Field sets split: list nodes are `ContainerRepository` (no `lastPublishedAt`), single-repo is `ContainerRepositoryDetails`.

## Testing
- Unit: 15 tests (mocked GraphQL client) covering every action + the bulk filter (regex, keep_n, name_regex_keep, no-match, invalid older_than).
- Integration: schema validation + `list_repositories` end-to-end against the live instance, with env-adaptive drill-down into a repository/tags when an image exists.
- `yarn test` 5045 unit pass; `yarn test:integration` 418 pass; lint + build clean. Tool count reported as 52.

Closes #437

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Container Registry browsing: list repositories, fetch repository and tag details, and view tags.
  * Added Container Registry management: delete repositories, delete single tags, and bulk tag cleanup with regex filters, retention (keep_n), and age-based pruning.
  * Added token-scope requirements for registry operations.

* **Tests**
  * Added integration and unit tests covering schemas, browse/manage flows, bulk cleanup, pagination, batching, and error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->