### PR TITLE
feat(runners): expose CI runner management via GraphQL

### DIFF
--- a/src/entities/runners/registry.ts
+++ b/src/entities/runners/registry.ts
@@ -1,0 +1,281 @@
+import * as z from 'zod';
+import { BrowseRunnersSchema } from './schema-readonly';
+import { ManageRunnerSchema } from './schema';
+import { ToolRegistry, EnhancedToolDefinition } from '../../types';
+import { assertActionAllowed } from '../utils';
+import { ConnectionManager } from '../../services/ConnectionManager';
+import { cleanGidsFromObject } from '../../utils/idConversion';
+import { gitlab } from '../../utils/gitlab-api';
+import {
+  LIST_RUNNERS,
+  LIST_OWNED_RUNNERS,
+  LIST_GROUP_RUNNERS,
+  LIST_PROJECT_RUNNERS,
+  GET_RUNNER,
+  LIST_RUNNER_JOBS,
+  RESOLVE_GROUP_ID,
+  RESOLVE_PROJECT_ID,
+  RUNNER_CREATE,
+  RUNNER_UPDATE,
+  RUNNER_DELETE,
+  type RunnerListVars,
+} from '../../graphql/runners';
+
+/**
+ * Runners tools registry - 2 CQRS tools
+ *
+ * browse_runners (Query): list_all, list_owned, list_project, list_group, get, list_jobs
+ * manage_runner (Command): create_authentication_token, update, pause, resume, delete,
+ *                          reset_authentication_token
+ *
+ * Backed by the GitLab GraphQL runner API. pause/resume map to runnerUpdate(paused).
+ * Per-runner token reset has no GraphQL mutation, so reset_authentication_token uses
+ * the REST endpoint. Gated behind USE_RUNNERS. Free tier (writes require the
+ * create_runner / manage_runner scope; list_all needs admin).
+ */
+
+const runnerGid = (id: number): string => `gid://gitlab/Ci::Runner/${id}`;
+
+/** Build the shared GraphQL list filter variables from the parsed input. */
+function listVars(input: {
+  type?: string;
+  status?: string;
+  paused?: boolean;
+  tag_list?: string[];
+  search?: string;
+  first?: number;
+  after?: string;
+}): RunnerListVars {
+  return {
+    type: input.type ?? null,
+    status: input.status ?? null,
+    paused: input.paused ?? null,
+    tagList: input.tag_list ?? null,
+    search: input.search ?? null,
+    first: input.first ?? 20,
+    after: input.after ?? null,
+  };
+}
+
+interface RunnerSettingsInput {
+  description?: string | null;
+  paused?: boolean | null;
+  locked?: boolean | null;
+  runUntagged?: boolean | null;
+  tagList?: string[] | null;
+  accessLevel?: string | null;
+  maximumTimeout?: number | null;
+  maintenanceNote?: string | null;
+}
+
+/** Map provided snake_case settings onto a camelCase mutation input (omitting absent ones). */
+function applyRunnerSettings(
+  target: RunnerSettingsInput,
+  src: {
+    description?: string;
+    paused?: boolean;
+    locked?: boolean;
+    run_untagged?: boolean;
+    tag_list?: string[];
+    access_level?: string;
+    maximum_timeout?: number;
+    maintenance_note?: string;
+  },
+): void {
+  if (src.description !== undefined) target.description = src.description;
+  if (src.paused !== undefined) target.paused = src.paused;
+  if (src.locked !== undefined) target.locked = src.locked;
+  if (src.run_untagged !== undefined) target.runUntagged = src.run_untagged;
+  if (src.tag_list !== undefined) target.tagList = src.tag_list;
+  if (src.access_level !== undefined) target.accessLevel = src.access_level;
+  if (src.maximum_timeout !== undefined) target.maximumTimeout = src.maximum_timeout;
+  if (src.maintenance_note !== undefined) target.maintenanceNote = src.maintenance_note;
+}
+
+/** Throw on a non-empty GraphQL mutation `errors` array. */
+function assertNoErrors(errors: string[] | undefined): void {
+  if (errors && errors.length > 0) {
+    throw new Error(`GitLab API error: ${errors.join(', ')}`);
+  }
+}
+
+export const runnersToolRegistry: ToolRegistry = new Map<string, EnhancedToolDefinition>([
+  // ============================================================================
+  // browse_runners - CQRS Query Tool (discriminated union schema)
+  // ============================================================================
+  [
+    'browse_runners',
+    {
+      name: 'browse_runners',
+      description:
+        "Inspect CI runners. Actions: list_all (every runner on the instance - admin), list_owned (the current user's runners), list_project / list_group (runners available to a project/group), get (single runner by ID), list_jobs (jobs a runner has executed). Related: manage_runner to register, update, pause/resume, or delete runners.",
+      inputSchema: z.toJSONSchema(BrowseRunnersSchema),
+      requirements: { default: { tier: 'free', minVersion: '13.2' } },
+      gate: { envVar: 'USE_RUNNERS', defaultValue: true },
+      handler: async (args: unknown): Promise<unknown> => {
+        const input = BrowseRunnersSchema.parse(args);
+
+        assertActionAllowed('browse_runners', input.action);
+
+        const client = ConnectionManager.getInstance().getClient();
+
+        switch (input.action) {
+          case 'list_all': {
+            const res = await client.request(LIST_RUNNERS, listVars(input));
+            return cleanGidsFromObject(res.runners);
+          }
+
+          case 'list_owned': {
+            const res = await client.request(LIST_OWNED_RUNNERS, listVars(input));
+            return cleanGidsFromObject(res.currentUser?.runners ?? { nodes: [] });
+          }
+
+          case 'list_project': {
+            const res = await client.request(LIST_PROJECT_RUNNERS, {
+              fullPath: input.project_id,
+              ...listVars(input),
+            });
+            if (!res.project) {
+              throw new Error(`Project "${input.project_id}" not found or not accessible`);
+            }
+            return cleanGidsFromObject(res.project.runners);
+          }
+
+          case 'list_group': {
+            const res = await client.request(LIST_GROUP_RUNNERS, {
+              fullPath: input.group_id,
+              ...listVars(input),
+            });
+            if (!res.group) {
+              throw new Error(`Group "${input.group_id}" not found or not accessible`);
+            }
+            return cleanGidsFromObject(res.group.runners);
+          }
+
+          case 'get': {
+            const res = await client.request(GET_RUNNER, { id: runnerGid(input.runner_id) });
+            if (!res.runner) {
+              throw new Error(`Runner ${input.runner_id} not found`);
+            }
+            return cleanGidsFromObject(res.runner);
+          }
+
+          case 'list_jobs': {
+            const res = await client.request(LIST_RUNNER_JOBS, {
+              id: runnerGid(input.runner_id),
+              statuses: input.statuses ?? null,
+              first: input.first ?? 20,
+              after: input.after ?? null,
+            });
+            if (!res.runner) {
+              throw new Error(`Runner ${input.runner_id} not found`);
+            }
+            return cleanGidsFromObject(res.runner.jobs ?? { nodes: [] });
+          }
+
+          /* istanbul ignore next -- unreachable with Zod discriminatedUnion */
+          default:
+            throw new Error(`Unknown action: ${(input as { action: string }).action}`);
+        }
+      },
+    },
+  ],
+
+  // ============================================================================
+  // manage_runner - CQRS Command Tool (discriminated union schema)
+  // ============================================================================
+  [
+    'manage_runner',
+    {
+      name: 'manage_runner',
+      description:
+        'Register and control CI runners. Actions: create_authentication_token (register a runner, GitLab 16+, returns a one-time token), update (settings), pause/resume (toggle job pickup), delete, reset_authentication_token (rotate the token). Related: browse_runners to discover runners.',
+      inputSchema: z.toJSONSchema(ManageRunnerSchema),
+      requirements: { default: { tier: 'free', minVersion: '13.2' } },
+      gate: { envVar: 'USE_RUNNERS', defaultValue: true },
+      handler: async (args: unknown): Promise<unknown> => {
+        const input = ManageRunnerSchema.parse(args);
+
+        assertActionAllowed('manage_runner', input.action);
+
+        const client = ConnectionManager.getInstance().getClient();
+
+        switch (input.action) {
+          case 'create_authentication_token': {
+            const createInput: {
+              runnerType: string;
+              groupId?: string;
+              projectId?: string;
+            } & RunnerSettingsInput = { runnerType: input.runner_type };
+            applyRunnerSettings(createInput, input);
+
+            if (input.runner_type === 'GROUP_TYPE') {
+              if (!input.group_id) {
+                throw new Error('group_id is required for a GROUP_TYPE runner');
+              }
+              const g = await client.request(RESOLVE_GROUP_ID, { fullPath: input.group_id });
+              if (!g.group) throw new Error(`Group "${input.group_id}" not found`);
+              createInput.groupId = g.group.id;
+            } else if (input.runner_type === 'PROJECT_TYPE') {
+              if (!input.project_id) {
+                throw new Error('project_id is required for a PROJECT_TYPE runner');
+              }
+              const p = await client.request(RESOLVE_PROJECT_ID, { fullPath: input.project_id });
+              if (!p.project) throw new Error(`Project "${input.project_id}" not found`);
+              createInput.projectId = p.project.id;
+            }
+
+            const res = await client.request(RUNNER_CREATE, { input: createInput });
+            assertNoErrors(res.runnerCreate?.errors);
+            return cleanGidsFromObject(res.runnerCreate?.runner);
+          }
+
+          case 'update': {
+            const updateInput: { id: string } & RunnerSettingsInput = {
+              id: runnerGid(input.runner_id),
+            };
+            applyRunnerSettings(updateInput, input);
+            const res = await client.request(RUNNER_UPDATE, { input: updateInput });
+            assertNoErrors(res.runnerUpdate?.errors);
+            return cleanGidsFromObject(res.runnerUpdate?.runner);
+          }
+
+          case 'pause':
+          case 'resume': {
+            const res = await client.request(RUNNER_UPDATE, {
+              input: { id: runnerGid(input.runner_id), paused: input.action === 'pause' },
+            });
+            assertNoErrors(res.runnerUpdate?.errors);
+            return cleanGidsFromObject(res.runnerUpdate?.runner);
+          }
+
+          case 'delete': {
+            const res = await client.request(RUNNER_DELETE, {
+              input: { id: runnerGid(input.runner_id) },
+            });
+            assertNoErrors(res.runnerDelete?.errors);
+            return { deleted: true, runner_id: input.runner_id };
+          }
+
+          case 'reset_authentication_token': {
+            // No GraphQL mutation for per-runner token reset; use the REST endpoint.
+            return gitlab.post(`runners/${input.runner_id}/reset_authentication_token`, {
+              contentType: 'json',
+            });
+          }
+
+          /* istanbul ignore next -- unreachable with Zod discriminatedUnion */
+          default:
+            throw new Error(`Unknown action: ${(input as { action: string }).action}`);
+        }
+      },
+    },
+  ],
+]);
+
+/**
+ * Get read-only tool names from the registry
+ */
+export function getRunnersReadOnlyToolNames(): string[] {
+  return ['browse_runners'];
+}

