### PR TITLE
feat(access-tokens): expose personal/project/group token management

### DIFF
--- a/src/entities/access_tokens/registry.ts
+++ b/src/entities/access_tokens/registry.ts
@@ -1,0 +1,164 @@
+import * as z from 'zod';
+import { BrowseAccessTokensSchema } from './schema-readonly';
+import { ManageAccessTokenSchema } from './schema';
+import { gitlab, toQuery } from '../../utils/gitlab-api';
+import { ToolRegistry, EnhancedToolDefinition } from '../../types';
+import { assertActionAllowed } from '../utils';
+
+// Personal/project/group access tokens are Free tier. Project access tokens
+// landed in 13.0, group access tokens in 14.7; the tool degrades per-action
+// rather than gating the whole pair, so the lowest floor is declared here.
+const FREE_REQ = { tier: 'free', minVersion: '13.0' } as const;
+
+const NEW_TOKEN_NOTICE =
+  'This response contains a token value shown only once. Store it securely; it cannot be retrieved again.';
+
+/**
+ * Wrap a create/rotate response so the secret it carries is explicitly flagged.
+ * The result is serialized to the tool output, so the marker travels with it.
+ */
+function flagSensitive(response: unknown): unknown {
+  if (response && typeof response === 'object') {
+    return {
+      ...(response as Record<string, unknown>),
+      _meta: { sensitive: true, notice: NEW_TOKEN_NOTICE },
+    };
+  }
+  return response;
+}
+
+/**
+ * Resolve the REST collection path for a single-token action (get/rotate/revoke).
+ * A token belongs to exactly one scope: project, group, or the current user.
+ */
+function tokenBasePath(input: { project_id?: string; group_id?: string }): string {
+  if (input.project_id) {
+    return `projects/${encodeURIComponent(input.project_id)}/access_tokens`;
+  }
+  if (input.group_id) {
+    return `groups/${encodeURIComponent(input.group_id)}/access_tokens`;
+  }
+  return 'personal_access_tokens';
+}
+
+/**
+ * Access-tokens tools registry - 2 CQRS tools.
+ *
+ * browse_access_tokens (Query): list_personal, list_project, list_group, get
+ * manage_access_token (Command): create_project, create_group, rotate, revoke
+ *
+ * Backed by the GitLab REST access-token endpoints (no GraphQL surface exists).
+ * The personal/project/group scopes fold in as actions; get/rotate/revoke infer
+ * the scope from project_id / group_id. Gated behind USE_ACCESS_TOKENS. Free tier;
+ * project/group creation requires owner/admin on the namespace.
+ */
+export const accessTokensToolRegistry: ToolRegistry = new Map<string, EnhancedToolDefinition>([
+  // ============================================================================
+  // browse_access_tokens - CQRS Query Tool
+  // ============================================================================
+  [
+    'browse_access_tokens',
+    {
+      name: 'browse_access_tokens',
+      description:
+        "Inspect access tokens (CI/automation credentials). Actions: list_personal (the current user's PATs; admins may filter by user_id), list_project / list_group (a project's or group's tokens), get (a single token by ID - pass project_id or group_id for project/group tokens, neither for personal). Related: manage_access_token to create, rotate, or revoke.",
+      inputSchema: z.toJSONSchema(BrowseAccessTokensSchema),
+      requirements: { default: FREE_REQ },
+      gate: { envVar: 'USE_ACCESS_TOKENS', defaultValue: true },
+      handler: async (args: unknown): Promise<unknown> => {
+        const input = BrowseAccessTokensSchema.parse(args);
+        assertActionAllowed('browse_access_tokens', input.action);
+
+        switch (input.action) {
+          case 'list_personal': {
+            const { action: _action, ...query } = input;
+            return gitlab.get('personal_access_tokens', { query: toQuery(query, []) });
+          }
+
+          case 'list_project': {
+            const { action: _action, project_id, ...query } = input;
+            return gitlab.get(`projects/${encodeURIComponent(project_id)}/access_tokens`, {
+              query: toQuery(query, []),
+            });
+          }
+
+          case 'list_group': {
+            const { action: _action, group_id, ...query } = input;
+            return gitlab.get(`groups/${encodeURIComponent(group_id)}/access_tokens`, {
+              query: toQuery(query, []),
+            });
+          }
+
+          case 'get':
+            return gitlab.get(`${tokenBasePath(input)}/${input.token_id}`);
+
+          /* istanbul ignore next -- unreachable with Zod discriminatedUnion */
+          default:
+            throw new Error(`Unknown action: ${(input as { action: string }).action}`);
+        }
+      },
+    },
+  ],
+
+  // ============================================================================
+  // manage_access_token - CQRS Command Tool
+  // ============================================================================
+  [
+    'manage_access_token',
+    {
+      name: 'manage_access_token',
+      description:
+        'Create, rotate, or revoke access tokens. Actions: create_project / create_group (issue a new token with name + scopes, returns the value once), rotate (revoke the old token and return a new value), revoke (delete a token permanently). For rotate/revoke pass project_id or group_id for project/group tokens, neither for personal. Related: browse_access_tokens to discover token IDs.',
+      inputSchema: z.toJSONSchema(ManageAccessTokenSchema),
+      requirements: { default: FREE_REQ },
+      gate: { envVar: 'USE_ACCESS_TOKENS', defaultValue: true },
+      handler: async (args: unknown): Promise<unknown> => {
+        const input = ManageAccessTokenSchema.parse(args);
+        assertActionAllowed('manage_access_token', input.action);
+
+        switch (input.action) {
+          case 'create_project': {
+            const { action: _action, project_id, ...body } = input;
+            const res = await gitlab.post(
+              `projects/${encodeURIComponent(project_id)}/access_tokens`,
+              { body, contentType: 'json' },
+            );
+            return flagSensitive(res);
+          }
+
+          case 'create_group': {
+            const { action: _action, group_id, ...body } = input;
+            const res = await gitlab.post(`groups/${encodeURIComponent(group_id)}/access_tokens`, {
+              body,
+              contentType: 'json',
+            });
+            return flagSensitive(res);
+          }
+
+          case 'rotate': {
+            const body = input.expires_at ? { expires_at: input.expires_at } : {};
+            const res = await gitlab.post(`${tokenBasePath(input)}/${input.token_id}/rotate`, {
+              body,
+              contentType: 'json',
+            });
+            return flagSensitive(res);
+          }
+
+          case 'revoke': {
+            await gitlab.delete(`${tokenBasePath(input)}/${input.token_id}`);
+            return { revoked: true, token_id: input.token_id };
+          }
+
+          /* istanbul ignore next -- unreachable with Zod discriminatedUnion */
+          default:
+            throw new Error(`Unknown action: ${(input as { action: string }).action}`);
+        }
+      },
+    },
+  ],
+]);
+
+/** Read-only tool names from the registry (for read-only mode filtering). */
+export function getAccessTokensReadOnlyToolNames(): string[] {
+  return ['browse_access_tokens'];
+}

