### PR TITLE
feat(audit-events): expose instance/group/project audit events

### DIFF
--- a/src/entities/audit_events/registry.ts
+++ b/src/entities/audit_events/registry.ts
@@ -1,0 +1,85 @@
+import * as z from 'zod';
+import { BrowseAuditEventsSchema } from './schema-readonly';
+import { gitlab, toQuery } from '../../utils/gitlab-api';
+import { ToolRegistry, EnhancedToolDefinition } from '../../types';
+import { assertActionAllowed } from '../utils';
+
+// Audit events are a Premium/Ultimate feature; the tier gate hides the tool on
+// lower-tier instances. Instance audit events landed in 12.4, group/project in
+// 12.5/13.1 - the lowest floor is declared here and the tier gate does the rest.
+const PREMIUM_REQ = { tier: 'premium', minVersion: '12.4', notes: 'Audit Events' } as const;
+
+/**
+ * Resolve the REST collection path for a single audit event (get action).
+ * An event belongs to exactly one scope: project, group, or the instance.
+ */
+function auditBasePath(input: { project_id?: string; group_id?: string }): string {
+  if (input.project_id) {
+    return `projects/${encodeURIComponent(input.project_id)}/audit_events`;
+  }
+  if (input.group_id) {
+    return `groups/${encodeURIComponent(input.group_id)}/audit_events`;
+  }
+  return 'audit_events';
+}
+
+/**
+ * Audit events tools registry - 1 read-only CQRS tool.
+ *
+ * browse_audit_events (Query): list_instance, list_group, list_project, get
+ *
+ * Backed by the GitLab REST audit-event endpoints. There is no manage_* tool:
+ * audit events are immutable by design. The instance/group/project scopes fold in
+ * as actions; get infers the scope from project_id / group_id. Gated behind
+ * USE_AUDIT_EVENTS. Premium/Ultimate tier; list_instance additionally needs admin.
+ */
+export const auditEventsToolRegistry: ToolRegistry = new Map<string, EnhancedToolDefinition>([
+  [
+    'browse_audit_events',
+    {
+      name: 'browse_audit_events',
+      description:
+        'Inspect audit events: the immutable record of who did what, when. Actions: list_instance (instance-wide, admin-only), list_group / list_project (a group or project audit trail), get (a single event by ID - pass project_id or group_id for group/project events, neither for an instance event). Premium/Ultimate feature; there is no write counterpart because audit events cannot be modified.',
+      inputSchema: z.toJSONSchema(BrowseAuditEventsSchema),
+      requirements: { default: PREMIUM_REQ },
+      gate: { envVar: 'USE_AUDIT_EVENTS', defaultValue: true },
+      handler: async (args: unknown): Promise<unknown> => {
+        const input = BrowseAuditEventsSchema.parse(args);
+        assertActionAllowed('browse_audit_events', input.action);
+
+        switch (input.action) {
+          case 'list_instance': {
+            const { action: _action, ...query } = input;
+            return gitlab.get('audit_events', { query: toQuery(query, []) });
+          }
+
+          case 'list_group': {
+            const { action: _action, group_id, ...query } = input;
+            return gitlab.get(`groups/${encodeURIComponent(group_id)}/audit_events`, {
+              query: toQuery(query, []),
+            });
+          }
+
+          case 'list_project': {
+            const { action: _action, project_id, ...query } = input;
+            return gitlab.get(`projects/${encodeURIComponent(project_id)}/audit_events`, {
+              query: toQuery(query, []),
+            });
+          }
+
+          case 'get':
+            return gitlab.get(`${auditBasePath(input)}/${input.audit_event_id}`);
+
+          /* istanbul ignore next -- unreachable with Zod discriminatedUnion */
+          default:
+            throw new Error(`Unknown action: ${(input as { action: string }).action}`);
+        }
+      },
+    },
+  ],
+]);
+
+/** Read-only tool names from the registry (for read-only mode filtering). */
+export function getAuditEventsReadOnlyToolNames(): string[] {
+  return ['browse_audit_events'];
+}