--- a/src/entities/runners/schema-readonly.ts
+++ b/src/entities/runners/schema-readonly.ts
@@ -1,0 +1,130 @@
+import { z } from 'zod';
+import { requiredId, flexibleBoolean } from '../utils';
+
+// ============================================================================
+// browse_runners - CQRS Query Tool (discriminated union schema)
+// Actions: list_all, list_owned, list_project, list_group, get, list_jobs
+// Backed by the GitLab GraphQL runners API. Jobs fold in as the list_jobs action
+// rather than a separate tool. Gated behind USE_RUNNERS. Free tier.
+// ============================================================================
+
+const projectPathField = requiredId.describe(
+  "Project full path (e.g., 'my-group/my-project') - required by the GraphQL project lookup",
+);
+const groupPathField = requiredId.describe(
+  "Group full path (e.g., 'my-group' or 'my-group/sub') - required by the GraphQL group lookup",
+);
+const runnerIdField = z.coerce
+  .number()
+  .int()
+  .positive()
+  .describe('Numeric ID of the runner (from a list action); expanded to a global ID internally');
+
+const runnerTypeFilter = z
+  .enum(['INSTANCE_TYPE', 'GROUP_TYPE', 'PROJECT_TYPE'])
+  .optional()
+  .describe('Filter by runner type');
+const runnerStatusFilter = z
+  .enum(['ONLINE', 'OFFLINE', 'STALE', 'NEVER_CONTACTED'])
+  .optional()
+  .describe('Filter by runner status');
+const pausedFilter = flexibleBoolean.optional().describe('Filter by paused state');
+const tagListFilter = z
+  .array(z.string())
+  .optional()
+  .describe('Filter by runners that have ALL of these tags');
+const searchFilter = z.string().optional().describe('Filter by description/token substring');
+const firstField = z.coerce
+  .number()
+  .int()
+  .positive()
+  .max(100)
+  .optional()
+  .describe('Max items to return (cursor pagination, default 20, max 100)');
+const afterField = z.string().optional().describe('Cursor for the next page (endCursor)');
+
+// Shared filter fields reused across the list actions.
+const listFilters = {
+  type: runnerTypeFilter,
+  status: runnerStatusFilter,
+  paused: pausedFilter,
+  tag_list: tagListFilter,
+  search: searchFilter,
+  first: firstField,
+  after: afterField,
+};
+
+// --- Action: list_all (instance-wide; admin) ---
+const ListAllRunnersSchema = z.object({
+  action: z
+    .literal('list_all')
+    .describe('List all runners on the instance (requires admin / elevated access)'),
+  ...listFilters,
+});
+
+// --- Action: list_owned (current user) ---
+const ListOwnedRunnersSchema = z.object({
+  action: z.literal('list_owned').describe('List runners owned by the current user'),
+  ...listFilters,
+});
+
+// --- Action: list_project ---
+const ListProjectRunnersSchema = z.object({
+  action: z.literal('list_project').describe('List runners available to a project'),
+  project_id: projectPathField,
+  ...listFilters,
+});
+
+// --- Action: list_group ---
+const ListGroupRunnersSchema = z.object({
+  action: z.literal('list_group').describe('List runners available to a group'),
+  group_id: groupPathField,
+  ...listFilters,
+});
+
+// --- Action: get ---
+const GetRunnerSchema = z.object({
+  action: z.literal('get').describe('Get a single runner by its numeric ID'),
+  runner_id: runnerIdField,
+});
+
+// --- Action: list_jobs ---
+const ListRunnerJobsSchema = z.object({
+  action: z.literal('list_jobs').describe('List jobs that have run on a runner'),
+  runner_id: runnerIdField,
+  statuses: z
+    .enum([
+      'CREATED',
+      'PENDING',
+      'RUNNING',
+      'FAILED',
+      'SUCCESS',
+      'CANCELED',
+      'SKIPPED',
+      'MANUAL',
+      'SCHEDULED',
+      'WAITING_FOR_RESOURCE',
+      'PREPARING',
+      'CANCELING',
+    ])
+    .optional()
+    .describe('Filter jobs by status'),
+  first: firstField,
+  after: afterField,
+});
+
+// --- Discriminated union combining all actions ---
+export const BrowseRunnersSchema = z.discriminatedUnion('action', [
+  ListAllRunnersSchema,
+  ListOwnedRunnersSchema,
+  ListProjectRunnersSchema,
+  ListGroupRunnersSchema,
+  GetRunnerSchema,
+  ListRunnerJobsSchema,
+]);
+
+// ============================================================================
+// Type exports
+// ============================================================================
+
+export type BrowseRunnersInput = z.infer<typeof BrowseRunnersSchema>;