--- a/src/entities/access_tokens/schema-readonly.ts
+++ b/src/entities/access_tokens/schema-readonly.ts
@@ -1,0 +1,88 @@
+import { z } from 'zod';
+import { requiredId, paginationFields, flexibleBoolean } from '../utils';
+
+// ============================================================================
+// browse_access_tokens - CQRS Query Tool (discriminated union schema)
+// Actions: list_personal, list_project, list_group, get
+//
+// Access tokens (personal / project / group) are CI and automation credentials.
+// GitLab exposes them only through REST (no GraphQL surface), so all actions map
+// to the /personal_access_tokens, /projects/:id/access_tokens and
+// /groups/:id/access_tokens endpoints. The three scopes fold in as actions, not
+// separate tools. Gated behind USE_ACCESS_TOKENS. Free tier.
+// ============================================================================
+
+export const projectIdField = requiredId.describe(
+  "Project ID or URL-encoded path (e.g. 'group/project' or '123').",
+);
+export const groupIdField = requiredId.describe(
+  "Group ID or URL-encoded path (e.g. 'my-group' or '42').",
+);
+export const tokenIdField = z.coerce
+  .number()
+  .int()
+  .positive()
+  .describe('Numeric access-token ID (from a list action).');
+
+const stateFilter = z.enum(['active', 'inactive']).optional().describe('Filter by token state.');
+
+// --- Action: list_personal (the current user's PATs; admin can pass user_id) ---
+const ListPersonalSchema = z.object({
+  action: z
+    .literal('list_personal')
+    .describe('List personal access tokens for the current user (admins may filter by user_id)'),
+  user_id: z.coerce
+    .number()
+    .int()
+    .positive()
+    .optional()
+    .describe('Admin only: list PATs belonging to this user ID.'),
+  revoked: flexibleBoolean.optional().describe('Filter by revoked state.'),
+  state: stateFilter,
+  search: z.string().optional().describe('Filter by token name substring.'),
+  ...paginationFields(),
+});
+
+// --- Action: list_project ---
+const ListProjectSchema = z.object({
+  action: z.literal('list_project').describe('List a project access tokens'),
+  project_id: projectIdField,
+  state: stateFilter,
+  ...paginationFields(),
+});
+
+// --- Action: list_group ---
+const ListGroupSchema = z.object({
+  action: z.literal('list_group').describe('List a group access tokens'),
+  group_id: groupIdField,
+  state: stateFilter,
+  ...paginationFields(),
+});
+
+// --- Action: get (single token; scope inferred from project_id/group_id) ---
+const GetTokenSchema = z.object({
+  action: z
+    .literal('get')
+    .describe(
+      'Get a single access token by ID. Pass project_id for a project token, group_id for a group token, or neither for a personal token.',
+    ),
+  token_id: tokenIdField,
+  project_id: requiredId.optional().describe('Set for a project access token.'),
+  group_id: requiredId.optional().describe('Set for a group access token.'),
+});
+
+// --- Discriminated union combining all actions ---
+export const BrowseAccessTokensSchema = z
+  .discriminatedUnion('action', [
+    ListPersonalSchema,
+    ListProjectSchema,
+    ListGroupSchema,
+    GetTokenSchema,
+  ])
+  // A token is owned by exactly one scope; project_id and group_id are mutually exclusive.
+  .refine((data) => data.action !== 'get' || !(data.project_id && data.group_id), {
+    message: 'Pass at most one of project_id or group_id (a token belongs to a single scope)',
+    path: ['project_id'],
+  });
+
+export type BrowseAccessTokensInput = z.infer<typeof BrowseAccessTokensSchema>;

