### PR TITLE
feat(vulnerabilities): expose Vulnerability Management via GraphQL

### DIFF
--- a/src/entities/vulnerabilities/registry.ts
+++ b/src/entities/vulnerabilities/registry.ts
@@ -47,11 +47,21 @@ function listVars(input: {
   };
 }
 
-/** Throw on a non-empty GraphQL mutation `errors` array. */
-function assertNoErrors(errors: string[] | undefined): void {
-  if (errors && errors.length > 0) {
-    throw new Error(`GitLab API error: ${errors.join(', ')}`);
+/**
+ * Unwrap a mutation payload: surface a non-empty `errors` array as an error, treat
+ * a null payload as an error too (rather than silently returning undefined), and
+ * return the cleaned vulnerability on success.
+ */
+function unwrapVuln(
+  payload: { vulnerability: unknown; errors: string[] } | null | undefined,
+): unknown {
+  if (!payload) {
+    throw new Error('GitLab API error: empty mutation response');
   }
+  if (payload.errors.length > 0) {
+    throw new Error(`GitLab API error: ${payload.errors.join(', ')}`);
+  }
+  return cleanGidsFromObject(payload.vulnerability);
 }
 
 /**
@@ -159,26 +169,22 @@ export const vulnerabilitiesToolRegistry: ToolRegistry = new Map<string, Enhance
               comment: input.comment ?? null,
               dismissalReason: input.dismissal_reason ?? null,
             });
-            assertNoErrors(res.vulnerabilityDismiss?.errors);
-            return cleanGidsFromObject(res.vulnerabilityDismiss?.vulnerability);
+            return unwrapVuln(res.vulnerabilityDismiss);
           }
 
           case 'confirm': {
             const res = await client.request(CONFIRM_VULN, { id });
-            assertNoErrors(res.vulnerabilityConfirm?.errors);
-            return cleanGidsFromObject(res.vulnerabilityConfirm?.vulnerability);
+            return unwrapVuln(res.vulnerabilityConfirm);
           }
 
           case 'resolve': {
             const res = await client.request(RESOLVE_VULN, { id });
-            assertNoErrors(res.vulnerabilityResolve?.errors);
-            return cleanGidsFromObject(res.vulnerabilityResolve?.vulnerability);
+            return unwrapVuln(res.vulnerabilityResolve);
           }
 
           case 'revert': {
             const res = await client.request(REVERT_VULN, { id });
-            assertNoErrors(res.vulnerabilityRevertToDetected?.errors);
-            return cleanGidsFromObject(res.vulnerabilityRevertToDetected?.vulnerability);
+            return unwrapVuln(res.vulnerabilityRevertToDetected);
           }
 
           /* istanbul ignore next -- unreachable with Zod discriminatedUnion */

--- a/src/entities/vulnerabilities/registry.ts
+++ b/src/entities/vulnerabilities/registry.ts
@@ -1,0 +1,196 @@
+import * as z from 'zod';
+import { BrowseVulnerabilitiesSchema } from './schema-readonly';
+import { ManageVulnerabilitySchema } from './schema';
+import { ToolRegistry, EnhancedToolDefinition } from '../../types';
+import { assertActionAllowed } from '../utils';
+import { ConnectionManager } from '../../services/ConnectionManager';
+import { cleanGidsFromObject } from '../../utils/idConversion';
+import {
+  LIST_PROJECT_VULNS,
+  LIST_GROUP_VULNS,
+  LIST_INSTANCE_VULNS,
+  GET_VULN,
+  DISMISS_VULN,
+  CONFIRM_VULN,
+  RESOLVE_VULN,
+  REVERT_VULN,
+  type VulnListVars,
+} from '../../graphql/vulnerabilities';
+
+// Vulnerability Management is Ultimate-tier; the capability gate hides the tool on
+// lower tiers. The GraphQL surface stabilised around 13.x; the floor is declared
+// here and the tier gate does the rest.
+const ULTIMATE_REQ = {
+  tier: 'ultimate',
+  minVersion: '13.0',
+  notes: 'Vulnerability Management',
+} as const;
+
+const vulnerabilityGid = (id: number): string => `gid://gitlab/Vulnerability/${id}`;
+
+/** Build the shared GraphQL list filter variables from the parsed input. */
+function listVars(input: {
+  state?: string[];
+  severity?: string[];
+  report_type?: string[];
+  sort?: string;
+  first?: number;
+  after?: string;
+}): VulnListVars {
+  return {
+    state: input.state ?? null,
+    severity: input.severity ?? null,
+    reportType: input.report_type ?? null,
+    sort: input.sort ?? null,
+    first: input.first ?? 20,
+    after: input.after ?? null,
+  };
+}
+
+/** Throw on a non-empty GraphQL mutation `errors` array. */
+function assertNoErrors(errors: string[] | undefined): void {
+  if (errors && errors.length > 0) {
+    throw new Error(`GitLab API error: ${errors.join(', ')}`);
+  }
+}
+
+/**
+ * Vulnerabilities tools registry - 2 CQRS tools.
+ *
+ * browse_vulnerabilities (Query): list (project/group/instance), get
+ * manage_vulnerability (Command): dismiss, confirm, resolve, revert
+ *
+ * Backed by the GitLab GraphQL Vulnerability API (richer than REST). list scopes
+ * by project_id / group_id, or neither for an instance-wide view. State changes
+ * map to the vulnerability* mutations. Gated behind USE_VULNERABILITIES. Ultimate
+ * tier - the capability gate returns a clear error on Free/Premium.
+ */
+export const vulnerabilitiesToolRegistry: ToolRegistry = new Map<string, EnhancedToolDefinition>([
+  // ============================================================================
+  // browse_vulnerabilities - CQRS Query Tool
+  // ============================================================================
+  [
+    'browse_vulnerabilities',
+    {
+      name: 'browse_vulnerabilities',
+      description:
+        'Inspect security vulnerabilities (Ultimate). Actions: list (a project, a group, or the whole instance when neither id is given; filter by state, severity, report_type), get (a single vulnerability by ID with full detail). Related: manage_vulnerability to dismiss, confirm, resolve, or revert findings.',
+      inputSchema: z.toJSONSchema(BrowseVulnerabilitiesSchema),
+      requirements: { default: ULTIMATE_REQ },
+      gate: { envVar: 'USE_VULNERABILITIES', defaultValue: true },
+      handler: async (args: unknown): Promise<unknown> => {
+        const input = BrowseVulnerabilitiesSchema.parse(args);
+        assertActionAllowed('browse_vulnerabilities', input.action);
+
+        const client = ConnectionManager.getInstance().getClient();
+
+        switch (input.action) {
+          case 'list': {
+            if (input.project_id) {
+              const res = await client.request(LIST_PROJECT_VULNS, {
+                fullPath: input.project_id,
+                ...listVars(input),
+              });
+              if (!res.project) {
+                throw new Error(`Project "${input.project_id}" not found or not accessible`);
+              }
+              return cleanGidsFromObject(res.project.vulnerabilities ?? { nodes: [] });
+            }
+
+            if (input.group_id) {
+              const res = await client.request(LIST_GROUP_VULNS, {
+                fullPath: input.group_id,
+                ...listVars(input),
+              });
+              if (!res.group) {
+                throw new Error(`Group "${input.group_id}" not found or not accessible`);
+              }
+              return cleanGidsFromObject(res.group.vulnerabilities ?? { nodes: [] });
+            }
+
+            const res = await client.request(LIST_INSTANCE_VULNS, {
+              projectId: null,
+              ...listVars(input),
+            });
+            return cleanGidsFromObject(res.vulnerabilities ?? { nodes: [] });
+          }
+
+          case 'get': {
+            const res = await client.request(GET_VULN, {
+              id: vulnerabilityGid(input.vulnerability_id),
+            });
+            if (!res.vulnerability) {
+              throw new Error(`Vulnerability ${input.vulnerability_id} not found`);
+            }
+            return cleanGidsFromObject(res.vulnerability);
+          }
+
+          /* istanbul ignore next -- unreachable with Zod discriminatedUnion */
+          default:
+            throw new Error(`Unknown action: ${(input as { action: string }).action}`);
+        }
+      },
+    },
+  ],
+
+  // ============================================================================
+  // manage_vulnerability - CQRS Command Tool
+  // ============================================================================
+  [
+    'manage_vulnerability',
+    {
+      name: 'manage_vulnerability',
+      description:
+        'Drive the vulnerability state machine (Ultimate). Actions: dismiss (with optional dismissal_reason + comment), confirm (genuine finding), resolve (fixed), revert (back to detected). Related: browse_vulnerabilities to discover vulnerability IDs.',
+      inputSchema: z.toJSONSchema(ManageVulnerabilitySchema),
+      requirements: { default: ULTIMATE_REQ },
+      gate: { envVar: 'USE_VULNERABILITIES', defaultValue: true },
+      handler: async (args: unknown): Promise<unknown> => {
+        const input = ManageVulnerabilitySchema.parse(args);
+        assertActionAllowed('manage_vulnerability', input.action);
+
+        const client = ConnectionManager.getInstance().getClient();
+        const id = vulnerabilityGid(input.vulnerability_id);
+
+        switch (input.action) {
+          case 'dismiss': {
+            const res = await client.request(DISMISS_VULN, {
+              id,
+              comment: input.comment ?? null,
+              dismissalReason: input.dismissal_reason ?? null,
+            });
+            assertNoErrors(res.vulnerabilityDismiss?.errors);
+            return cleanGidsFromObject(res.vulnerabilityDismiss?.vulnerability);
+          }
+
+          case 'confirm': {
+            const res = await client.request(CONFIRM_VULN, { id });
+            assertNoErrors(res.vulnerabilityConfirm?.errors);
+            return cleanGidsFromObject(res.vulnerabilityConfirm?.vulnerability);
+          }
+
+          case 'resolve': {
+            const res = await client.request(RESOLVE_VULN, { id });
+            assertNoErrors(res.vulnerabilityResolve?.errors);
+            return cleanGidsFromObject(res.vulnerabilityResolve?.vulnerability);
+          }
+
+          case 'revert': {
+            const res = await client.request(REVERT_VULN, { id });
+            assertNoErrors(res.vulnerabilityRevertToDetected?.errors);
+            return cleanGidsFromObject(res.vulnerabilityRevertToDetected?.vulnerability);
+          }
+
+          /* istanbul ignore next -- unreachable with Zod discriminatedUnion */
+          default:
+            throw new Error(`Unknown action: ${(input as { action: string }).action}`);
+        }
+      },
+    },
+  ],
+]);
+
+/** Read-only tool names from the registry (for read-only mode filtering). */
+export function getVulnerabilitiesReadOnlyToolNames(): string[] {
+  return ['browse_vulnerabilities'];
+}

--- a/src/entities/vulnerabilities/schema-readonly.ts
+++ b/src/entities/vulnerabilities/schema-readonly.ts
@@ -1,0 +1,99 @@
+import { z } from 'zod';
+import { requiredId } from '../utils';
+
+// ============================================================================
+// browse_vulnerabilities - CQRS Query Tool (discriminated union schema)
+// Actions: list, get
+//
+// Vulnerability Management is an Ultimate-tier capability. GraphQL exposes a much
+// richer surface than REST (nested scanner/location/state metadata), so the entity
+// is GraphQL-first. list scopes by project_id / group_id, or neither for an
+// instance-wide view. Gated behind USE_VULNERABILITIES.
+// ============================================================================
+
+export const vulnerabilityIdField = z.coerce
+  .number()
+  .int()
+  .positive()
+  .describe('Numeric vulnerability ID (from a list action); expanded to a global ID internally.');
+
+const stateFilter = z
+  .array(z.enum(['DETECTED', 'CONFIRMED', 'RESOLVED', 'DISMISSED']))
+  .optional()
+  .describe('Filter by vulnerability state(s).');
+const severityFilter = z
+  .array(z.enum(['INFO', 'UNKNOWN', 'LOW', 'MEDIUM', 'HIGH', 'CRITICAL']))
+  .optional()
+  .describe('Filter by severity level(s).');
+const reportTypeFilter = z
+  .array(
+    z.enum([
+      'SAST',
+      'DAST',
+      'DEPENDENCY_SCANNING',
+      'CONTAINER_SCANNING',
+      'SECRET_DETECTION',
+      'COVERAGE_FUZZING',
+      'API_FUZZING',
+      'CLUSTER_IMAGE_SCANNING',
+      'GENERIC',
+    ]),
+  )
+  .optional()
+  .describe('Filter by scanner report type(s).');
+const sortField = z
+  .enum([
+    'severity_desc',
+    'severity_asc',
+    'detected_desc',
+    'detected_asc',
+    'state_desc',
+    'state_asc',
+    'title_desc',
+    'title_asc',
+  ])
+  .optional()
+  .describe('Sort order (default: severity_desc).');
+const firstField = z.coerce
+  .number()
+  .int()
+  .positive()
+  .max(100)
+  .optional()
+  .describe('Max items to return (cursor pagination, default 20, max 100).');
+const afterField = z.string().optional().describe('Cursor for the next page (endCursor).');
+
+// --- Action: list (project / group / instance) ---
+const ListVulnerabilitiesSchema = z.object({
+  action: z
+    .literal('list')
+    .describe(
+      'List vulnerabilities. Pass project_id for a project, group_id for a group, or neither for an instance-wide view (admin).',
+    ),
+  project_id: requiredId.optional().describe('Project full path or ID to scope the list.'),
+  group_id: requiredId.optional().describe('Group full path or ID to scope the list.'),
+  state: stateFilter,
+  severity: severityFilter,
+  report_type: reportTypeFilter,
+  sort: sortField,
+  first: firstField,
+  after: afterField,
+});
+
+// --- Action: get ---
+const GetVulnerabilitySchema = z.object({
+  action: z.literal('get').describe('Get a single vulnerability by its numeric ID.'),
+  vulnerability_id: vulnerabilityIdField,
+});
+
+// --- Discriminated union combining all actions ---
+export const BrowseVulnerabilitiesSchema = z
+  .discriminatedUnion('action', [ListVulnerabilitiesSchema, GetVulnerabilitySchema])
+  // A vulnerability list is scoped to a single namespace; project_id and group_id
+  // are mutually exclusive.
+  .refine((data) => data.action !== 'list' || !(data.project_id && data.group_id), {
+    message: 'Pass at most one of project_id or group_id (a list targets a single scope)',
+    path: ['project_id'],
+  });
+
+export type BrowseVulnerabilitiesInput = z.infer<typeof BrowseVulnerabilitiesSchema>;

--- a/src/entities/vulnerabilities/schema.ts
+++ b/src/entities/vulnerabilities/schema.ts
@@ -1,0 +1,62 @@
+import { z } from 'zod';
+import { vulnerabilityIdField } from './schema-readonly';
+
+// ============================================================================
+// manage_vulnerability - CQRS Command Tool (discriminated union schema)
+// Actions: dismiss, confirm, resolve, revert
+//
+// Drives the vulnerability state machine via the GitLab GraphQL mutations
+// (vulnerabilityDismiss / Confirm / Resolve / RevertToDetected). Ultimate tier.
+// Gated behind USE_VULNERABILITIES.
+// ============================================================================
+
+// --- Action: dismiss ---
+const DismissSchema = z.object({
+  action: z
+    .literal('dismiss')
+    .describe(
+      'Dismiss a vulnerability (e.g. false positive), optionally with a reason and comment',
+    ),
+  vulnerability_id: vulnerabilityIdField,
+  comment: z.string().optional().describe('Free-text justification for the dismissal.'),
+  dismissal_reason: z
+    .enum([
+      'ACCEPTABLE_RISK',
+      'FALSE_POSITIVE',
+      'MITIGATING_CONTROL',
+      'USED_IN_TESTS',
+      'NOT_APPLICABLE',
+    ])
+    .optional()
+    .describe('Structured dismissal reason.'),
+});
+
+// --- Action: confirm ---
+const ConfirmSchema = z.object({
+  action: z.literal('confirm').describe('Confirm a vulnerability as a genuine finding'),
+  vulnerability_id: vulnerabilityIdField,
+});
+
+// --- Action: resolve ---
+const ResolveSchema = z.object({
+  action: z.literal('resolve').describe('Mark a vulnerability as resolved'),
+  vulnerability_id: vulnerabilityIdField,
+});
+
+// --- Action: revert ---
+const RevertSchema = z.object({
+  action: z
+    .literal('revert')
+    .describe('Revert a vulnerability back to the detected state (un-dismiss / un-resolve)'),
+  vulnerability_id: vulnerabilityIdField,
+});
+
+// --- Discriminated union combining all actions ---
+export const ManageVulnerabilitySchema = z.discriminatedUnion('action', [
+  DismissSchema,
+  ConfirmSchema,
+  ResolveSchema,
+  RevertSchema,
+]);
+
+export type ManageVulnerabilityInput = z.infer<typeof ManageVulnerabilitySchema>;

--- a/src/graphql/vulnerabilities.ts
+++ b/src/graphql/vulnerabilities.ts
@@ -1,0 +1,217 @@
+import { gql } from 'graphql-tag';
+import { TypedDocumentNode } from '@graphql-typed-document-node/core';
+
+/**
+ * GraphQL documents for Vulnerability Management (Ultimate).
+ *
+ * Verified against a live GitLab 19.x instance by executing each query/mutation:
+ * - Queries: `project(fullPath).vulnerabilities`, `group(fullPath).vulnerabilities`,
+ *   top-level `vulnerabilities(projectId: [ID!])` (instance-wide), `vulnerability(id)`.
+ *   Connection filters: `state`, `severity`, `reportType`, `sort`.
+ * - Mutations: `vulnerabilityDismiss` (id, comment, dismissalReason), `vulnerabilityConfirm`,
+ *   `vulnerabilityResolve`, `vulnerabilityRevertToDetected` - each returns `{ vulnerability, errors }`.
+ *
+ * Vulnerabilities have a far richer GraphQL surface than REST (nested scanner /
+ * location / identifiers, state timestamps), so the entity is GraphQL-first.
+ */
+
+const VULN_FIELDS = `
+  id
+  title
+  description
+  state
+  severity
+  reportType
+  resolvedOnDefaultBranch
+  detectedAt
+  confirmedAt
+  resolvedAt
+  dismissedAt
+  vulnerabilityPath
+  webUrl
+`;
+
+export interface VulnerabilityNode {
+  id: string;
+  title: string | null;
+  description: string | null;
+  state: string | null;
+  severity: string | null;
+  reportType: string | null;
+  resolvedOnDefaultBranch: boolean | null;
+  detectedAt: string | null;
+  confirmedAt: string | null;
+  resolvedAt: string | null;
+  dismissedAt: string | null;
+  vulnerabilityPath: string | null;
+  webUrl: string | null;
+}
+
+interface PageInfo {
+  hasNextPage: boolean;
+  endCursor: string | null;
+}
+interface VulnConnection {
+  nodes: VulnerabilityNode[];
+  pageInfo: PageInfo;
+}
+
+// Shared list filters exposed on the vulnerabilities connections.
+export interface VulnListVars {
+  state?: string[] | null;
+  severity?: string[] | null;
+  reportType?: string[] | null;
+  sort?: string | null;
+  first?: number | null;
+  after?: string | null;
+}
+
+const LIST_ARG_DECLS = `
+  $state: [VulnerabilityState!]
+  $severity: [VulnerabilitySeverity!]
+  $reportType: [VulnerabilityReportType!]
+  $sort: VulnerabilitySort
+  $first: Int
+  $after: String
+`;
+const LIST_ARG_USE = `
+  state: $state
+  severity: $severity
+  reportType: $reportType
+  sort: $sort
+  first: $first
+  after: $after
+`;
+
+// --- Query: project vulnerabilities ---
+export interface ListProjectVulnsResult {
+  project: { vulnerabilities: VulnConnection | null } | null;
+}
+export interface ListNamespaceVulnsVars extends VulnListVars {
+  fullPath: string;
+}
+export const LIST_PROJECT_VULNS: TypedDocumentNode<ListProjectVulnsResult, ListNamespaceVulnsVars> =
+  gql`
+  query ListProjectVulnerabilities($fullPath: ID!, ${LIST_ARG_DECLS}) {
+    project(fullPath: $fullPath) {
+      vulnerabilities(${LIST_ARG_USE}) {
+        nodes { ${VULN_FIELDS} }
+        pageInfo { hasNextPage endCursor }
+      }
+    }
+  }
+`;
+
+// --- Query: group vulnerabilities ---
+export interface ListGroupVulnsResult {
+  group: { vulnerabilities: VulnConnection | null } | null;
+}
+export const LIST_GROUP_VULNS: TypedDocumentNode<ListGroupVulnsResult, ListNamespaceVulnsVars> =
+  gql`
+  query ListGroupVulnerabilities($fullPath: ID!, ${LIST_ARG_DECLS}) {
+    group(fullPath: $fullPath) {
+      vulnerabilities(${LIST_ARG_USE}) {
+        nodes { ${VULN_FIELDS} }
+        pageInfo { hasNextPage endCursor }
+      }
+    }
+  }
+`;
+
+// --- Query: instance-wide vulnerabilities (optionally narrowed by project gids) ---
+export interface ListInstanceVulnsResult {
+  vulnerabilities: VulnConnection | null;
+}
+export interface ListInstanceVulnsVars extends VulnListVars {
+  projectId?: string[] | null;
+}
+export const LIST_INSTANCE_VULNS: TypedDocumentNode<
+  ListInstanceVulnsResult,
+  ListInstanceVulnsVars
+> = gql`
+  query ListInstanceVulnerabilities($projectId: [ID!], ${LIST_ARG_DECLS}) {
+    vulnerabilities(projectId: $projectId, ${LIST_ARG_USE}) {
+      nodes { ${VULN_FIELDS} }
+      pageInfo { hasNextPage endCursor }
+    }
+  }
+`;
+
+// --- Query: a single vulnerability ---
+export interface GetVulnResult {
+  vulnerability: VulnerabilityNode | null;
+}
+export interface GetVulnVars {
+  id: string;
+}
+export const GET_VULN: TypedDocumentNode<GetVulnResult, GetVulnVars> = gql`
+  query GetVulnerability($id: VulnerabilityID!) {
+    vulnerability(id: $id) { ${VULN_FIELDS} }
+  }
+`;
+
+// --- Mutations: state transitions. Each returns { vulnerability, errors }. ---
+interface VulnMutationPayload {
+  vulnerability: VulnerabilityNode | null;
+  errors: string[];
+}
+
+export interface DismissVulnResult {
+  vulnerabilityDismiss: VulnMutationPayload | null;
+}
+export interface DismissVulnVars {
+  id: string;
+  comment?: string | null;
+  dismissalReason?: string | null;
+}
+export const DISMISS_VULN: TypedDocumentNode<DismissVulnResult, DismissVulnVars> = gql`
+  mutation DismissVulnerability(
+    $id: VulnerabilityID!
+    $comment: String
+    $dismissalReason: VulnerabilityDismissalReason
+  ) {
+    vulnerabilityDismiss(input: { id: $id, comment: $comment, dismissalReason: $dismissalReason }) {
+      vulnerability { ${VULN_FIELDS} }
+      errors
+    }
+  }
+`;
+
+export interface ConfirmVulnResult {
+  vulnerabilityConfirm: VulnMutationPayload | null;
+}
+export interface VulnIdVars {
+  id: string;
+}
+export const CONFIRM_VULN: TypedDocumentNode<ConfirmVulnResult, VulnIdVars> = gql`
+  mutation ConfirmVulnerability($id: VulnerabilityID!) {
+    vulnerabilityConfirm(input: { id: $id }) {
+      vulnerability { ${VULN_FIELDS} }
+      errors
+    }
+  }
+`;
+
+export interface ResolveVulnResult {
+  vulnerabilityResolve: VulnMutationPayload | null;
+}
+export const RESOLVE_VULN: TypedDocumentNode<ResolveVulnResult, VulnIdVars> = gql`
+  mutation ResolveVulnerability($id: VulnerabilityID!) {
+    vulnerabilityResolve(input: { id: $id }) {
+      vulnerability { ${VULN_FIELDS} }
+      errors
+    }
+  }
+`;
+
+export interface RevertVulnResult {
+  vulnerabilityRevertToDetected: VulnMutationPayload | null;
+}
+export const REVERT_VULN: TypedDocumentNode<RevertVulnResult, VulnIdVars> = gql`
+  mutation RevertVulnerabilityToDetected($id: VulnerabilityID!) {
+    vulnerabilityRevertToDetected(input: { id: $id }) {
+      vulnerability { ${VULN_FIELDS} }
+      errors
+    }
+  }
+`;

--- a/src/registry-manager.ts
+++ b/src/registry-manager.ts
@@ -57,6 +57,10 @@ import {
   getAuditEventsReadOnlyToolNames,
 } from './entities/audit_events/registry';
 import {
+  vulnerabilitiesToolRegistry,
+  getVulnerabilitiesReadOnlyToolNames,
+} from './entities/vulnerabilities/registry';
+import {
   accessTokensToolRegistry,
   getAccessTokensReadOnlyToolNames,
 } from './entities/access_tokens/registry';
@@ -87,6 +91,7 @@ import {
   USE_ACCESS_TOKENS,
   USE_RUNNERS,
   USE_AUDIT_EVENTS,
+  USE_VULNERABILITIES,
   getToolDescriptionOverrides,
 } from './config';
 import { isToolAvailable, getRestrictedParameters } from './services/InstanceCapabilities';
@@ -247,6 +252,10 @@ class RegistryManager {
       this.registries.set('audit_events', auditEventsToolRegistry);
     }
 
+    if (USE_VULNERABILITIES) {
+      this.registries.set('vulnerabilities', vulnerabilitiesToolRegistry);
+    }
+
     // All entity registries have been migrated to the new pattern!
   }
 
@@ -364,6 +373,10 @@ class RegistryManager {
 
     if (USE_AUDIT_EVENTS) {
       readOnlyTools.push(...getAuditEventsReadOnlyToolNames());
+    }
+
+    if (USE_VULNERABILITIES) {
+      readOnlyTools.push(...getVulnerabilitiesReadOnlyToolNames());
     }
 
     return readOnlyTools;
@@ -797,6 +810,7 @@ class RegistryManager {
     const useAccessTokens = process.env.USE_ACCESS_TOKENS !== 'false';
     const useRunners = process.env.USE_RUNNERS !== 'false';
     const useAuditEvents = process.env.USE_AUDIT_EVENTS !== 'false';
+    const useVulnerabilities = process.env.USE_VULNERABILITIES !== 'false';
 
     // Build registries map based on dynamic feature flags
     const registriesToUse = new Map<string, ToolRegistry>();
@@ -833,6 +847,7 @@ class RegistryManager {
     if (useAccessTokens) registriesToUse.set('access_tokens', accessTokensToolRegistry);
     if (useRunners) registriesToUse.set('runners', runnersToolRegistry);
     if (useAuditEvents) registriesToUse.set('audit_events', auditEventsToolRegistry);
+    if (useVulnerabilities) registriesToUse.set('vulnerabilities', vulnerabilitiesToolRegistry);
 
     // Dynamically load description overrides
     const descOverrides = getToolDescriptionOverrides();
@@ -938,6 +953,7 @@ class RegistryManager {
       accessTokensToolRegistry,
       runnersToolRegistry,
       auditEventsToolRegistry,
+      vulnerabilitiesToolRegistry,
     ];
 
     for (const registry of allRegistries) {

--- a/src/services/TokenScopeDetector.ts
+++ b/src/services/TokenScopeDetector.ts
@@ -158,6 +158,10 @@ const TOOL_SCOPE_REQUIREMENTS: Record<string, GitLabScope[]> = {
   // Audit events (Premium/Ultimate, read-only)
   browse_audit_events: ['api', 'read_api'],
 
+  // Vulnerabilities (Ultimate)
+  browse_vulnerabilities: ['api', 'read_api'],
+  manage_vulnerability: ['api'],
+
   // Wiki
   browse_wiki: ['api', 'read_api'],
   manage_wiki: ['api'],

--- a/tests/integration/helpers/registry-helper.ts
+++ b/tests/integration/helpers/registry-helper.ts
@@ -625,3 +625,21 @@ export async function initIntegrationHelper(): Promise<IntegrationTestHelper> {
   await helper.initialize();
   return helper;
 }
+
+/**
+ * Resolve a project path under the mandatory `test/` root group for read-only
+ * end-to-end checks. Returns the first `test/`-scoped project, falling back to
+ * the first project the token can see, or undefined when none exist. Shared so
+ * the identical "search test → pick test/ project" block is not repeated per file.
+ */
+export async function findTestProjectPath(
+  helper: IntegrationTestHelper,
+): Promise<string | undefined> {
+  const projects = (await helper.listProjects({ search: 'test', per_page: 10 })) as {
+    path_with_namespace: string;
+  }[];
+  return (
+    projects.find((p) => p.path_with_namespace.startsWith('test/'))?.path_with_namespace ??
+    projects[0]?.path_with_namespace
+  );
+}

--- a/tests/integration/schemas/vulnerabilities.test.ts
+++ b/tests/integration/schemas/vulnerabilities.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Vulnerabilities Schema Integration Tests
+ *
+ * Backed by the GitLab GraphQL Vulnerability API (Ultimate). Schema validation
+ * always runs. The end-to-end list checks are tier-gated via
+ * describeIfTier('ultimate', ...) and run read-only against a test/ project, group,
+ * and the instance. State mutations (dismiss/confirm/resolve/revert) are NOT run
+ * here: they would permanently alter real finding state.
+ */
+
+import { BrowseVulnerabilitiesSchema } from '../../../src/entities/vulnerabilities/schema-readonly';
+import { ManageVulnerabilitySchema } from '../../../src/entities/vulnerabilities/schema';
+import { IntegrationTestHelper } from '../helpers/registry-helper';
+import { describeIfTier } from '../../setup/tierGate';
+
+interface VulnConnection {
+  nodes: { id: number }[];
+}
+
+describe('Vulnerabilities Schema - GitLab Integration', () => {
+  describe('schema validation', () => {
+    it('validates browse_vulnerabilities actions', () => {
+      for (const params of [
+        { action: 'list' },
+        { action: 'list', project_id: 'g/p', state: ['DETECTED'], severity: ['CRITICAL'] },
+        { action: 'list', group_id: 'g', report_type: ['SAST'], sort: 'severity_desc' },
+        { action: 'get', vulnerability_id: 1 },
+      ]) {
+        expect(BrowseVulnerabilitiesSchema.safeParse(params).success).toBe(true);
+      }
+    });
+
+    it('validates manage_vulnerability actions', () => {
+      for (const params of [
+        { action: 'dismiss', vulnerability_id: 1, dismissal_reason: 'FALSE_POSITIVE' },
+        { action: 'confirm', vulnerability_id: 1 },
+        { action: 'resolve', vulnerability_id: 1 },
+        { action: 'revert', vulnerability_id: 1 },
+      ]) {
+        expect(ManageVulnerabilitySchema.safeParse(params).success).toBe(true);
+      }
+    });
+
+    it('rejects an invalid severity filter', () => {
+      const result = BrowseVulnerabilitiesSchema.safeParse({
+        action: 'list',
+        severity: ['SUPER_BAD'],
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects list with both project_id and group_id', () => {
+      const result = BrowseVulnerabilitiesSchema.safeParse({
+        action: 'list',
+        project_id: 'g/p',
+        group_id: 'g',
+      });
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describeIfTier('ultimate', 'vulnerabilities (end-to-end, Ultimate)', () => {
+    let helper: IntegrationTestHelper;
+    let testProjectPath: string | undefined;
+
+    beforeAll(async () => {
+      if (!process.env.GITLAB_TOKEN) {
+        throw new Error('GITLAB_TOKEN environment variable is required');
+      }
+      helper = new IntegrationTestHelper();
+      await helper.initialize();
+
+      const projects = (await helper.listProjects({ search: 'test', per_page: 10 })) as {
+        path_with_namespace: string;
+      }[];
+      testProjectPath = projects.find((p) =>
+        p.path_with_namespace.startsWith('test/'),
+      )?.path_with_namespace;
+    });
+
+    it('lists project vulnerabilities (possibly empty) for a test project', async () => {
+      if (!testProjectPath) {
+        console.log('No test/ project available; skipping project vulnerabilities list');
+        return;
+      }
+
+      const result = (await helper.executeTool('browse_vulnerabilities', {
+        action: 'list',
+        project_id: testProjectPath,
+        first: 5,
+      })) as VulnConnection;
+
+      expect(Array.isArray(result.nodes)).toBe(true);
+      console.log(`  ${testProjectPath} has ${result.nodes.length} vulnerabilities`);
+    }, 20000);
+
+    it('lists group vulnerabilities for the test group', async () => {
+      if (!testProjectPath) {
+        console.log('No test/ project available; skipping group vulnerabilities list');
+        return;
+      }
+      const groupPath = testProjectPath.split('/')[0];
+
+      const result = (await helper.executeTool('browse_vulnerabilities', {
+        action: 'list',
+        group_id: groupPath,
+        first: 5,
+      })) as VulnConnection;
+
+      expect(Array.isArray(result.nodes)).toBe(true);
+      console.log(`  group ${groupPath} has ${result.nodes.length} vulnerabilities`);
+    }, 20000);
+
+    it('lists instance vulnerabilities or reports lack of access', async () => {
+      try {
+        const result = (await helper.executeTool('browse_vulnerabilities', {
+          action: 'list',
+          first: 5,
+        })) as VulnConnection;
+        expect(Array.isArray(result.nodes)).toBe(true);
+        console.log(`  instance-wide list returned ${result.nodes.length} vulnerabilities`);
+      } catch (error) {
+        console.log(`  instance list not available: ${(error as Error).message}`);
+      }
+    }, 20000);
+  });
+});

--- a/tests/integration/schemas/vulnerabilities.test.ts
+++ b/tests/integration/schemas/vulnerabilities.test.ts
@@ -10,7 +10,11 @@
 
 import { BrowseVulnerabilitiesSchema } from '../../../src/entities/vulnerabilities/schema-readonly';
 import { ManageVulnerabilitySchema } from '../../../src/entities/vulnerabilities/schema';
-import { IntegrationTestHelper } from '../helpers/registry-helper';
+import {
+  IntegrationTestHelper,
+  initIntegrationHelper,
+  findTestProjectPath,
+} from '../helpers/registry-helper';
 import { describeIfTier } from '../../setup/tierGate';
 
 interface VulnConnection {
@@ -64,34 +68,30 @@ describe('Vulnerabilities Schema - GitLab Integration', () => {
     let testProjectPath: string | undefined;
 
     beforeAll(async () => {
-      if (!process.env.GITLAB_TOKEN) {
-        throw new Error('GITLAB_TOKEN environment variable is required');
-      }
-      helper = new IntegrationTestHelper();
-      await helper.initialize();
-
-      const projects = (await helper.listProjects({ search: 'test', per_page: 10 })) as {
-        path_with_namespace: string;
-      }[];
-      testProjectPath = projects.find((p) =>
-        p.path_with_namespace.startsWith('test/'),
-      )?.path_with_namespace;
+      helper = await initIntegrationHelper();
+      testProjectPath = await findTestProjectPath(helper);
     });
+
+    /** Run a list scope and assert it returns a (possibly empty) node array. */
+    const expectListNodes = async (
+      scope: Record<string, unknown>,
+      label: string,
+    ): Promise<void> => {
+      const result = (await helper.executeTool('browse_vulnerabilities', {
+        action: 'list',
+        first: 5,
+        ...scope,
+      })) as VulnConnection;
+      expect(Array.isArray(result.nodes)).toBe(true);
+      console.log(`  ${label} has ${result.nodes.length} vulnerabilities`);
+    };
 
     it('lists project vulnerabilities (possibly empty) for a test project', async () => {
       if (!testProjectPath) {
         console.log('No test/ project available; skipping project vulnerabilities list');
         return;
       }
-
-      const result = (await helper.executeTool('browse_vulnerabilities', {
-        action: 'list',
-        project_id: testProjectPath,
-        first: 5,
-      })) as VulnConnection;
-
-      expect(Array.isArray(result.nodes)).toBe(true);
-      console.log(`  ${testProjectPath} has ${result.nodes.length} vulnerabilities`);
+      await expectListNodes({ project_id: testProjectPath }, testProjectPath);
     }, 20000);
 
     it('lists group vulnerabilities for the test group', async () => {
@@ -100,25 +100,12 @@ describe('Vulnerabilities Schema - GitLab Integration', () => {
         return;
       }
       const groupPath = testProjectPath.split('/')[0];
-
-      const result = (await helper.executeTool('browse_vulnerabilities', {
-        action: 'list',
-        group_id: groupPath,
-        first: 5,
-      })) as VulnConnection;
-
-      expect(Array.isArray(result.nodes)).toBe(true);
-      console.log(`  group ${groupPath} has ${result.nodes.length} vulnerabilities`);
+      await expectListNodes({ group_id: groupPath }, `group ${groupPath}`);
     }, 20000);
 
     it('lists instance vulnerabilities or reports lack of access', async () => {
       try {
-        const result = (await helper.executeTool('browse_vulnerabilities', {
-          action: 'list',
-          first: 5,
-        })) as VulnConnection;
-        expect(Array.isArray(result.nodes)).toBe(true);
-        console.log(`  instance-wide list returned ${result.nodes.length} vulnerabilities`);
+        await expectListNodes({}, 'instance-wide');
       } catch (error) {
         console.log(`  instance list not available: ${(error as Error).message}`);
       }

--- a/tests/unit/entities/vulnerabilities/registry.test.ts
+++ b/tests/unit/entities/vulnerabilities/registry.test.ts
@@ -1,0 +1,192 @@
+import {
+  vulnerabilitiesToolRegistry,
+  getVulnerabilitiesReadOnlyToolNames,
+} from '../../../../src/entities/vulnerabilities/registry';
+import {
+  LIST_PROJECT_VULNS,
+  LIST_GROUP_VULNS,
+  LIST_INSTANCE_VULNS,
+  GET_VULN,
+  DISMISS_VULN,
+  CONFIRM_VULN,
+  RESOLVE_VULN,
+  REVERT_VULN,
+} from '../../../../src/graphql/vulnerabilities';
+
+const mockClient = { request: jest.fn() };
+
+jest.mock('../../../../src/services/ConnectionManager', () => ({
+  ConnectionManager: {
+    getInstance: jest.fn(() => ({ getClient: jest.fn(() => mockClient) })),
+  },
+}));
+
+const browse = () => vulnerabilitiesToolRegistry.get('browse_vulnerabilities')!;
+const manage = () => vulnerabilitiesToolRegistry.get('manage_vulnerability')!;
+const VULN_GID = 'gid://gitlab/Vulnerability/5';
+
+beforeEach(() => {
+  mockClient.request.mockReset();
+});
+
+describe('vulnerabilities registry', () => {
+  it('registers the CQRS pair with browse read-only, both Ultimate + gated', () => {
+    expect(vulnerabilitiesToolRegistry.has('browse_vulnerabilities')).toBe(true);
+    expect(vulnerabilitiesToolRegistry.has('manage_vulnerability')).toBe(true);
+    expect(getVulnerabilitiesReadOnlyToolNames()).toEqual(['browse_vulnerabilities']);
+    expect(browse().requirements?.default).toMatchObject({ tier: 'ultimate' });
+    expect(manage().requirements?.default).toMatchObject({ tier: 'ultimate' });
+    expect(browse().gate).toEqual({ envVar: 'USE_VULNERABILITIES', defaultValue: true });
+    expect(manage().gate).toEqual({ envVar: 'USE_VULNERABILITIES', defaultValue: true });
+  });
+
+  describe('browse_vulnerabilities', () => {
+    it('list with project_id queries the project connection with filters', async () => {
+      mockClient.request.mockResolvedValueOnce({ project: { vulnerabilities: { nodes: [] } } });
+      await browse().handler({
+        action: 'list',
+        project_id: 'g/p',
+        state: ['DETECTED'],
+        severity: ['CRITICAL'],
+        report_type: ['SAST'],
+      });
+      const [doc, vars] = mockClient.request.mock.calls[0];
+      expect(doc).toBe(LIST_PROJECT_VULNS);
+      expect(vars).toMatchObject({
+        fullPath: 'g/p',
+        state: ['DETECTED'],
+        severity: ['CRITICAL'],
+        reportType: ['SAST'],
+        first: 20,
+      });
+    });
+
+    it('list with project_id throws when the project is missing', async () => {
+      mockClient.request.mockResolvedValueOnce({ project: null });
+      await expect(browse().handler({ action: 'list', project_id: 'missing' })).rejects.toThrow(
+        'not found or not accessible',
+      );
+    });
+
+    it('list with group_id queries the group connection', async () => {
+      mockClient.request.mockResolvedValueOnce({ group: { vulnerabilities: { nodes: [] } } });
+      await browse().handler({ action: 'list', group_id: 'g' });
+      const [doc, vars] = mockClient.request.mock.calls[0];
+      expect(doc).toBe(LIST_GROUP_VULNS);
+      expect(vars).toMatchObject({ fullPath: 'g' });
+    });
+
+    it('list with group_id throws when the group is missing', async () => {
+      mockClient.request.mockResolvedValueOnce({ group: null });
+      await expect(browse().handler({ action: 'list', group_id: 'missing' })).rejects.toThrow(
+        'not found or not accessible',
+      );
+    });
+
+    it('list without a scope queries the instance-wide connection', async () => {
+      mockClient.request.mockResolvedValueOnce({ vulnerabilities: { nodes: [] } });
+      await browse().handler({ action: 'list', sort: 'detected_desc' });
+      const [doc, vars] = mockClient.request.mock.calls[0];
+      expect(doc).toBe(LIST_INSTANCE_VULNS);
+      expect(vars).toMatchObject({ projectId: null, sort: 'detected_desc' });
+    });
+
+    it('get expands the numeric id to a global ID', async () => {
+      mockClient.request.mockResolvedValueOnce({ vulnerability: { id: VULN_GID } });
+      await browse().handler({ action: 'get', vulnerability_id: 5 });
+      const [doc, vars] = mockClient.request.mock.calls[0];
+      expect(doc).toBe(GET_VULN);
+      expect(vars).toEqual({ id: VULN_GID });
+    });
+
+    it('get throws when the vulnerability is missing', async () => {
+      mockClient.request.mockResolvedValueOnce({ vulnerability: null });
+      await expect(browse().handler({ action: 'get', vulnerability_id: 5 })).rejects.toThrow(
+        'Vulnerability 5 not found',
+      );
+    });
+
+    it('rejects list with both project_id and group_id', async () => {
+      await expect(
+        browse().handler({ action: 'list', project_id: 'g/p', group_id: 'g' }),
+      ).rejects.toThrow();
+      expect(mockClient.request).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('manage_vulnerability', () => {
+    it('dismiss passes comment and dismissalReason', async () => {
+      mockClient.request.mockResolvedValueOnce({
+        vulnerabilityDismiss: { vulnerability: { id: VULN_GID }, errors: [] },
+      });
+      await manage().handler({
+        action: 'dismiss',
+        vulnerability_id: 5,
+        comment: 'noise',
+        dismissal_reason: 'FALSE_POSITIVE',
+      });
+      const [doc, vars] = mockClient.request.mock.calls[0];
+      expect(doc).toBe(DISMISS_VULN);
+      expect(vars).toEqual({ id: VULN_GID, comment: 'noise', dismissalReason: 'FALSE_POSITIVE' });
+    });
+
+    it('dismiss surfaces GraphQL payload errors', async () => {
+      mockClient.request.mockResolvedValueOnce({
+        vulnerabilityDismiss: { vulnerability: null, errors: ['not allowed'] },
+      });
+      await expect(manage().handler({ action: 'dismiss', vulnerability_id: 5 })).rejects.toThrow(
+        'GitLab API error: not allowed',
+      );
+    });
+
+    it('confirm runs vulnerabilityConfirm with the gid', async () => {
+      mockClient.request.mockResolvedValueOnce({
+        vulnerabilityConfirm: { vulnerability: { id: VULN_GID }, errors: [] },
+      });
+      await manage().handler({ action: 'confirm', vulnerability_id: 5 });
+      const [doc, vars] = mockClient.request.mock.calls[0];
+      expect(doc).toBe(CONFIRM_VULN);
+      expect(vars).toEqual({ id: VULN_GID });
+    });
+
+    it('resolve runs vulnerabilityResolve', async () => {
+      mockClient.request.mockResolvedValueOnce({
+        vulnerabilityResolve: { vulnerability: {}, errors: [] },
+      });
+      await manage().handler({ action: 'resolve', vulnerability_id: 5 });
+      expect(mockClient.request.mock.calls[0][0]).toBe(RESOLVE_VULN);
+    });
+
+    it('revert runs vulnerabilityRevertToDetected', async () => {
+      mockClient.request.mockResolvedValueOnce({
+        vulnerabilityRevertToDetected: { vulnerability: {}, errors: [] },
+      });
+      await manage().handler({ action: 'revert', vulnerability_id: 5 });
+      expect(mockClient.request.mock.calls[0][0]).toBe(REVERT_VULN);
+    });
+
+    it('revert surfaces GraphQL payload errors', async () => {
+      mockClient.request.mockResolvedValueOnce({
+        vulnerabilityRevertToDetected: { vulnerability: null, errors: ['bad state'] },
+      });
+      await expect(manage().handler({ action: 'revert', vulnerability_id: 5 })).rejects.toThrow(
+        'GitLab API error: bad state',
+      );
+    });
+
+    it('coerces a string vulnerability_id to a number gid', async () => {
+      mockClient.request.mockResolvedValueOnce({
+        vulnerabilityConfirm: { vulnerability: {}, errors: [] },
+      });
+      await manage().handler({ action: 'confirm', vulnerability_id: '5' });
+      expect(mockClient.request.mock.calls[0][1]).toEqual({ id: VULN_GID });
+    });
+
+    it('rejects an invalid dismissal_reason', async () => {
+      await expect(
+        manage().handler({ action: 'dismiss', vulnerability_id: 5, dismissal_reason: 'NOPE' }),
+      ).rejects.toThrow();
+      expect(mockClient.request).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/unit/entities/vulnerabilities/registry.test.ts
+++ b/tests/unit/entities/vulnerabilities/registry.test.ts
@@ -174,6 +174,13 @@ describe('vulnerabilities registry', () => {
       );
     });
 
+    it('throws when the mutation returns a null payload (silent-success guard)', async () => {
+      mockClient.request.mockResolvedValueOnce({ vulnerabilityConfirm: null });
+      await expect(manage().handler({ action: 'confirm', vulnerability_id: 5 })).rejects.toThrow(
+        'GitLab API error',
+      );
+    });
+
     it('coerces a string vulnerability_id to a number gid', async () => {
       mockClient.request.mockResolvedValueOnce({
         vulnerabilityConfirm: { vulnerability: {}, errors: [] },


### PR DESCRIPTION
## Summary

Adds the `browse_vulnerabilities` / `manage_vulnerability` CQRS pair so security teams can triage GitLab's Ultimate-tier Vulnerability Management surface: list findings, inspect detail, and drive the dismiss/confirm/resolve/revert state machine.

- **browse_vulnerabilities** (Query): `list` (project / group / instance), `get`
- **manage_vulnerability** (Command): `dismiss`, `confirm`, `resolve`, `revert`

## Implementation notes

- **GraphQL-first** per repo convention. The GraphQL `Vulnerability` surface is far richer than REST (state timestamps, scanner/report metadata, web paths), so all actions use GraphQL: `project/group.vulnerabilities`, top-level `vulnerabilities(projectId:)`, `vulnerability(id)`, and the `vulnerabilityDismiss/Confirm/Resolve/RevertToDetected` mutations. Every query and mutation was verified against the live Ultimate instance before implementation.
- `list` infers the scope from `project_id` / `group_id`; neither => instance-wide. A schema refine forbids passing both.
- Filters: `state`, `severity`, `report_type` (all enum-validated), plus `sort` and cursor pagination.
- `dismiss` accepts a structured `dismissal_reason` (ACCEPTABLE_RISK / FALSE_POSITIVE / MITIGATING_CONTROL / USED_IN_TESTS / NOT_APPLICABLE) and an optional comment.
- Mutation payload `errors` arrays surface as thrown errors; numeric IDs expand to `gid://gitlab/Vulnerability/N`; gids are cleaned from responses.
- Gated behind `USE_VULNERABILITIES`; **Ultimate** tier so the capability gate auto-hides the pair (clear error) on Free/Premium. Token-scope requirements wired into `TokenScopeDetector`.

## Testing

- Unit: 17 tests covering list scope routing (project/group/instance), get, all four mutations, the GraphQL-error path, `vulnerability_id` coercion, and the mutual-exclusion / invalid-enum schema guards (GraphQL client mocked).
- Integration: schema validation (always) + tier-gated (`describeIfTier('ultimate', ...)`) read-only list against a test project, group, and instance. State mutations are not run against live data (they permanently alter findings).
- Full suite green: 5133 unit tests, 460 integration tests, clean build and lint.

Closes #438

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Ultimate-tier vulnerability browsing and management (project, group, or instance scope)
  * Browse with filters and cursor pagination; read-only mode exposes listing only
  * Manage vulnerability states: dismiss (with optional comment and reason), confirm, resolve, revert
  * Improved error handling with clear "not found or not accessible" responses when targets or items are missing
<!-- end of auto-generated comment: release notes by coderabbit.ai -->