--- a/src/entities/runners/schema.ts
+++ b/src/entities/runners/schema.ts
@@ -1,0 +1,116 @@
+import { z } from 'zod';
+import { requiredId, flexibleBoolean } from '../utils';
+
+// ============================================================================
+// manage_runner - CQRS Command Tool (discriminated union schema)
+// Actions: create_authentication_token, update, pause, resume, delete,
+//          reset_authentication_token
+// Backed by the GitLab GraphQL runner mutations (runnerCreate / runnerUpdate /
+// runnerDelete). pause/resume map to runnerUpdate(paused). Per-runner token reset
+// has no GraphQL mutation, so reset_authentication_token uses the REST endpoint.
+// Gated behind USE_RUNNERS. Writes require the create_runner / manage_runner scope.
+// ============================================================================
+
+const groupPathField = requiredId.describe("Group full path for a group runner (e.g., 'my-group')");
+const projectPathField = requiredId.describe(
+  "Project full path for a project runner (e.g., 'my-group/my-project')",
+);
+const runnerIdField = z.coerce
+  .number()
+  .int()
+  .positive()
+  .describe('Numeric ID of the runner (from browse_runners); expanded to a global ID internally');
+const accessLevelField = z
+  .enum(['NOT_PROTECTED', 'REF_PROTECTED'])
+  .optional()
+  .describe('Access level: NOT_PROTECTED or REF_PROTECTED (protected refs only)');
+const tagListField = z.array(z.string()).optional().describe('Tags that determine which jobs run');
+const descriptionField = z.string().optional().describe('Runner description');
+const maintenanceNoteField = z
+  .string()
+  .optional()
+  .describe('Free-form maintenance note (Markdown)');
+const maximumTimeoutField = z.coerce
+  .number()
+  .int()
+  .optional()
+  .describe('Maximum job timeout in seconds');
+
+// Settings shared by create and update.
+const runnerSettings = {
+  description: descriptionField,
+  paused: flexibleBoolean.optional().describe('Whether the runner is paused (ignores new jobs)'),
+  locked: flexibleBoolean.optional().describe('Lock the runner to its current projects'),
+  run_untagged: flexibleBoolean.optional().describe('Allow running untagged jobs'),
+  tag_list: tagListField,
+  access_level: accessLevelField,
+  maximum_timeout: maximumTimeoutField,
+  maintenance_note: maintenanceNoteField,
+};
+
+// --- Action: create_authentication_token (GitLab 16+ runner registration) ---
+const CreateRunnerSchema = z.object({
+  action: z
+    .literal('create_authentication_token')
+    .describe(
+      'Create a new runner and return its one-time authentication token (GitLab 16+ flow). ' +
+        'For GROUP_TYPE pass group_id; for PROJECT_TYPE pass project_id.',
+    ),
+  runner_type: z
+    .enum(['INSTANCE_TYPE', 'GROUP_TYPE', 'PROJECT_TYPE'])
+    .describe(
+      'Runner scope. INSTANCE_TYPE needs admin; GROUP_TYPE/PROJECT_TYPE need the namespace',
+    ),
+  group_id: groupPathField.optional(),
+  project_id: projectPathField.optional(),
+  ...runnerSettings,
+});
+
+// --- Action: update ---
+const UpdateRunnerSchema = z.object({
+  action: z.literal('update').describe("Update a runner's settings"),
+  runner_id: runnerIdField,
+  ...runnerSettings,
+});
+
+// --- Action: pause ---
+const PauseRunnerSchema = z.object({
+  action: z.literal('pause').describe('Pause a runner (stops it picking up new jobs)'),
+  runner_id: runnerIdField,
+});
+
+// --- Action: resume ---
+const ResumeRunnerSchema = z.object({
+  action: z.literal('resume').describe('Resume a paused runner'),
+  runner_id: runnerIdField,
+});
+
+// --- Action: delete ---
+const DeleteRunnerSchema = z.object({
+  action: z.literal('delete').describe('Delete a runner permanently'),
+  runner_id: runnerIdField,
+});
+
+// --- Action: reset_authentication_token ---
+const ResetTokenSchema = z.object({
+  action: z
+    .literal('reset_authentication_token')
+    .describe('Rotate the runner authentication token, returning the new value'),
+  runner_id: runnerIdField,
+});
+
+// --- Discriminated union combining all actions ---
+export const ManageRunnerSchema = z.discriminatedUnion('action', [
+  CreateRunnerSchema,
+  UpdateRunnerSchema,
+  PauseRunnerSchema,
+  ResumeRunnerSchema,
+  DeleteRunnerSchema,
+  ResetTokenSchema,
+]);
+
+// ============================================================================
+// Type exports
+// ============================================================================
+
+export type ManageRunnerInput = z.infer<typeof ManageRunnerSchema>;