--- a/src/entities/audit_events/schema-readonly.ts
+++ b/src/entities/audit_events/schema-readonly.ts
@@ -1,0 +1,106 @@
+import { z } from 'zod';
+import { requiredId, paginationFields } from '../utils';
+
+// ============================================================================
+// browse_audit_events - CQRS Query Tool (discriminated union schema)
+// Actions: list_instance, list_group, list_project, get
+//
+// Audit events are an immutable compliance record of who did what, when. There is
+// no manage_* counterpart - they cannot be created or edited via the API. Exposed
+// only through REST. The instance/group/project scopes fold in as actions; get
+// infers the scope from project_id / group_id. Gated behind USE_AUDIT_EVENTS.
+// Premium/Ultimate tier; list_instance additionally requires admin.
+// ============================================================================
+
+export const projectIdField = requiredId.describe(
+  "Project ID or URL-encoded path (e.g. 'group/project' or '123').",
+);
+export const groupIdField = requiredId.describe(
+  "Group ID or URL-encoded path (e.g. 'my-group' or '42').",
+);
+export const auditEventIdField = z.coerce
+  .number()
+  .int()
+  .positive()
+  .describe('Numeric audit-event ID (from a list action).');
+
+const createdAfterField = z
+  .string()
+  .regex(/^\d{4}-\d{2}-\d{2}$/, 'created_after must be a YYYY-MM-DD date')
+  .optional()
+  .describe('Return events created on or after this date (YYYY-MM-DD).');
+const createdBeforeField = z
+  .string()
+  .regex(/^\d{4}-\d{2}-\d{2}$/, 'created_before must be a YYYY-MM-DD date')
+  .optional()
+  .describe('Return events created on or before this date (YYYY-MM-DD).');
+
+// --- Action: list_instance (admin-only, instance-wide) ---
+const ListInstanceSchema = z.object({
+  action: z
+    .literal('list_instance')
+    .describe('List instance-wide audit events (requires admin; Premium+)'),
+  entity_type: z
+    .string()
+    .optional()
+    .describe("Filter by entity type, e.g. 'User', 'Group', 'Project', 'Key'."),
+  entity_id: z.coerce
+    .number()
+    .int()
+    .positive()
+    .optional()
+    .describe('Filter by the numeric ID of the entity (used with entity_type).'),
+  created_after: createdAfterField,
+  created_before: createdBeforeField,
+  ...paginationFields(),
+});
+
+// --- Action: list_group ---
+const ListGroupSchema = z.object({
+  action: z
+    .literal('list_group')
+    .describe('List a group audit events (Premium+, group owner/admin)'),
+  group_id: groupIdField,
+  created_after: createdAfterField,
+  created_before: createdBeforeField,
+  ...paginationFields(),
+});
+
+// --- Action: list_project ---
+const ListProjectSchema = z.object({
+  action: z
+    .literal('list_project')
+    .describe('List a project audit events (Premium+, project owner/admin)'),
+  project_id: projectIdField,
+  created_after: createdAfterField,
+  created_before: createdBeforeField,
+  ...paginationFields(),
+});
+
+// --- Action: get (single event; scope inferred from project_id/group_id) ---
+const GetAuditEventSchema = z.object({
+  action: z
+    .literal('get')
+    .describe(
+      'Get a single audit event by ID. Pass project_id for a project event, group_id for a group event, or neither for an instance event (admin).',
+    ),
+  audit_event_id: auditEventIdField,
+  project_id: requiredId.optional().describe('Set for a project audit event.'),
+  group_id: requiredId.optional().describe('Set for a group audit event.'),
+});
+
+// --- Discriminated union combining all actions ---
+export const BrowseAuditEventsSchema = z
+  .discriminatedUnion('action', [
+    ListInstanceSchema,
+    ListGroupSchema,
+    ListProjectSchema,
+    GetAuditEventSchema,
+  ])
+  // An audit event belongs to a single scope; project_id and group_id are mutually exclusive.
+  .refine((data) => data.action !== 'get' || !(data.project_id && data.group_id), {
+    message: 'Pass at most one of project_id or group_id (an event belongs to a single scope)',
+    path: ['project_id'],
+  });
+
+export type BrowseAuditEventsInput = z.infer<typeof BrowseAuditEventsSchema>;

--- a/src/registry-manager.ts
+++ b/src/registry-manager.ts
@@ -53,6 +53,10 @@ import {
 } from './entities/container_registry/registry';
 import { runnersToolRegistry, getRunnersReadOnlyToolNames } from './entities/runners/registry';
 import {
+  auditEventsToolRegistry,
+  getAuditEventsReadOnlyToolNames,
+} from './entities/audit_events/registry';
+import {
   accessTokensToolRegistry,
   getAccessTokensReadOnlyToolNames,
 } from './entities/access_tokens/registry';
