### PR TITLE
refactor(entities): thread request-context instanceUrl through handler call sites

### DIFF
--- a/src/entities/container_registry/registry.ts
+++ b/src/entities/container_registry/registry.ts
@@ -5,6 +5,7 @@ import { ToolRegistry, EnhancedToolDefinition } from '../../types';
 import { assertActionAllowed } from '../utils';
 import { ConnectionManager } from '../../services/ConnectionManager';
 import { cleanGidsFromObject } from '../../utils/idConversion';
+import { getGitLabApiUrlFromContext } from '../../oauth/token-context';
 import {
   LIST_CONTAINER_REPOSITORIES,
   GET_CONTAINER_REPOSITORY,
@@ -104,7 +105,7 @@ export const containerRegistryToolRegistry: ToolRegistry = new Map<string, Enhan
 
         assertActionAllowed('browse_registry', input.action);
 
-        const client = ConnectionManager.getInstance().getClient();
+        const client = ConnectionManager.getInstance().getClient(getGitLabApiUrlFromContext());
 
         switch (input.action) {
           case 'list_repositories': {
@@ -196,7 +197,7 @@ export const containerRegistryToolRegistry: ToolRegistry = new Map<string, Enhan
 
         assertActionAllowed('manage_registry', input.action);
 
-        const client = ConnectionManager.getInstance().getClient();
+        const client = ConnectionManager.getInstance().getClient(getGitLabApiUrlFromContext());
         const gid = repositoryGid(input.repository_id);
 
         switch (input.action) {

--- a/src/entities/context/whoami.ts
+++ b/src/entities/context/whoami.ts
@@ -19,6 +19,7 @@
 import { GITLAB_BASE_URL, GITLAB_READ_ONLY_MODE } from '../../config';
 import { logInfo, logDebug } from '../../logger';
 import { isOAuthEnabled } from '../../oauth/index.js';
+import { getGitLabApiUrlFromContext } from '../../oauth/token-context';
 import { ConnectionManager } from '../../services/ConnectionManager';
 import { getTokenCreationUrl } from '../../services/TokenScopeDetector';
 import { RegistryManager } from '../../registry-manager';
@@ -142,7 +143,7 @@ function buildServerInfo(): WhoamiServerInfo {
 
   try {
     const connectionManager = ConnectionManager.getInstance();
-    const instanceInfo = connectionManager.getInstanceInfo();
+    const instanceInfo = connectionManager.getInstanceInfo(getGitLabApiUrlFromContext());
     version = instanceInfo.version;
     tier = instanceInfo.tier;
   } catch {

--- a/src/entities/core/registry.ts
+++ b/src/entities/core/registry.ts
@@ -22,6 +22,7 @@ import { cleanGidsFromObject } from '../../utils/idConversion';
 import { ToolRegistry, EnhancedToolDefinition } from '../../types';
 import { assertActionAllowed } from '../utils';
 import { ConnectionManager } from '../../services/ConnectionManager';
+import { getGitLabApiUrlFromContext } from '../../oauth/token-context';
 import { parseVersion } from '../../utils/version';
 
 /**
@@ -188,7 +189,9 @@ export const coreToolRegistry: ToolRegistry = new Map<string, EnhancedToolDefini
             // read; an unknown version fails open to the native parameter.
             let activeFilterSupported = true;
             try {
-              const version = ConnectionManager.getInstance().getInstanceInfo().version;
+              const version = ConnectionManager.getInstance().getInstanceInfo(
+                getGitLabApiUrlFromContext(),
+              ).version;
               activeFilterSupported =
                 version === 'unknown' || parseVersion(version) >= parseVersion('18.5');
             } catch {
@@ -996,7 +999,9 @@ export const coreToolRegistry: ToolRegistry = new Map<string, EnhancedToolDefini
             // initialised) so we never block on a missing detection.
             let version = 'unknown';
             try {
-              version = ConnectionManager.getInstance().getInstanceInfo().version;
+              version = ConnectionManager.getInstance().getInstanceInfo(
+                getGitLabApiUrlFromContext(),
+              ).version;
             } catch {
               // Connection not initialised — leave version unknown (fail-open).
             }

--- a/src/entities/runners/registry.ts
+++ b/src/entities/runners/registry.ts
@@ -5,6 +5,7 @@ import { ToolRegistry, EnhancedToolDefinition } from '../../types';
 import { assertActionAllowed } from '../utils';
 import { ConnectionManager } from '../../services/ConnectionManager';
 import { cleanGidsFromObject } from '../../utils/idConversion';
+import { getGitLabApiUrlFromContext } from '../../oauth/token-context';
 import { gitlab } from '../../utils/gitlab-api';
 import {
   LIST_RUNNERS,
@@ -117,7 +118,7 @@ export const runnersToolRegistry: ToolRegistry = new Map<string, EnhancedToolDef
 
         assertActionAllowed('browse_runners', input.action);
 
-        const client = ConnectionManager.getInstance().getClient();
+        const client = ConnectionManager.getInstance().getClient(getGitLabApiUrlFromContext());
 
         switch (input.action) {
           case 'list_all': {
@@ -198,7 +199,7 @@ export const runnersToolRegistry: ToolRegistry = new Map<string, EnhancedToolDef
 
         assertActionAllowed('manage_runner', input.action);
 
-        const client = ConnectionManager.getInstance().getClient();
+        const client = ConnectionManager.getInstance().getClient(getGitLabApiUrlFromContext());
 
         switch (input.action) {
           case 'create_authentication_token': {

--- a/src/entities/vulnerabilities/registry.ts
+++ b/src/entities/vulnerabilities/registry.ts
@@ -5,6 +5,7 @@ import { ToolRegistry, EnhancedToolDefinition } from '../../types';
 import { assertActionAllowed } from '../utils';
 import { ConnectionManager } from '../../services/ConnectionManager';
 import { cleanGidsFromObject } from '../../utils/idConversion';
+import { getGitLabApiUrlFromContext } from '../../oauth/token-context';
 import {
   LIST_PROJECT_VULNS,
   LIST_GROUP_VULNS,
@@ -92,7 +93,7 @@ export const vulnerabilitiesToolRegistry: ToolRegistry = new Map<string, Enhance
         const input = BrowseVulnerabilitiesSchema.parse(args);
         assertActionAllowed('browse_vulnerabilities', input.action);
 
-        const client = ConnectionManager.getInstance().getClient();
+        const client = ConnectionManager.getInstance().getClient(getGitLabApiUrlFromContext());
 
         switch (input.action) {
           case 'list': {
@@ -159,7 +160,7 @@ export const vulnerabilitiesToolRegistry: ToolRegistry = new Map<string, Enhance
         const input = ManageVulnerabilitySchema.parse(args);
         assertActionAllowed('manage_vulnerability', input.action);
 
-        const client = ConnectionManager.getInstance().getClient();
+        const client = ConnectionManager.getInstance().getClient(getGitLabApiUrlFromContext());
         const id = vulnerabilityGid(input.vulnerability_id);
 
         switch (input.action) {

--- a/src/entities/workitems/registry.ts
+++ b/src/entities/workitems/registry.ts
@@ -12,6 +12,7 @@ import {
   type GitLabWorkItem,
 } from '../../utils/idConversion';
 import { WidgetAvailability } from '../../services/WidgetAvailability';
+import { getGitLabApiUrlFromContext } from '../../oauth/token-context';
 import {
   createVersionRestrictedError,
   normalizeTier,
@@ -294,7 +295,7 @@ export const workitemsToolRegistry: ToolRegistry = new Map<string, EnhancedToolD
 
             // Get GraphQL client from ConnectionManager
             const connectionManager = ConnectionManager.getInstance();
-            const client = connectionManager.getClient();
+            const client = connectionManager.getClient(getGitLabApiUrlFromContext());
 
             // For the work items GraphQL query, use type names as-is (GraphQL expects enum values)
             const resolvedTypes: string[] | undefined = types;
@@ -339,7 +340,7 @@ export const workitemsToolRegistry: ToolRegistry = new Map<string, EnhancedToolD
 
             // Get GraphQL client from ConnectionManager
             const connectionManager = ConnectionManager.getInstance();
-            const client = connectionManager.getClient();
+            const client = connectionManager.getClient(getGitLabApiUrlFromContext());
 
             // Route to appropriate query based on input
             if (namespace !== undefined && iid !== undefined) {
@@ -460,7 +461,10 @@ export const workitemsToolRegistry: ToolRegistry = new Map<string, EnhancedToolD
             if (labelIds && labelIds.length > 0) {
               widgetParams.labelIds = labelIds;
             }
-            const validationFailure = WidgetAvailability.validateWidgetParams(widgetParams);
+            const validationFailure = WidgetAvailability.validateWidgetParams(
+              widgetParams,
+              getGitLabApiUrlFromContext(),
+            );
             if (validationFailure) {
               throw new StructuredToolError(
                 createVersionRestrictedError(
@@ -478,7 +482,7 @@ export const workitemsToolRegistry: ToolRegistry = new Map<string, EnhancedToolD
 
             // Get GraphQL client from ConnectionManager
             const connectionManager = ConnectionManager.getInstance();
-            const client = connectionManager.getClient();
+            const client = connectionManager.getClient(getGitLabApiUrlFromContext());
 
             // Convert simple type name to work item type GID
             const workItemTypes = await getWorkItemTypes(namespacePath);
@@ -751,7 +755,10 @@ export const workitemsToolRegistry: ToolRegistry = new Map<string, EnhancedToolD
               linkType,
               targetId,
             };
-            const validationFailure = WidgetAvailability.validateWidgetParams(widgetParams);
+            const validationFailure = WidgetAvailability.validateWidgetParams(
+              widgetParams,
+              getGitLabApiUrlFromContext(),
+            );
             if (validationFailure) {
               throw new StructuredToolError(
                 createVersionRestrictedError(
@@ -769,7 +776,7 @@ export const workitemsToolRegistry: ToolRegistry = new Map<string, EnhancedToolD
 
             // Get GraphQL client from ConnectionManager
             const connectionManager = ConnectionManager.getInstance();
-            const client = connectionManager.getClient();
+            const client = connectionManager.getClient(getGitLabApiUrlFromContext());
 
             // Convert simple ID to GID for API call
             const workItemGid = toGid(workItemId, 'WorkItem');
@@ -1042,7 +1049,7 @@ export const workitemsToolRegistry: ToolRegistry = new Map<string, EnhancedToolD
 
             // Get GraphQL client from ConnectionManager
             const connectionManager = ConnectionManager.getInstance();
-            const client = connectionManager.getClient();
+            const client = connectionManager.getClient(getGitLabApiUrlFromContext());
 
             // Convert simple ID to GID for API call
             const workItemGid = toGid(workItemId, 'WorkItem');
@@ -1067,7 +1074,7 @@ export const workitemsToolRegistry: ToolRegistry = new Map<string, EnhancedToolD
             const { timelogId } = input;
 
             const connectionManager = ConnectionManager.getInstance();
-            const client = connectionManager.getClient();
+            const client = connectionManager.getClient(getGitLabApiUrlFromContext());
 
             // Ensure the timelog ID is a valid GID
             const timelogGid = toGid(timelogId, 'Timelog');
@@ -1091,7 +1098,7 @@ export const workitemsToolRegistry: ToolRegistry = new Map<string, EnhancedToolD
             const { id, targetId, linkType } = input;
 
             const connectionManager = ConnectionManager.getInstance();
-            const client = connectionManager.getClient();
+            const client = connectionManager.getClient(getGitLabApiUrlFromContext());
 
             const response = await client.request(WORK_ITEM_ADD_LINKED_ITEMS, {
               input: {
@@ -1123,7 +1130,7 @@ export const workitemsToolRegistry: ToolRegistry = new Map<string, EnhancedToolD
             const { id, targetId } = input;
 
             const connectionManager = ConnectionManager.getInstance();
-            const client = connectionManager.getClient();
+            const client = connectionManager.getClient(getGitLabApiUrlFromContext());
 
             // Note: GitLab API does NOT accept linkType for remove operation
             // Links are identified by source+target IDs only

--- a/tests/unit/entities/vulnerabilities/registry.test.ts
+++ b/tests/unit/entities/vulnerabilities/registry.test.ts
@@ -14,11 +14,17 @@ import {
 } from '../../../../src/graphql/vulnerabilities';
 
 const mockClient = { request: jest.fn() };
+const mockGetClient = jest.fn(() => mockClient);
 
 jest.mock('../../../../src/services/ConnectionManager', () => ({
   ConnectionManager: {
-    getInstance: jest.fn(() => ({ getClient: jest.fn(() => mockClient) })),
+    getInstance: jest.fn(() => ({ getClient: mockGetClient })),
   },
+}));
+
+const mockApiUrlFromContext = jest.fn<string | undefined, []>(() => undefined);
+jest.mock('../../../../src/oauth/token-context', () => ({
+  getGitLabApiUrlFromContext: () => mockApiUrlFromContext(),
 }));
 
 const browse = () => vulnerabilitiesToolRegistry.get('browse_vulnerabilities')!;
@@ -27,6 +33,9 @@ const VULN_GID = 'gid://gitlab/Vulnerability/5';
 
 beforeEach(() => {
   mockClient.request.mockReset();
+  mockGetClient.mockClear();
+  mockApiUrlFromContext.mockReset();
+  mockApiUrlFromContext.mockReturnValue(undefined);
 });
 
 describe('vulnerabilities registry', () => {
@@ -38,6 +47,13 @@ describe('vulnerabilities registry', () => {
     expect(manage().requirements?.default).toMatchObject({ tier: 'ultimate' });
     expect(browse().gate).toEqual({ envVar: 'USE_VULNERABILITIES', defaultValue: true });
     expect(manage().gate).toEqual({ envVar: 'USE_VULNERABILITIES', defaultValue: true });
+  });
+
+  it('threads the request-context instance URL into getClient (no cross-request leak)', async () => {
+    mockApiUrlFromContext.mockReturnValue('https://gitlab.example.com');
+    mockClient.request.mockResolvedValueOnce({ vulnerabilities: { nodes: [] } });
+    await browse().handler({ action: 'list' });
+    expect(mockGetClient).toHaveBeenCalledWith('https://gitlab.example.com');
   });
 
   describe('browse_vulnerabilities', () => {


### PR DESCRIPTION
## Summary

Threads the per-request GitLab URL from `getGitLabApiUrlFromContext()` into every entity-handler call that previously relied on the shared `ConnectionManager.currentInstanceUrl` fallback. Under concurrent OAuth traffic, a bare `getClient()` / `getInstanceInfo()` could read another request's tier/version; passing the request-scoped URL removes that cross-request leak.

## Changes

- **workitems**: 8 `getClient()` calls + 2 `WidgetAvailability.validateWidgetParams()` calls now receive the context URL.
- **container_registry / runners / vulnerabilities**: GraphQL client construction threads the context URL.
- **whoami / core**: `getInstanceInfo()` version+tier reads pass the context URL.
- Audit: zero remaining bare `getClient()` / `getInstanceInfo()` calls in `src/entities/`.

`getClient`/`getInstanceInfo`/`validateWidgetParams` already accept an optional `instanceUrl`; this PR only supplies it at the call sites (no signature changes). In static (non-OAuth) mode `getGitLabApiUrlFromContext()` returns `undefined`, so the default-instance behaviour is unchanged.

## Testing

- Added a unit test asserting the handler threads the request-context URL into `getClient` (regression guard against re-introducing a bare call).
- Full suite green: 5135 unit tests, 443 integration tests, clean build and lint.

Closes #397