--- a/src/graphql/runners.ts
+++ b/src/graphql/runners.ts
@@ -1,0 +1,315 @@
+import { gql } from 'graphql-tag';
+import { TypedDocumentNode } from '@graphql-typed-document-node/core';
+
+/**
+ * GraphQL documents for CI Runners.
+ *
+ * Verified against a live GitLab 19.x instance via schema introspection:
+ * - Queries: `runners` (admin, instance-wide), `currentUser.runners`,
+ *   `group/project(fullPath).runners`, `runner(id)` with a `jobs(statuses)` connection.
+ * - Mutations: `runnerCreate` (returns ephemeralAuthenticationToken), `runnerUpdate`
+ *   (description/tagList/paused/... — also powers pause/resume), `runnerDelete`.
+ *
+ * GitLab has no per-runner authentication-token reset mutation in GraphQL
+ * (only the legacy group/project registration-token reset), so that one action
+ * uses the REST endpoint in the handler.
+ */
+
+const RUNNER_FIELDS = `
+  id
+  description
+  runnerType
+  status
+  paused
+  locked
+  runUntagged
+  tagList
+  accessLevel
+  maximumTimeout
+  jobExecutionStatus
+  jobCount
+  contactedAt
+  createdAt
+`;
+
+export interface RunnerNode {
+  id: string;
+  description: string | null;
+  runnerType: string;
+  status: string | null;
+  paused: boolean;
+  locked: boolean;
+  runUntagged: boolean;
+  tagList: string[] | null;
+  accessLevel: string | null;
+  maximumTimeout: number | null;
+  jobExecutionStatus: string | null;
+  jobCount: number | null;
+  contactedAt: string | null;
+  createdAt: string | null;
+}
+
+interface PageInfo {
+  hasNextPage: boolean;
+  endCursor: string | null;
+}
+interface RunnerConnection {
+  nodes: RunnerNode[];
+  pageInfo: PageInfo;
+}
+
+// Shared list filters (subset of the runners connection args we expose).
+export interface RunnerListVars {
+  type?: string | null;
+  status?: string | null;
+  paused?: boolean | null;
+  tagList?: string[] | null;
+  search?: string | null;
+  first?: number | null;
+  after?: string | null;
+}
+
+const LIST_ARG_DECLS = `
+  $type: CiRunnerType
+  $status: CiRunnerStatus
+  $paused: Boolean
+  $tagList: [String!]
+  $search: String
+  $first: Int
+  $after: String
+`;
+const LIST_ARG_USE = `
+  type: $type
+  status: $status
+  paused: $paused
+  tagList: $tagList
+  search: $search
+  first: $first
+  after: $after
+`;
+
+// --- Query: instance-wide runners (admin) ---
+export interface ListRunnersResult {
+  runners: RunnerConnection | null;
+}
+export const LIST_RUNNERS: TypedDocumentNode<ListRunnersResult, RunnerListVars> = gql`
+  query ListRunners(${LIST_ARG_DECLS}) {
+    runners(${LIST_ARG_USE}) {
+      nodes { ${RUNNER_FIELDS} }
+      pageInfo { hasNextPage endCursor }
+    }
+  }
+`;
+
+// --- Query: current user's runners ---
+export interface ListOwnedRunnersResult {
+  currentUser: { runners: RunnerConnection | null } | null;
+}
+export const LIST_OWNED_RUNNERS: TypedDocumentNode<ListOwnedRunnersResult, RunnerListVars> = gql`
+  query ListOwnedRunners(${LIST_ARG_DECLS}) {
+    currentUser {
+      runners(${LIST_ARG_USE}) {
+        nodes { ${RUNNER_FIELDS} }
+        pageInfo { hasNextPage endCursor }
+      }
+    }
+  }
+`;
+
+// --- Query: group runners ---
+export interface ListGroupRunnersResult {
+  group: { runners: RunnerConnection | null } | null;
+}
+export interface ListNamespaceRunnersVars extends RunnerListVars {
+  fullPath: string;
+}
+export const LIST_GROUP_RUNNERS: TypedDocumentNode<
+  ListGroupRunnersResult,
+  ListNamespaceRunnersVars
+> = gql`
+  query ListGroupRunners($fullPath: ID!, ${LIST_ARG_DECLS}) {
+    group(fullPath: $fullPath) {
+      runners(${LIST_ARG_USE}) {
+        nodes { ${RUNNER_FIELDS} }
+        pageInfo { hasNextPage endCursor }
+      }
+    }
+  }
+`;
+
+// --- Query: project runners ---
+export interface ListProjectRunnersResult {
+  project: { runners: RunnerConnection | null } | null;
+}
+export const LIST_PROJECT_RUNNERS: TypedDocumentNode<
+  ListProjectRunnersResult,
+  ListNamespaceRunnersVars
+> = gql`
+  query ListProjectRunners($fullPath: ID!, ${LIST_ARG_DECLS}) {
+    project(fullPath: $fullPath) {
+      runners(${LIST_ARG_USE}) {
+        nodes { ${RUNNER_FIELDS} }
+        pageInfo { hasNextPage endCursor }
+      }
+    }
+  }
+`;
+
+// --- Query: a single runner ---
+export interface GetRunnerResult {
+  runner: RunnerNode | null;
+}
+export interface GetRunnerVars {
+  id: string;
+}
+export const GET_RUNNER: TypedDocumentNode<GetRunnerResult, GetRunnerVars> = gql`
+  query GetRunner($id: CiRunnerID!) {
+    runner(id: $id) { ${RUNNER_FIELDS} }
+  }
+`;
+
+// --- Query: jobs run by a runner ---
+export interface RunnerJobNode {
+  id: string;
+  name: string | null;
+  status: string | null;
+  createdAt: string | null;
+  finishedAt: string | null;
+  duration: number | null;
+  webPath: string | null;
+}
+export interface ListRunnerJobsResult {
+  runner: {
+    id: string;
+    jobs: { nodes: RunnerJobNode[]; pageInfo: PageInfo } | null;
+  } | null;
+}
+export interface ListRunnerJobsVars {
+  id: string;
+  statuses?: string | null;
+  first?: number | null;
+  after?: string | null;
+}
+export const LIST_RUNNER_JOBS: TypedDocumentNode<ListRunnerJobsResult, ListRunnerJobsVars> = gql`
+  query ListRunnerJobs($id: CiRunnerID!, $statuses: CiJobStatus, $first: Int, $after: String) {
+    runner(id: $id) {
+      id
+      jobs(statuses: $statuses, first: $first, after: $after) {
+        nodes {
+          id
+          name
+          status
+          createdAt
+          finishedAt
+          duration
+          webPath
+        }
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+      }
+    }
+  }
+`;
+
+// --- Lookups: resolve a group/project full path to its global ID ---
+// runnerCreate needs the namespace global ID, but callers pass the human path.
+export interface ResolveGroupResult {
+  group: { id: string } | null;
+}
+export interface ResolveProjectResult {
+  project: { id: string } | null;
+}
+export interface ResolvePathVars {
+  fullPath: string;
+}
+export const RESOLVE_GROUP_ID: TypedDocumentNode<ResolveGroupResult, ResolvePathVars> = gql`
+  query ResolveGroupId($fullPath: ID!) {
+    group(fullPath: $fullPath) {
+      id
+    }
+  }
+`;
+export const RESOLVE_PROJECT_ID: TypedDocumentNode<ResolveProjectResult, ResolvePathVars> = gql`
+  query ResolveProjectId($fullPath: ID!) {
+    project(fullPath: $fullPath) {
+      id
+    }
+  }
+`;
+
+// --- Mutation: create a runner (returns ephemeral auth token) ---
+export interface RunnerCreateResult {
+  runnerCreate: {
+    runner: (RunnerNode & { ephemeralAuthenticationToken: string | null }) | null;
+    errors: string[];
+  } | null;
+}
+export interface RunnerCreateVars {
+  input: {
+    runnerType: string;
+    groupId?: string | null;
+    projectId?: string | null;
+    description?: string | null;
+    paused?: boolean | null;
+    locked?: boolean | null;
+    runUntagged?: boolean | null;
+    tagList?: string[] | null;
+    accessLevel?: string | null;
+    maximumTimeout?: number | null;
+    maintenanceNote?: string | null;
+  };
+}
+export const RUNNER_CREATE: TypedDocumentNode<RunnerCreateResult, RunnerCreateVars> = gql`
+  mutation RunnerCreate($input: RunnerCreateInput!) {
+    runnerCreate(input: $input) {
+      runner {
+        ${RUNNER_FIELDS}
+        ephemeralAuthenticationToken
+      }
+      errors
+    }
+  }
+`;
+
+// --- Mutation: update a runner (also powers pause/resume via `paused`) ---
+export interface RunnerUpdateResult {
+  runnerUpdate: { runner: RunnerNode | null; errors: string[] } | null;
+}
+export interface RunnerUpdateVars {
+  input: {
+    id: string;
+    description?: string | null;
+    paused?: boolean | null;
+    locked?: boolean | null;
+    runUntagged?: boolean | null;
+    tagList?: string[] | null;
+    accessLevel?: string | null;
+    maximumTimeout?: number | null;
+    maintenanceNote?: string | null;
+  };
+}
+export const RUNNER_UPDATE: TypedDocumentNode<RunnerUpdateResult, RunnerUpdateVars> = gql`
+  mutation RunnerUpdate($input: RunnerUpdateInput!) {
+    runnerUpdate(input: $input) {
+      runner { ${RUNNER_FIELDS} }
+      errors
+    }
+  }
+`;
+
+// --- Mutation: delete a runner ---
+export interface RunnerDeleteResult {
+  runnerDelete: { errors: string[] } | null;
+}
+export interface RunnerDeleteVars {
+  input: { id: string };
+}
+export const RUNNER_DELETE: TypedDocumentNode<RunnerDeleteResult, RunnerDeleteVars> = gql`
+  mutation RunnerDelete($input: RunnerDeleteInput!) {
+    runnerDelete(input: $input) {
+      errors
+    }
+  }
+`;