--- a/src/entities/access_tokens/schema.ts
+++ b/src/entities/access_tokens/schema.ts
@@ -1,0 +1,106 @@
+import { z } from 'zod';
+import { requiredId } from '../utils';
+import { projectIdField, groupIdField, tokenIdField } from './schema-readonly';
+
+// ============================================================================
+// manage_access_token - CQRS Command Tool (discriminated union schema)
+// Actions: create_project, create_group, rotate, revoke
+//
+// Creates, rotates, and revokes project / group / personal access tokens via the
+// GitLab REST endpoints (no GraphQL surface exists). create_* and rotate return a
+// token value exactly once; the handler flags those responses as sensitive.
+// Personal-token creation is intentionally absent: GitLab only allows it for
+// admins against a specific user, which is out of scope for this tool. Gated
+// behind USE_ACCESS_TOKENS. Free tier; project/group create needs owner/admin.
+// ============================================================================
+
+// Access-token scopes are a free-form, version-dependent set (api, read_api,
+// read_repository, write_repository, read_registry, write_registry, ...). Kept
+// as strings rather than an enum so new GitLab scopes work without a code change.
+const scopesField = z
+  .array(z.string())
+  .min(1)
+  .describe(
+    "Token scopes, e.g. ['api'], ['read_repository','write_repository']. At least one required.",
+  );
+
+// GitLab member access levels: 10 Guest, 20 Reporter, 30 Developer, 40 Maintainer, 50 Owner.
+const accessLevelField = z
+  .union([z.literal(10), z.literal(20), z.literal(30), z.literal(40), z.literal(50)])
+  .optional()
+  .describe('Access level: 10 Guest, 20 Reporter, 30 Developer, 40 Maintainer, 50 Owner.');
+
+const expiresAtField = z
+  .string()
+  .optional()
+  .describe('Expiry date in YYYY-MM-DD format (e.g. "2026-12-31").');
+
+// --- Action: create_project ---
+const CreateProjectTokenSchema = z.object({
+  action: z
+    .literal('create_project')
+    .describe('Create a project access token (returns the value once)'),
+  project_id: projectIdField,
+  name: z.string().describe('Human-readable token name.'),
+  scopes: scopesField,
+  access_level: accessLevelField,
+  expires_at: expiresAtField,
+});
+
+// --- Action: create_group ---
+const CreateGroupTokenSchema = z.object({
+  action: z
+    .literal('create_group')
+    .describe('Create a group access token (returns the value once)'),
+  group_id: groupIdField,
+  name: z.string().describe('Human-readable token name.'),
+  scopes: scopesField,
+  access_level: accessLevelField,
+  expires_at: expiresAtField,
+});
+
+// --- Action: rotate (scope inferred from project_id/group_id) ---
+const RotateTokenSchema = z.object({
+  action: z
+    .literal('rotate')
+    .describe(
+      'Rotate a token: revoke the old one and return a new value. Pass project_id for a project token, group_id for a group token, or neither for a personal token.',
+    ),
+  token_id: tokenIdField,
+  project_id: requiredId.optional().describe('Set for a project access token.'),
+  group_id: requiredId.optional().describe('Set for a group access token.'),
+  expires_at: expiresAtField,
+});
+
+// --- Action: revoke (scope inferred from project_id/group_id) ---
+const RevokeTokenSchema = z.object({
+  action: z
+    .literal('revoke')
+    .describe(
+      'Revoke a token permanently. Pass project_id for a project token, group_id for a group token, or neither for a personal token.',
+    ),
+  token_id: tokenIdField,
+  project_id: requiredId.optional().describe('Set for a project access token.'),
+  group_id: requiredId.optional().describe('Set for a group access token.'),
+});
+
+// --- Discriminated union combining all actions ---
+export const ManageAccessTokenSchema = z
+  .discriminatedUnion('action', [
+    CreateProjectTokenSchema,
+    CreateGroupTokenSchema,
+    RotateTokenSchema,
+    RevokeTokenSchema,
+  ])
+  // A token belongs to a single scope; project_id and group_id are mutually exclusive
+  // on the scope-inferring actions.
+  .refine(
+    (data) =>
+      (data.action !== 'rotate' && data.action !== 'revoke') || !(data.project_id && data.group_id),
+    {
+      message: 'Pass at most one of project_id or group_id (a token belongs to a single scope)',
+      path: ['project_id'],
+    },
+  );
+
+export type ManageAccessTokenInput = z.infer<typeof ManageAccessTokenSchema>;