@@ -82,6 +86,7 @@ import {
   USE_REGISTRY,
   USE_ACCESS_TOKENS,
   USE_RUNNERS,
+  USE_AUDIT_EVENTS,
   getToolDescriptionOverrides,
 } from './config';
 import { isToolAvailable, getRestrictedParameters } from './services/InstanceCapabilities';
@@ -238,6 +243,10 @@ class RegistryManager {
       this.registries.set('runners', runnersToolRegistry);
     }
 
+    if (USE_AUDIT_EVENTS) {
+      this.registries.set('audit_events', auditEventsToolRegistry);
+    }
+
     // All entity registries have been migrated to the new pattern!
   }
 
@@ -351,6 +360,10 @@ class RegistryManager {
 
     if (USE_RUNNERS) {
       readOnlyTools.push(...getRunnersReadOnlyToolNames());
+    }
+
+    if (USE_AUDIT_EVENTS) {
+      readOnlyTools.push(...getAuditEventsReadOnlyToolNames());
     }
 
     return readOnlyTools;
@@ -783,6 +796,7 @@ class RegistryManager {
     const useRegistry = process.env.USE_REGISTRY !== 'false';
     const useAccessTokens = process.env.USE_ACCESS_TOKENS !== 'false';
     const useRunners = process.env.USE_RUNNERS !== 'false';
+    const useAuditEvents = process.env.USE_AUDIT_EVENTS !== 'false';
 
     // Build registries map based on dynamic feature flags
     const registriesToUse = new Map<string, ToolRegistry>();
@@ -818,6 +832,7 @@ class RegistryManager {
     if (useRegistry) registriesToUse.set('registry', containerRegistryToolRegistry);
     if (useAccessTokens) registriesToUse.set('access_tokens', accessTokensToolRegistry);
     if (useRunners) registriesToUse.set('runners', runnersToolRegistry);
+    if (useAuditEvents) registriesToUse.set('audit_events', auditEventsToolRegistry);
 
     // Dynamically load description overrides
     const descOverrides = getToolDescriptionOverrides();
@@ -922,6 +937,7 @@ class RegistryManager {
       containerRegistryToolRegistry,
       accessTokensToolRegistry,
       runnersToolRegistry,
+      auditEventsToolRegistry,
     ];
 
     for (const registry of allRegistries) {

--- a/src/services/TokenScopeDetector.ts
+++ b/src/services/TokenScopeDetector.ts
@@ -155,6 +155,9 @@ const TOOL_SCOPE_REQUIREMENTS: Record<string, GitLabScope[]> = {
   browse_runners: ['api', 'read_api'],
   manage_runner: ['api', 'create_runner', 'manage_runner'],
 
+  // Audit events (Premium/Ultimate, read-only)
+  browse_audit_events: ['api', 'read_api'],
+
   // Wiki
   browse_wiki: ['api', 'read_api'],
   manage_wiki: ['api'],

--- a/tests/integration/schemas/audit-events.test.ts
+++ b/tests/integration/schemas/audit-events.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Audit Events Schema Integration Tests
+ *
+ * Backed by the GitLab REST audit-event endpoints (Premium/Ultimate). Schema
+ * validation always runs. The end-to-end list checks are tier-gated via
+ * describeIfTier('premium', ...) and run against a test/ group or project when
+ * available; list_instance needs admin, so it is exercised tolerantly.
+ */
+
+import { BrowseAuditEventsSchema } from '../../../src/entities/audit_events/schema-readonly';
+import { IntegrationTestHelper } from '../helpers/registry-helper';
+import { describeIfTier } from '../../setup/tierGate';
+
+interface AuditEvent {
+  id: number;
+}
+
+describe('Audit Events Schema - GitLab Integration', () => {
+  describe('schema validation', () => {
+    it('validates browse_audit_events actions', () => {
+      for (const params of [
+        { action: 'list_instance', entity_type: 'User', entity_id: 1, created_after: '2026-01-01' },
+        { action: 'list_group', group_id: 'g' },
+        { action: 'list_project', project_id: 'g/p' },
+        { action: 'get', audit_event_id: 1 },
+        { action: 'get', audit_event_id: 1, group_id: 'g' },
+      ]) {
+        expect(BrowseAuditEventsSchema.safeParse(params).success).toBe(true);
+      }
+    });
+
+    it('rejects a malformed created_before date', () => {
+      const result = BrowseAuditEventsSchema.safeParse({
+        action: 'list_group',
+        group_id: 'g',
+        created_before: '01-01-2026',
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects get with both project_id and group_id', () => {
+      const result = BrowseAuditEventsSchema.safeParse({
+        action: 'get',
+        audit_event_id: 1,
+        project_id: 'g/p',
+        group_id: 'g',
+      });
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describeIfTier('premium', 'audit events (end-to-end, Premium+)', () => {
+    let helper: IntegrationTestHelper;
+    let testProjectPath: string | undefined;
+
+    beforeAll(async () => {
+      if (!process.env.GITLAB_TOKEN) {
+        throw new Error('GITLAB_TOKEN environment variable is required');
+      }
+      helper = new IntegrationTestHelper();
+      await helper.initialize();
+
+      const projects = (await helper.listProjects({ search: 'test', per_page: 10 })) as {
+        path_with_namespace: string;
+      }[];
+      testProjectPath = projects.find((p) =>
+        p.path_with_namespace.startsWith('test/'),
+      )?.path_with_namespace;
+    });
+
+    it('lists a project audit trail when a test project is available', async () => {
+      if (!testProjectPath) {
+        console.log('No test/ project available; skipping project audit trail');
+        return;
+      }
+
+      const result = (await helper.executeTool('browse_audit_events', {
+        action: 'list_project',
+        project_id: testProjectPath,
+        per_page: 5,
+      })) as AuditEvent[];
+
+      expect(Array.isArray(result)).toBe(true);
+      console.log(`  ${testProjectPath} returned ${result.length} audit events`);
+    }, 15000);
+
+    it('lists instance audit events or reports lack of admin access', async () => {
+      try {
+        const result = (await helper.executeTool('browse_audit_events', {
+          action: 'list_instance',
+          per_page: 5,
+        })) as AuditEvent[];
+        expect(Array.isArray(result)).toBe(true);
+        console.log(`  instance-wide audit events returned ${result.length} rows`);
+      } catch (error) {
+        // Non-admin tokens cannot read instance audit events; expected.
+        console.log(`  list_instance not available for this token: ${(error as Error).message}`);
+      }
+    }, 15000);
+  });
+});

--- a/tests/unit/entities/audit_events/registry.test.ts
+++ b/tests/unit/entities/audit_events/registry.test.ts
@@ -1,0 +1,118 @@
+import {
+  auditEventsToolRegistry,
+  getAuditEventsReadOnlyToolNames,
+} from '../../../../src/entities/audit_events/registry';
+import {
+  installFetchMock,
+  mockOk,
+  lastFetchCall as lastCall,
+  mockEnhancedFetch,
+} from '../../helpers/fetch-mock';
+
+jest.mock('../../../../src/utils/fetch', () => ({
+  enhancedFetch: jest.fn(),
+}));
+
+installFetchMock();
+
+const browse = () => auditEventsToolRegistry.get('browse_audit_events')!;
+
+describe('Audit Events Registry', () => {
+  describe('Registry Structure', () => {
+    it('contains exactly the one read-only CQRS tool', () => {
+      expect(Array.from(auditEventsToolRegistry.keys())).toEqual(['browse_audit_events']);
+    });
+
+    it('exposes the browse tool as read-only with no manage counterpart', () => {
+      expect(getAuditEventsReadOnlyToolNames()).toEqual(['browse_audit_events']);
+      expect(auditEventsToolRegistry.size).toBe(1);
+    });
+
+    it('declares the Premium-tier requirement and USE_AUDIT_EVENTS gate', () => {
+      expect(browse().requirements?.default).toMatchObject({ tier: 'premium' });
+      expect(browse().gate).toEqual({ envVar: 'USE_AUDIT_EVENTS', defaultValue: true });
+    });
+  });
+
+  describe('browse_audit_events', () => {
+    it('list_instance reads the instance audit_events with filters', async () => {
+      mockOk([{ id: 1 }]);
+      await browse().handler({
+        action: 'list_instance',
+        entity_type: 'User',
+        entity_id: 42,
+        created_after: '2026-01-01',
+      });
+
+      const [url] = lastCall();
+      expect(url).toContain('https://gitlab.example.com/api/v4/audit_events?');
+      expect(url).toContain('entity_type=User');
+      expect(url).toContain('entity_id=42');
+      expect(url).toContain('created_after=2026-01-01');
+      expect(url).not.toContain('/projects/');
+      expect(url).not.toContain('/groups/');
+    });
+
+    it('list_group reads the group audit_events collection', async () => {
+      mockOk([{ id: 1 }]);
+      await browse().handler({ action: 'list_group', group_id: 'my-group' });
+
+      const [url] = lastCall();
+      expect(url).toContain('/groups/my-group/audit_events');
+    });
+
+    it('list_project reads the project audit_events collection', async () => {
+      mockOk([{ id: 1 }]);
+      await browse().handler({ action: 'list_project', project_id: 'group/project' });
+
+      const [url] = lastCall();
+      expect(url).toContain('/projects/group%2Fproject/audit_events');
+    });
+
+    it('get without a scope reads an instance audit event by id', async () => {
+      mockOk({ id: 7 });
+      await browse().handler({ action: 'get', audit_event_id: 7 });
+
+      const [url] = lastCall();
+      expect(url).toBe('https://gitlab.example.com/api/v4/audit_events/7');
+    });
+
+    it('get with group_id reads a group audit event by id', async () => {
+      mockOk({ id: 7 });
+      await browse().handler({ action: 'get', audit_event_id: 7, group_id: 'g' });
+
+      const [url] = lastCall();
+      expect(url).toBe('https://gitlab.example.com/api/v4/groups/g/audit_events/7');
+    });
+
+    it('get with project_id reads a project audit event by id', async () => {
+      mockOk({ id: 7 });
+      await browse().handler({ action: 'get', audit_event_id: 7, project_id: '123' });
+
+      const [url] = lastCall();
+      expect(url).toBe('https://gitlab.example.com/api/v4/projects/123/audit_events/7');
+    });
+
+    it('coerces a string audit_event_id to a number', async () => {
+      mockOk({ id: 7 });
+      await browse().handler({ action: 'get', audit_event_id: '7' });
+
+      const [url] = lastCall();
+      expect(url).toBe('https://gitlab.example.com/api/v4/audit_events/7');
+    });
+
+    it('rejects get with both project_id and group_id', async () => {
+      await expect(
+        browse().handler({ action: 'get', audit_event_id: 7, project_id: '1', group_id: 'g' }),
+      ).rejects.toThrow();
+      expect(mockEnhancedFetch).not.toHaveBeenCalled();
+    });
+
+    it('rejects a malformed created_after that is not YYYY-MM-DD', async () => {
+      await expect(
+        browse().handler({ action: 'list_instance', created_after: '2026/01/01' }),
+      ).rejects.toThrow();
+      expect(mockEnhancedFetch).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds the read-only `browse_audit_events` tool so agents can inspect the immutable audit trail (who did what, when) at instance, group, and project scope.

- **browse_audit_events** (Query): `list_instance` (admin-only), `list_group`, `list_project`, `get`

There is intentionally no `manage_*` counterpart: audit events cannot be created or modified through the API.

## Implementation notes

- REST-backed (the documented audit-events API): `/audit_events`, `/groups/:id/audit_events`, `/projects/:id/audit_events`.
- The instance/group/project scopes fold in as actions, not separate tools. `get` infers the scope from `project_id` / `group_id` (neither => instance); a schema refine forbids passing both.
- `created_after` / `created_before` are validated as `YYYY-MM-DD`.
- Gated behind `USE_AUDIT_EVENTS`; Premium/Ultimate tier so the capability gate auto-hides the tool on lower-tier instances. `list_instance` additionally requires admin.
- Token-scope requirement (`api`/`read_api`) wired into `TokenScopeDetector`.

## Testing

- Unit: 12 tests covering every action, scope routing (instance/group/project), `audit_event_id` coercion, the mutual-exclusion guard, and the malformed-date rejection (REST `enhancedFetch` mocked).
- Integration: schema validation (always) + tier-gated (`describeIfTier('premium', ...)`) end-to-end project audit-trail list and a tolerant `list_instance` check.
- Full suite green: 5116 unit tests, 436 integration tests, clean build and lint.

Closes #439

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added audit event browsing capability for instance, group, and project levels
  * Supports date range filtering and individual event retrieval
  * Feature available for premium/ultimate tiers with appropriate API token scopes

* **Tests**
  * Added integration and unit test coverage for audit events functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->