--- a/src/registry-manager.ts
+++ b/src/registry-manager.ts
@@ -51,6 +51,7 @@ import {
   containerRegistryToolRegistry,
   getContainerRegistryReadOnlyToolNames,
 } from './entities/container_registry/registry';
+import { runnersToolRegistry, getRunnersReadOnlyToolNames } from './entities/runners/registry';
 import {
   accessTokensToolRegistry,
   getAccessTokensReadOnlyToolNames,
@@ -80,6 +81,7 @@ import {
   USE_ENVIRONMENTS,
   USE_REGISTRY,
   USE_ACCESS_TOKENS,
+  USE_RUNNERS,
   getToolDescriptionOverrides,
 } from './config';
 import { isToolAvailable, getRestrictedParameters } from './services/InstanceCapabilities';
@@ -232,6 +234,10 @@ class RegistryManager {
       this.registries.set('access_tokens', accessTokensToolRegistry);
     }
 
+    if (USE_RUNNERS) {
+      this.registries.set('runners', runnersToolRegistry);
+    }
+
     // All entity registries have been migrated to the new pattern!
   }
 
@@ -341,6 +347,10 @@ class RegistryManager {
 
     if (USE_ACCESS_TOKENS) {
       readOnlyTools.push(...getAccessTokensReadOnlyToolNames());
+    }
+
+    if (USE_RUNNERS) {
+      readOnlyTools.push(...getRunnersReadOnlyToolNames());
     }
 
     return readOnlyTools;
@@ -772,6 +782,7 @@ class RegistryManager {
     const useEnvironments = process.env.USE_ENVIRONMENTS !== 'false';
     const useRegistry = process.env.USE_REGISTRY !== 'false';
     const useAccessTokens = process.env.USE_ACCESS_TOKENS !== 'false';
+    const useRunners = process.env.USE_RUNNERS !== 'false';
 
     // Build registries map based on dynamic feature flags
     const registriesToUse = new Map<string, ToolRegistry>();
@@ -806,6 +817,7 @@ class RegistryManager {
     if (useEnvironments) registriesToUse.set('environments', environmentsToolRegistry);
     if (useRegistry) registriesToUse.set('registry', containerRegistryToolRegistry);
     if (useAccessTokens) registriesToUse.set('access_tokens', accessTokensToolRegistry);
+    if (useRunners) registriesToUse.set('runners', runnersToolRegistry);
 
     // Dynamically load description overrides
     const descOverrides = getToolDescriptionOverrides();
@@ -909,6 +921,7 @@ class RegistryManager {
       environmentsToolRegistry,
       containerRegistryToolRegistry,
       accessTokensToolRegistry,
+      runnersToolRegistry,
     ];
 
     for (const registry of allRegistries) {

--- a/src/services/TokenScopeDetector.ts
+++ b/src/services/TokenScopeDetector.ts
@@ -148,6 +148,10 @@ const TOOL_SCOPE_REQUIREMENTS: Record<string, GitLabScope[]> = {
   browse_access_tokens: ['api', 'read_api'],
   manage_access_token: ['api'],
 
+  // Runners
+  browse_runners: ['api', 'read_api'],
+  manage_runner: ['api', 'create_runner', 'manage_runner'],
+
   // Wiki
   browse_wiki: ['api', 'read_api'],
   manage_wiki: ['api'],

--- a/src/services/TokenScopeDetector.ts
+++ b/src/services/TokenScopeDetector.ts
@@ -149,6 +149,9 @@ const TOOL_SCOPE_REQUIREMENTS: Record<string, GitLabScope[]> = {
   manage_access_token: ['api'],
 
   // Runners
+  // ANY-match: create_runner and manage_runner are standalone GitLab scopes that
+  // enable runner registration / management on their own (no api required) - that
+  // is their whole reason to exist, so any one of these scopes surfaces the tool.
   browse_runners: ['api', 'read_api'],
   manage_runner: ['api', 'create_runner', 'manage_runner'],
 

--- a/tests/integration/schemas/runners.test.ts
+++ b/tests/integration/schemas/runners.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Runners Schema Integration Tests
+ *
+ * Backed by the GitLab GraphQL runner API. The test instance may or may not have
+ * runners registered and the token may or may not be an admin, so the lifecycle is
+ * environment-adaptive: it always exercises list_owned end-to-end, tries list_all
+ * (admin-only) tolerantly, and only drills into a single runner / its jobs when one
+ * actually exists. No runners are created, mutated, or deleted against real data.
+ */
+
+import { BrowseRunnersSchema } from '../../../src/entities/runners/schema-readonly';
+import { ManageRunnerSchema } from '../../../src/entities/runners/schema';
+import { IntegrationTestHelper } from '../helpers/registry-helper';
+
+interface RunnerConnection {
+  nodes: { id: number; description: string | null }[];
+  pageInfo: { hasNextPage: boolean };
+}
+
+describe('Runners Schema - GitLab Integration', () => {
+  let helper: IntegrationTestHelper;
+
+  beforeAll(async () => {
+    if (!process.env.GITLAB_TOKEN) {
+      throw new Error('GITLAB_TOKEN environment variable is required');
+    }
+    helper = new IntegrationTestHelper();
+    await helper.initialize();
+  });
+
+  describe('schema validation', () => {
+    it('validates browse_runners actions', () => {
+      for (const params of [
+        { action: 'list_all', status: 'ONLINE', first: 10 },
+        { action: 'list_owned', type: 'INSTANCE_TYPE' },
+        { action: 'list_project', project_id: 'g/p', paused: false },
+        { action: 'list_group', group_id: 'g', tag_list: ['linux'] },
+        { action: 'get', runner_id: 1 },
+        { action: 'list_jobs', runner_id: 1, statuses: 'FAILED' },
+      ]) {
+        expect(BrowseRunnersSchema.safeParse(params).success).toBe(true);
+      }
+    });
+
+    it('validates manage_runner actions', () => {
+      for (const params of [
+        {
+          action: 'create_authentication_token',
+          runner_type: 'INSTANCE_TYPE',
+          description: 'ci-box',
+          tag_list: ['linux'],
+        },
+        { action: 'create_authentication_token', runner_type: 'GROUP_TYPE', group_id: 'g' },
+        { action: 'update', runner_id: 1, run_untagged: false, maximum_timeout: 600 },
+        { action: 'pause', runner_id: 1 },
+        { action: 'resume', runner_id: 1 },
+        { action: 'delete', runner_id: 1 },
+        { action: 'reset_authentication_token', runner_id: 1 },
+      ]) {
+        expect(ManageRunnerSchema.safeParse(params).success).toBe(true);
+      }
+    });
+
+    it('rejects an invalid access_level', () => {
+      const result = ManageRunnerSchema.safeParse({
+        action: 'update',
+        runner_id: 1,
+        access_level: 'PUBLIC',
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects a non-positive runner_id', () => {
+      const result = BrowseRunnersSchema.safeParse({ action: 'get', runner_id: 0 });
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('list_owned (end-to-end)', () => {
+    it('returns a runner connection for the current user', async () => {
+      const result = (await helper.executeTool('browse_runners', {
+        action: 'list_owned',
+        first: 5,
+      })) as RunnerConnection;
+
+      expect(Array.isArray(result.nodes)).toBe(true);
+      expect(result.pageInfo).toBeDefined();
+      console.log(`  current user can see ${result.nodes.length} runners`);
+    }, 15000);
+
+    it('drills into a runner and its jobs when one exists', async () => {
+      const list = (await helper.executeTool('browse_runners', {
+        action: 'list_owned',
+        first: 1,
+      })) as RunnerConnection;
+
+      if (list.nodes.length === 0) {
+        console.log('  No runners registered; skipping runner/jobs drill-down');
+        return;
+      }
+
+      const runnerId = list.nodes[0].id;
+      const runner = (await helper.executeTool('browse_runners', {
+        action: 'get',
+        runner_id: runnerId,
+      })) as { id: number };
+      expect(runner.id).toBe(runnerId);
+
+      const jobs = (await helper.executeTool('browse_runners', {
+        action: 'list_jobs',
+        runner_id: runnerId,
+        first: 5,
+      })) as { nodes: unknown[] };
+      expect(Array.isArray(jobs.nodes)).toBe(true);
+      console.log(`  runner ${runnerId} has ${jobs.nodes.length} recent jobs`);
+    }, 20000);
+  });
+
+  describe('list_all (admin, tolerant)', () => {
+    it('returns a connection or reports lack of admin access', async () => {
+      try {
+        const result = (await helper.executeTool('browse_runners', {
+          action: 'list_all',
+          first: 5,
+        })) as RunnerConnection;
+        expect(Array.isArray(result.nodes)).toBe(true);
+        console.log(`  instance-wide list returned ${result.nodes.length} runners`);
+      } catch (error) {
+        // Non-admin tokens cannot list every runner; that is an expected outcome.
+        console.log(`  list_all not available for this token: ${(error as Error).message}`);
+      }
+    }, 15000);
+  });
+});

--- a/tests/unit/entities/runners/registry.test.ts
+++ b/tests/unit/entities/runners/registry.test.ts
@@ -1,0 +1,272 @@
+import {
+  runnersToolRegistry,
+  getRunnersReadOnlyToolNames,
+} from '../../../../src/entities/runners/registry';
+import {
+  LIST_RUNNERS,
+  LIST_OWNED_RUNNERS,
+  LIST_GROUP_RUNNERS,
+  LIST_PROJECT_RUNNERS,
+  GET_RUNNER,
+  LIST_RUNNER_JOBS,
+  RESOLVE_GROUP_ID,
+  RESOLVE_PROJECT_ID,
+  RUNNER_CREATE,
+  RUNNER_UPDATE,
+  RUNNER_DELETE,
+} from '../../../../src/graphql/runners';
+
+const mockClient = { request: jest.fn() };
+const mockGitlab = { post: jest.fn() };
+
+jest.mock('../../../../src/services/ConnectionManager', () => ({
+  ConnectionManager: {
+    getInstance: jest.fn(() => ({ getClient: jest.fn(() => mockClient) })),
+  },
+}));
+jest.mock('../../../../src/utils/gitlab-api', () => ({
+  gitlab: { post: (...args: unknown[]) => mockGitlab.post(...args) },
+}));
+
+const browse = () => runnersToolRegistry.get('browse_runners')!;
+const manage = () => runnersToolRegistry.get('manage_runner')!;
+const RUNNER_GID = 'gid://gitlab/Ci::Runner/7';
+
+beforeEach(() => {
+  mockClient.request.mockReset();
+  mockGitlab.post.mockReset();
+});
+
+describe('runners registry', () => {
+  it('registers the CQRS pair with browse_runners read-only', () => {
+    expect(runnersToolRegistry.has('browse_runners')).toBe(true);
+    expect(runnersToolRegistry.has('manage_runner')).toBe(true);
+    expect(getRunnersReadOnlyToolNames()).toEqual(['browse_runners']);
+    expect(browse().gate).toEqual({ envVar: 'USE_RUNNERS', defaultValue: true });
+    expect(manage().gate).toEqual({ envVar: 'USE_RUNNERS', defaultValue: true });
+  });
+
+  describe('browse_runners', () => {
+    it('list_all queries the instance-wide runners with filters', async () => {
+      mockClient.request.mockResolvedValueOnce({ runners: { nodes: [], pageInfo: {} } });
+      await browse().handler({ action: 'list_all', status: 'ONLINE', type: 'INSTANCE_TYPE' });
+      const [doc, vars] = mockClient.request.mock.calls[0];
+      expect(doc).toBe(LIST_RUNNERS);
+      expect(vars).toMatchObject({ status: 'ONLINE', type: 'INSTANCE_TYPE', first: 20 });
+    });
+
+    it('list_owned queries the current user runners', async () => {
+      mockClient.request.mockResolvedValueOnce({ currentUser: { runners: { nodes: [] } } });
+      await browse().handler({ action: 'list_owned' });
+      expect(mockClient.request.mock.calls[0][0]).toBe(LIST_OWNED_RUNNERS);
+    });
+
+    it('list_owned tolerates a null currentUser', async () => {
+      mockClient.request.mockResolvedValueOnce({ currentUser: null });
+      const res = (await browse().handler({ action: 'list_owned' })) as { nodes: unknown[] };
+      expect(res.nodes).toEqual([]);
+    });
+
+    it('list_project queries by full path', async () => {
+      mockClient.request.mockResolvedValueOnce({ project: { runners: { nodes: [] } } });
+      await browse().handler({ action: 'list_project', project_id: 'g/p' });
+      const [doc, vars] = mockClient.request.mock.calls[0];
+      expect(doc).toBe(LIST_PROJECT_RUNNERS);
+      expect(vars).toMatchObject({ fullPath: 'g/p' });
+    });
+
+    it('list_project throws when the project is missing', async () => {
+      mockClient.request.mockResolvedValueOnce({ project: null });
+      await expect(
+        browse().handler({ action: 'list_project', project_id: 'missing' }),
+      ).rejects.toThrow('not found or not accessible');
+    });
+
+    it('list_group queries by full path', async () => {
+      mockClient.request.mockResolvedValueOnce({ group: { runners: { nodes: [] } } });
+      await browse().handler({ action: 'list_group', group_id: 'g' });
+      expect(mockClient.request.mock.calls[0][0]).toBe(LIST_GROUP_RUNNERS);
+    });
+
+    it('list_group throws when the group is missing', async () => {
+      mockClient.request.mockResolvedValueOnce({ group: null });
+      await expect(browse().handler({ action: 'list_group', group_id: 'missing' })).rejects.toThrow(
+        'not found or not accessible',
+      );
+    });
+
+    it('get expands the numeric id to a global ID', async () => {
+      mockClient.request.mockResolvedValueOnce({ runner: { id: RUNNER_GID } });
+      await browse().handler({ action: 'get', runner_id: 7 });
+      const [doc, vars] = mockClient.request.mock.calls[0];
+      expect(doc).toBe(GET_RUNNER);
+      expect(vars).toEqual({ id: RUNNER_GID });
+    });
+
+    it('get throws when the runner is missing', async () => {
+      mockClient.request.mockResolvedValueOnce({ runner: null });
+      await expect(browse().handler({ action: 'get', runner_id: 7 })).rejects.toThrow(
+        'Runner 7 not found',
+      );
+    });
+
+    it('list_jobs queries the runner jobs connection', async () => {
+      mockClient.request.mockResolvedValueOnce({ runner: { id: RUNNER_GID, jobs: { nodes: [] } } });
+      await browse().handler({ action: 'list_jobs', runner_id: 7, statuses: 'FAILED' });
+      const [doc, vars] = mockClient.request.mock.calls[0];
+      expect(doc).toBe(LIST_RUNNER_JOBS);
+      expect(vars).toMatchObject({ id: RUNNER_GID, statuses: 'FAILED' });
+    });
+
+    it('list_jobs throws when the runner is missing', async () => {
+      mockClient.request.mockResolvedValueOnce({ runner: null });
+      await expect(browse().handler({ action: 'list_jobs', runner_id: 7 })).rejects.toThrow(
+        'Runner 7 not found',
+      );
+    });
+  });
+
+  describe('manage_runner', () => {
+    it('create INSTANCE_TYPE runs runnerCreate without a namespace', async () => {
+      mockClient.request.mockResolvedValueOnce({
+        runnerCreate: {
+          runner: { id: RUNNER_GID, ephemeralAuthenticationToken: 'glrt-x' },
+          errors: [],
+        },
+      });
+
+      await manage().handler({
+        action: 'create_authentication_token',
+        runner_type: 'INSTANCE_TYPE',
+        description: 'ci-box',
+        tag_list: ['linux'],
+      });
+
+      const [doc, vars] = mockClient.request.mock.calls[0];
+      expect(doc).toBe(RUNNER_CREATE);
+      expect(vars).toEqual({
+        input: { runnerType: 'INSTANCE_TYPE', description: 'ci-box', tagList: ['linux'] },
+      });
+    });
+
+    it('create GROUP_TYPE resolves the group path to a global ID', async () => {
+      mockClient.request
+        .mockResolvedValueOnce({ group: { id: 'gid://gitlab/Group/3' } })
+        .mockResolvedValueOnce({ runnerCreate: { runner: { id: RUNNER_GID }, errors: [] } });
+
+      await manage().handler({
+        action: 'create_authentication_token',
+        runner_type: 'GROUP_TYPE',
+        group_id: 'my-group',
+      });
+
+      expect(mockClient.request.mock.calls[0][0]).toBe(RESOLVE_GROUP_ID);
+      expect(mockClient.request.mock.calls[1][0]).toBe(RUNNER_CREATE);
+      expect(mockClient.request.mock.calls[1][1]).toEqual({
+        input: { runnerType: 'GROUP_TYPE', groupId: 'gid://gitlab/Group/3' },
+      });
+    });
+
+    it('create PROJECT_TYPE resolves the project path to a global ID', async () => {
+      mockClient.request
+        .mockResolvedValueOnce({ project: { id: 'gid://gitlab/Project/9' } })
+        .mockResolvedValueOnce({ runnerCreate: { runner: { id: RUNNER_GID }, errors: [] } });
+
+      await manage().handler({
+        action: 'create_authentication_token',
+        runner_type: 'PROJECT_TYPE',
+        project_id: 'g/p',
+      });
+
+      expect(mockClient.request.mock.calls[0][0]).toBe(RESOLVE_PROJECT_ID);
+      expect(mockClient.request.mock.calls[1][1]).toEqual({
+        input: { runnerType: 'PROJECT_TYPE', projectId: 'gid://gitlab/Project/9' },
+      });
+    });
+
+    it('create GROUP_TYPE requires group_id', async () => {
+      await expect(
+        manage().handler({ action: 'create_authentication_token', runner_type: 'GROUP_TYPE' }),
+      ).rejects.toThrow('group_id is required');
+    });
+
+    it('create PROJECT_TYPE requires project_id', async () => {
+      await expect(
+        manage().handler({ action: 'create_authentication_token', runner_type: 'PROJECT_TYPE' }),
+      ).rejects.toThrow('project_id is required');
+    });
+
+    it('create surfaces GraphQL payload errors', async () => {
+      mockClient.request.mockResolvedValueOnce({
+        runnerCreate: { runner: null, errors: ['not allowed'] },
+      });
+      await expect(
+        manage().handler({ action: 'create_authentication_token', runner_type: 'INSTANCE_TYPE' }),
+      ).rejects.toThrow('GitLab API error: not allowed');
+    });
+
+    it('update maps settings to the runnerUpdate input', async () => {
+      mockClient.request.mockResolvedValueOnce({
+        runnerUpdate: { runner: { id: RUNNER_GID }, errors: [] },
+      });
+      await manage().handler({
+        action: 'update',
+        runner_id: 7,
+        description: 'new',
+        run_untagged: false,
+        maximum_timeout: 600,
+      });
+      const [doc, vars] = mockClient.request.mock.calls[0];
+      expect(doc).toBe(RUNNER_UPDATE);
+      expect(vars).toEqual({
+        input: { id: RUNNER_GID, description: 'new', runUntagged: false, maximumTimeout: 600 },
+      });
+    });
+
+    it('pause sets paused=true via runnerUpdate', async () => {
+      mockClient.request.mockResolvedValueOnce({ runnerUpdate: { runner: {}, errors: [] } });
+      await manage().handler({ action: 'pause', runner_id: 7 });
+      expect(mockClient.request.mock.calls[0][1]).toEqual({
+        input: { id: RUNNER_GID, paused: true },
+      });
+    });
+
+    it('resume sets paused=false via runnerUpdate', async () => {
+      mockClient.request.mockResolvedValueOnce({ runnerUpdate: { runner: {}, errors: [] } });
+      await manage().handler({ action: 'resume', runner_id: 7 });
+      expect(mockClient.request.mock.calls[0][1]).toEqual({
+        input: { id: RUNNER_GID, paused: false },
+      });
+    });
+
+    it('delete runs runnerDelete and returns a confirmation', async () => {
+      mockClient.request.mockResolvedValueOnce({ runnerDelete: { errors: [] } });
+      const res = (await manage().handler({ action: 'delete', runner_id: 7 })) as {
+        deleted: boolean;
+        runner_id: number;
+      };
+      expect(mockClient.request.mock.calls[0][0]).toBe(RUNNER_DELETE);
+      expect(res).toEqual({ deleted: true, runner_id: 7 });
+    });
+
+    it('delete surfaces GraphQL payload errors', async () => {
+      mockClient.request.mockResolvedValueOnce({ runnerDelete: { errors: ['in use'] } });
+      await expect(manage().handler({ action: 'delete', runner_id: 7 })).rejects.toThrow(
+        'GitLab API error: in use',
+      );
+    });
+
+    it('reset_authentication_token uses the REST endpoint', async () => {
+      mockGitlab.post.mockResolvedValueOnce({ token: 'glrt-new', token_expires_at: null });
+      const res = (await manage().handler({
+        action: 'reset_authentication_token',
+        runner_id: 7,
+      })) as { token: string };
+      expect(mockGitlab.post).toHaveBeenCalledWith('runners/7/reset_authentication_token', {
+        contentType: 'json',
+      });
+      expect(res.token).toBe('glrt-new');
+      expect(mockClient.request).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds the `browse_runners` / `manage_runner` CQRS pair backed by the GitLab GraphQL runner API, so agents can inspect, register, and decommission CI runners.

- **browse_runners** (Query): `list_all` (instance-wide, admin), `list_owned` (current user), `list_project`, `list_group`, `get`, `list_jobs`
- **manage_runner** (Command): `create_authentication_token` (GitLab 16+ registration flow, returns a one-time token), `update`, `pause`/`resume`, `delete`, `reset_authentication_token`

## Implementation notes

- GraphQL-first per repo convention: queries hit `runners`, `currentUser.runners`, `group/project(fullPath).runners`, `runner(id).jobs`; mutations use `runnerCreate` / `runnerUpdate` / `runnerDelete`.
- `pause` / `resume` map onto `runnerUpdate(paused:)` rather than separate mutations.
- GitLab exposes no per-runner authentication-token reset mutation in GraphQL (only the legacy group/project registration-token reset), so `reset_authentication_token` uses the REST endpoint. This is documented at the call site.
- `create_authentication_token` resolves a group/project full path to its global ID before `runnerCreate`, so callers pass human paths.
- Gated behind `USE_RUNNERS`; token-scope requirements (`create_runner` / `manage_runner`) wired into `TokenScopeDetector`.

## Testing

- Unit: 24 tests covering every browse + manage action, namespace resolution, missing-id and GraphQL-payload-error branches, and the REST reset path (GraphQL client + REST mocked).
- Integration: schema validation + env-adaptive end-to-end (`list_owned` always, `list_all` tolerant of non-admin tokens, runner/jobs drill-down only when a runner exists). No runners are created or mutated against real data.
- Full suite green: 5080 unit tests, 449 integration tests, clean build and lint.

Closes #442

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added GitLab CI runners browsing and management: list by instance/group/project/owned, view runner jobs, create/update/pause/resume/delete runners, and manage authentication tokens and settings (opt-in).
* **Filters**
  * Filter runners by type, status, paused, tags, and search criteria.
* **Chores**
  * Updated tool availability based on token scopes.
* **Tests**
  * Added integration and unit tests covering runner queries and management flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->