--- a/src/entities/access_tokens/schema.ts
+++ b/src/entities/access_tokens/schema.ts
@@ -18,7 +18,7 @@ import { projectIdField, groupIdField, tokenIdField } from './schema-readonly';
 // read_repository, write_repository, read_registry, write_registry, ...). Kept
 // as strings rather than an enum so new GitLab scopes work without a code change.
 const scopesField = z
-  .array(z.string())
+  .array(z.string().trim().min(1, 'scope entries must be non-empty'))
   .min(1)
   .describe(
     "Token scopes, e.g. ['api'], ['read_repository','write_repository']. At least one required.",
@@ -32,6 +32,7 @@ const accessLevelField = z
 
 const expiresAtField = z
   .string()
+  .regex(/^\d{4}-\d{2}-\d{2}$/, 'expires_at must be a YYYY-MM-DD date')
   .optional()
   .describe('Expiry date in YYYY-MM-DD format (e.g. "2026-12-31").');
 

--- a/src/registry-manager.ts
+++ b/src/registry-manager.ts
@@ -52,6 +52,10 @@ import {
   getContainerRegistryReadOnlyToolNames,
 } from './entities/container_registry/registry';
 import {
+  accessTokensToolRegistry,
+  getAccessTokensReadOnlyToolNames,
+} from './entities/access_tokens/registry';
+import {
   GITLAB_BASE_URL,
   GITLAB_READ_ONLY_MODE,
   GITLAB_DENIED_TOOLS_REGEX,
@@ -75,6 +79,7 @@ import {
   USE_CI_TOKENS,
   USE_ENVIRONMENTS,
   USE_REGISTRY,
+  USE_ACCESS_TOKENS,
   getToolDescriptionOverrides,
 } from './config';
 import { isToolAvailable, getRestrictedParameters } from './services/InstanceCapabilities';
@@ -223,6 +228,10 @@ class RegistryManager {
       this.registries.set('registry', containerRegistryToolRegistry);
     }
 
+    if (USE_ACCESS_TOKENS) {
+      this.registries.set('access_tokens', accessTokensToolRegistry);
+    }
+
     // All entity registries have been migrated to the new pattern!
   }
 
@@ -328,6 +337,10 @@ class RegistryManager {
 
     if (USE_REGISTRY) {
       readOnlyTools.push(...getContainerRegistryReadOnlyToolNames());
+    }
+
+    if (USE_ACCESS_TOKENS) {
+      readOnlyTools.push(...getAccessTokensReadOnlyToolNames());
     }
 
     return readOnlyTools;
@@ -758,6 +771,7 @@ class RegistryManager {
     const useCiTokens = process.env.USE_CI_TOKENS !== 'false';
     const useEnvironments = process.env.USE_ENVIRONMENTS !== 'false';
     const useRegistry = process.env.USE_REGISTRY !== 'false';
+    const useAccessTokens = process.env.USE_ACCESS_TOKENS !== 'false';
 
     // Build registries map based on dynamic feature flags
     const registriesToUse = new Map<string, ToolRegistry>();
@@ -791,6 +805,7 @@ class RegistryManager {
     }
     if (useEnvironments) registriesToUse.set('environments', environmentsToolRegistry);
     if (useRegistry) registriesToUse.set('registry', containerRegistryToolRegistry);
+    if (useAccessTokens) registriesToUse.set('access_tokens', accessTokensToolRegistry);
 
     // Dynamically load description overrides
     const descOverrides = getToolDescriptionOverrides();
@@ -893,6 +908,7 @@ class RegistryManager {
       deployKeysToolRegistry,
       environmentsToolRegistry,
       containerRegistryToolRegistry,
+      accessTokensToolRegistry,
     ];
 
     for (const registry of allRegistries) {

--- a/src/services/TokenScopeDetector.ts
+++ b/src/services/TokenScopeDetector.ts
@@ -143,7 +143,8 @@ const TOOL_SCOPE_REQUIREMENTS: Record<string, GitLabScope[]> = {
   browse_registry: ['api', 'read_api', 'read_registry'],
   manage_registry: ['api', 'write_registry'],
 
-  // Access tokens (personal/project/group) - REST-only, require full api scope
+  // Access tokens (personal/project/group) - REST-only:
+  // browse requires api/read_api; manage requires api.
   browse_access_tokens: ['api', 'read_api'],
   manage_access_token: ['api'],
 

--- a/src/services/TokenScopeDetector.ts
+++ b/src/services/TokenScopeDetector.ts
@@ -143,6 +143,10 @@ const TOOL_SCOPE_REQUIREMENTS: Record<string, GitLabScope[]> = {
   browse_registry: ['api', 'read_api', 'read_registry'],
   manage_registry: ['api', 'write_registry'],
 
+  // Access tokens (personal/project/group) - REST-only, require full api scope
+  browse_access_tokens: ['api', 'read_api'],
+  manage_access_token: ['api'],
+
   // Wiki
   browse_wiki: ['api', 'read_api'],
   manage_wiki: ['api'],

--- a/tests/integration/schemas/access-tokens.test.ts
+++ b/tests/integration/schemas/access-tokens.test.ts
@@ -124,6 +124,7 @@ describe('Access Tokens Schema - GitLab Integration', () => {
         // Rotation issues a NEW token id; track that one for cleanup.
         tokenId = rotated.id;
         expect(typeof rotated.token).toBe('string');
+        expect(rotated._meta?.sensitive).toBe(true);
         console.log(`  rotated project token on ${testProjectPath}`);
       } catch (error) {
         console.log(`  project-token lifecycle not permitted: ${(error as Error).message}`);

--- a/tests/integration/schemas/access-tokens.test.ts
+++ b/tests/integration/schemas/access-tokens.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Access Tokens Schema Integration Tests
+ *
+ * Backed by the GitLab REST access-token endpoints. list_personal runs end-to-end
+ * against the current user. The project-token lifecycle (create -> rotate -> revoke)
+ * runs only when a writable test/ project is available and the token has owner/admin
+ * rights; otherwise it skips. A created token is always revoked in cleanup so no
+ * live credential is left behind.
+ */
+
+import { BrowseAccessTokensSchema } from '../../../src/entities/access_tokens/schema-readonly';
+import { ManageAccessTokenSchema } from '../../../src/entities/access_tokens/schema';
+import { IntegrationTestHelper } from '../helpers/registry-helper';
+
+interface TokenResponse {
+  id: number;
+  name: string;
+  token?: string;
+}
+
+describe('Access Tokens Schema - GitLab Integration', () => {
+  let helper: IntegrationTestHelper;
+  let testProjectPath: string | undefined;
+
+  beforeAll(async () => {
+    if (!process.env.GITLAB_TOKEN) {
+      throw new Error('GITLAB_TOKEN environment variable is required');
+    }
+    helper = new IntegrationTestHelper();
+    await helper.initialize();
+
+    const projects = (await helper.listProjects({ search: 'test', per_page: 10 })) as {
+      path_with_namespace: string;
+    }[];
+    testProjectPath = projects.find((p) =>
+      p.path_with_namespace.startsWith('test/'),
+    )?.path_with_namespace;
+  });
+
+  describe('schema validation', () => {
+    it('validates browse_access_tokens actions', () => {
+      for (const params of [
+        { action: 'list_personal', state: 'active', search: 'ci' },
+        { action: 'list_project', project_id: 'g/p' },
+        { action: 'list_group', group_id: 'g' },
+        { action: 'get', token_id: 1 },
+        { action: 'get', token_id: 1, project_id: 'g/p' },
+      ]) {
+        expect(BrowseAccessTokensSchema.safeParse(params).success).toBe(true);
+      }
+    });
+
+    it('validates manage_access_token actions', () => {
+      for (const params of [
+        { action: 'create_project', project_id: 'g/p', name: 't', scopes: ['api'] },
+        { action: 'create_group', group_id: 'g', name: 't', scopes: ['api'], access_level: 40 },
+        { action: 'rotate', token_id: 1, expires_at: '2026-12-31' },
+        { action: 'revoke', token_id: 1, group_id: 'g' },
+      ]) {
+        expect(ManageAccessTokenSchema.safeParse(params).success).toBe(true);
+      }
+    });
+
+    it('rejects create with an empty scopes array', () => {
+      const result = ManageAccessTokenSchema.safeParse({
+        action: 'create_project',
+        project_id: 'g/p',
+        name: 't',
+        scopes: [],
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects get with both project_id and group_id', () => {
+      const result = BrowseAccessTokensSchema.safeParse({
+        action: 'get',
+        token_id: 1,
+        project_id: 'g/p',
+        group_id: 'g',
+      });
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('list_personal (end-to-end)', () => {
+    it('returns the current user personal access tokens', async () => {
+      const result = (await helper.executeTool('browse_access_tokens', {
+        action: 'list_personal',
+        per_page: 5,
+      })) as TokenResponse[];
+
+      expect(Array.isArray(result)).toBe(true);
+      console.log(`  current user has ${result.length} personal access tokens (page 1)`);
+    }, 15000);
+  });
+
+  describe('project token lifecycle (create -> rotate -> revoke)', () => {
+    it('creates, rotates, and revokes a project access token when permitted', async () => {
+      if (!testProjectPath) {
+        console.log('No test/ project available; skipping project-token lifecycle');
+        return;
+      }
+
+      const uniqueName = `mcp-it-${Date.now()}`;
+      let tokenId: number | undefined;
+
+      try {
+        const created = (await helper.executeTool('manage_access_token', {
+          action: 'create_project',
+          project_id: testProjectPath,
+          name: uniqueName,
+          scopes: ['read_api'],
+        })) as TokenResponse & { _meta?: { sensitive?: boolean } };
+
+        tokenId = created.id;
+        expect(typeof created.token).toBe('string');
+        expect(created._meta?.sensitive).toBe(true);
+
+        const rotated = (await helper.executeTool('manage_access_token', {
+          action: 'rotate',
+          project_id: testProjectPath,
+          token_id: tokenId,
+        })) as TokenResponse & { _meta?: { sensitive?: boolean } };
+        // Rotation issues a NEW token id; track that one for cleanup.
+        tokenId = rotated.id;
+        expect(typeof rotated.token).toBe('string');
+        console.log(`  rotated project token on ${testProjectPath}`);
+      } catch (error) {
+        console.log(`  project-token lifecycle not permitted: ${(error as Error).message}`);
+      } finally {
+        if (tokenId !== undefined) {
+          await helper
+            .executeTool('manage_access_token', {
+              action: 'revoke',
+              project_id: testProjectPath,
+              token_id: tokenId,
+            })
+            .catch(() => undefined);
+        }
+      }
+    }, 30000);
+  });
+});

--- a/tests/unit/entities/access_tokens/registry.test.ts
+++ b/tests/unit/entities/access_tokens/registry.test.ts
@@ -182,6 +182,50 @@ describe('Access Tokens Registry', () => {
       expect(JSON.parse(init?.body as string)).toEqual({});
     });
 
+    it('rotate (group) routes to the group rotate sub-resource', async () => {
+      mockOk({ id: 7, token: 'glpat-new' });
+      await manage().handler({ action: 'rotate', token_id: 7, group_id: 'g' });
+
+      const [url, init] = lastCall();
+      expect(url).toBe('https://gitlab.example.com/api/v4/groups/g/access_tokens/7/rotate');
+      expect(init?.method).toBe('POST');
+    });
+
+    it('revoke (project) DELETEs the project token', async () => {
+      mockNoContent();
+      const result = await manage().handler({ action: 'revoke', token_id: 7, project_id: '123' });
+
+      const [url, init] = lastCall();
+      expect(url).toBe('https://gitlab.example.com/api/v4/projects/123/access_tokens/7');
+      expect(init?.method).toBe('DELETE');
+      expect(result).toEqual({ revoked: true, token_id: 7 });
+    });
+
+    it('rejects a scopes entry that is empty or whitespace-only', async () => {
+      await expect(
+        manage().handler({
+          action: 'create_project',
+          project_id: '1',
+          name: 'x',
+          scopes: ['api', '  '],
+        }),
+      ).rejects.toThrow();
+      expect(mockEnhancedFetch).not.toHaveBeenCalled();
+    });
+
+    it('rejects a malformed expires_at that is not YYYY-MM-DD', async () => {
+      await expect(
+        manage().handler({
+          action: 'create_project',
+          project_id: '1',
+          name: 'x',
+          scopes: ['api'],
+          expires_at: '2026/12/31',
+        }),
+      ).rejects.toThrow();
+      expect(mockEnhancedFetch).not.toHaveBeenCalled();
+    });
+
     it('revoke (group) DELETEs the group token and returns a confirmation', async () => {
       mockNoContent();
       const result = await manage().handler({ action: 'revoke', token_id: 7, group_id: 'g' });

--- a/tests/unit/entities/access_tokens/registry.test.ts
+++ b/tests/unit/entities/access_tokens/registry.test.ts
@@ -1,0 +1,217 @@
+import {
+  accessTokensToolRegistry,
+  getAccessTokensReadOnlyToolNames,
+} from '../../../../src/entities/access_tokens/registry';
+import {
+  installFetchMock,
+  mockOk,
+  mockNoContent,
+  lastFetchCall as lastCall,
+  mockEnhancedFetch,
+} from '../../helpers/fetch-mock';
+
+jest.mock('../../../../src/utils/fetch', () => ({
+  enhancedFetch: jest.fn(),
+}));
+
+installFetchMock();
+
+const browse = () => accessTokensToolRegistry.get('browse_access_tokens')!;
+const manage = () => accessTokensToolRegistry.get('manage_access_token')!;
+
+describe('Access Tokens Registry', () => {
+  describe('Registry Structure', () => {
+    it('contains exactly the two CQRS tools', () => {
+      expect(Array.from(accessTokensToolRegistry.keys())).toEqual([
+        'browse_access_tokens',
+        'manage_access_token',
+      ]);
+    });
+
+    it('exposes only the browse tool as read-only', () => {
+      expect(getAccessTokensReadOnlyToolNames()).toEqual(['browse_access_tokens']);
+      expect(accessTokensToolRegistry.size).toBe(2);
+    });
+
+    it('declares the Free-tier requirement and USE_ACCESS_TOKENS gate on both tools', () => {
+      expect(browse().requirements?.default).toEqual({ tier: 'free', minVersion: '13.0' });
+      expect(manage().requirements?.default).toEqual({ tier: 'free', minVersion: '13.0' });
+      expect(browse().gate).toEqual({ envVar: 'USE_ACCESS_TOKENS', defaultValue: true });
+      expect(manage().gate).toEqual({ envVar: 'USE_ACCESS_TOKENS', defaultValue: true });
+    });
+  });
+
+  describe('browse_access_tokens', () => {
+    it('list_personal reads the personal_access_tokens collection with filters', async () => {
+      mockOk([{ id: 1 }]);
+      await browse().handler({ action: 'list_personal', state: 'active', search: 'ci' });
+
+      const [url] = lastCall();
+      expect(url).toContain('https://gitlab.example.com/api/v4/personal_access_tokens?');
+      expect(url).toContain('state=active');
+      expect(url).toContain('search=ci');
+      expect(url).not.toContain('/projects/');
+    });
+
+    it('list_personal forwards an admin user_id filter', async () => {
+      mockOk([{ id: 1 }]);
+      await browse().handler({ action: 'list_personal', user_id: 42 });
+
+      const [url] = lastCall();
+      expect(url).toContain('user_id=42');
+    });
+
+    it('list_project reads the project access_tokens collection', async () => {
+      mockOk([{ id: 1 }]);
+      await browse().handler({ action: 'list_project', project_id: 'group/project' });
+
+      const [url] = lastCall();
+      expect(url).toContain('/projects/group%2Fproject/access_tokens');
+    });
+
+    it('list_group reads the group access_tokens collection', async () => {
+      mockOk([{ id: 1 }]);
+      await browse().handler({ action: 'list_group', group_id: 'my-group' });
+
+      const [url] = lastCall();
+      expect(url).toContain('/groups/my-group/access_tokens');
+    });
+
+    it('get without a scope reads a personal token by id', async () => {
+      mockOk({ id: 7 });
+      await browse().handler({ action: 'get', token_id: 7 });
+
+      const [url] = lastCall();
+      expect(url).toBe('https://gitlab.example.com/api/v4/personal_access_tokens/7');
+    });
+
+    it('get with project_id reads a project token by id', async () => {
+      mockOk({ id: 7 });
+      await browse().handler({ action: 'get', token_id: 7, project_id: '123' });
+
+      const [url] = lastCall();
+      expect(url).toBe('https://gitlab.example.com/api/v4/projects/123/access_tokens/7');
+    });
+
+    it('get with group_id reads a group token by id', async () => {
+      mockOk({ id: 7 });
+      await browse().handler({ action: 'get', token_id: 7, group_id: 'g' });
+
+      const [url] = lastCall();
+      expect(url).toBe('https://gitlab.example.com/api/v4/groups/g/access_tokens/7');
+    });
+
+    it('rejects get with both project_id and group_id', async () => {
+      await expect(
+        browse().handler({ action: 'get', token_id: 7, project_id: '1', group_id: 'g' }),
+      ).rejects.toThrow();
+      expect(mockEnhancedFetch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('manage_access_token', () => {
+    it('create_project POSTs the token payload and flags the response sensitive', async () => {
+      mockOk({ id: 9, token: 'glpat-secret' });
+      const result = (await manage().handler({
+        action: 'create_project',
+        project_id: '123',
+        name: 'ci-token',
+        scopes: ['api', 'read_repository'],
+        access_level: 30,
+        expires_at: '2026-12-31',
+      })) as { token: string; _meta: { sensitive: boolean } };
+
+      const [url, init] = lastCall();
+      expect(url).toBe('https://gitlab.example.com/api/v4/projects/123/access_tokens');
+      expect(init?.method).toBe('POST');
+      expect(JSON.parse(init?.body as string)).toEqual({
+        name: 'ci-token',
+        scopes: ['api', 'read_repository'],
+        access_level: 30,
+        expires_at: '2026-12-31',
+      });
+      expect(result.token).toBe('glpat-secret');
+      expect(result._meta.sensitive).toBe(true);
+    });
+
+    it('create_group POSTs to the group collection', async () => {
+      mockOk({ id: 9, token: 'glpat-g' });
+      await manage().handler({
+        action: 'create_group',
+        group_id: 'my-group',
+        name: 'grp-token',
+        scopes: ['api'],
+      });
+
+      const [url, init] = lastCall();
+      expect(url).toBe('https://gitlab.example.com/api/v4/groups/my-group/access_tokens');
+      expect(init?.method).toBe('POST');
+      expect(JSON.parse(init?.body as string)).toEqual({ name: 'grp-token', scopes: ['api'] });
+    });
+
+    it('rejects create_project with an empty scopes array', async () => {
+      await expect(
+        manage().handler({ action: 'create_project', project_id: '1', name: 'x', scopes: [] }),
+      ).rejects.toThrow();
+      expect(mockEnhancedFetch).not.toHaveBeenCalled();
+    });
+
+    it('rotate (personal) POSTs to the self rotate sub-resource and flags sensitive', async () => {
+      mockOk({ id: 7, token: 'glpat-new' });
+      const result = (await manage().handler({
+        action: 'rotate',
+        token_id: 7,
+        expires_at: '2026-09-01',
+      })) as { token: string; _meta: { sensitive: boolean } };
+
+      const [url, init] = lastCall();
+      expect(url).toBe('https://gitlab.example.com/api/v4/personal_access_tokens/7/rotate');
+      expect(init?.method).toBe('POST');
+      expect(JSON.parse(init?.body as string)).toEqual({ expires_at: '2026-09-01' });
+      expect(result.token).toBe('glpat-new');
+      expect(result._meta.sensitive).toBe(true);
+    });
+
+    it('rotate (project) routes to the project rotate sub-resource', async () => {
+      mockOk({ id: 7, token: 'glpat-new' });
+      await manage().handler({ action: 'rotate', token_id: 7, project_id: '123' });
+
+      const [url, init] = lastCall();
+      expect(url).toBe('https://gitlab.example.com/api/v4/projects/123/access_tokens/7/rotate');
+      expect(init?.method).toBe('POST');
+      expect(JSON.parse(init?.body as string)).toEqual({});
+    });
+
+    it('revoke (group) DELETEs the group token and returns a confirmation', async () => {
+      mockNoContent();
+      const result = await manage().handler({ action: 'revoke', token_id: 7, group_id: 'g' });
+
+      const [url, init] = lastCall();
+      expect(url).toBe('https://gitlab.example.com/api/v4/groups/g/access_tokens/7');
+      expect(init?.method).toBe('DELETE');
+      expect(result).toEqual({ revoked: true, token_id: 7 });
+    });
+
+    it('revoke (personal) DELETEs the personal token by id', async () => {
+      mockNoContent();
+      await manage().handler({ action: 'revoke', token_id: 7 });
+
+      const [url, init] = lastCall();
+      expect(url).toBe('https://gitlab.example.com/api/v4/personal_access_tokens/7');
+      expect(init?.method).toBe('DELETE');
+    });
+
+    it('coerces a string token_id to a number', async () => {
+      mockNoContent();
+      const result = await manage().handler({ action: 'revoke', token_id: '7' });
+      expect(result).toEqual({ revoked: true, token_id: 7 });
+    });
+
+    it('rejects rotate with both project_id and group_id', async () => {
+      await expect(
+        manage().handler({ action: 'rotate', token_id: 7, project_id: '1', group_id: 'g' }),
+      ).rejects.toThrow();
+      expect(mockEnhancedFetch).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds the `browse_access_tokens` / `manage_access_token` CQRS pair so agents can inspect, create, rotate, and revoke GitLab access tokens (the core CI/automation credentials).

- **browse_access_tokens** (Query): `list_personal` (current user's PATs; admins may filter by `user_id`), `list_project`, `list_group`, `get`
- **manage_access_token** (Command): `create_project`, `create_group`, `rotate`, `revoke`

## Implementation notes

- **REST-only by necessity.** GitLab exposes no GraphQL surface for personal/project/group access tokens (verified by live schema introspection: zero mutation or query fields matching `/token/i`). All actions map to the `/personal_access_tokens`, `/projects/:id/access_tokens` and `/groups/:id/access_tokens` endpoints.
- The three scopes fold in as actions, not separate tools. `get` / `rotate` / `revoke` infer the scope from `project_id` / `group_id` (neither => personal); a schema refine forbids passing both.
- `create_*` and `rotate` return a token value exactly once; those responses are wrapped with a `_meta.sensitive` marker and a store-securely notice so the secret is flagged in the tool output.
- Personal-token creation is intentionally absent: GitLab only allows it for admins against a specific user, out of scope for this tool.
- Token scopes are accepted as a free-form string array (not a fixed enum) so new GitLab scopes work without a code change.
- Gated behind `USE_ACCESS_TOKENS`; token-scope requirements (`browse` => `api`/`read_api`, `manage` => `api`) wired into `TokenScopeDetector`.

## Testing

- Unit: 20 tests covering every browse + manage action, scope routing (personal/project/group), the sensitive-metadata flag, `token_id` coercion, and the mutual-exclusion / empty-scopes schema guards (REST `enhancedFetch` mocked).
- Integration: schema validation + `list_personal` end-to-end + env-adaptive project-token lifecycle (create -> rotate -> revoke) that runs only with a writable `test/` project and always revokes the created token in cleanup.
- Full suite green: 5076 unit tests, 424 integration tests, clean build and lint.

Closes #441

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added access token management: list personal/project/group tokens; create, rotate, and revoke tokens. Creation/rotation return one-time sensitive tokens with a one-time retrieval notice. Availability is controlled by configuration.

* **Validation**
  * Added input validation for all access-token actions with safeguards against invalid parameter combinations.

* **Tests**
  * Added comprehensive unit and integration tests covering schemas, routing, lifecycle (create → rotate → revoke), and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->