### PR TITLE
feat(pipelines)!: fold manage_pipeline_job into manage_pipeline

### DIFF
--- a/docs/prompts/ci-cd/debug-failure.md
+++ b/docs/prompts/ci-cd/debug-failure.md
@@ -152,9 +152,9 @@ Look for:
 ```
 
 ```jsonc [Retry single job]
-// manage_pipeline_job
+// manage_pipeline
 {
-  "action": "retry",
+  "action": "retry_job",
   "project_id": "my-org/api",
   "job_id": "5678"
 }

--- a/docs/public/llms.txt.in
+++ b/docs/public/llms.txt.in
@@ -27,8 +27,7 @@ Optional: GITLAB_API_URL (defaults to https://gitlab.com)
 
 ## CI/CD (Pipelines)
 - browse_pipelines: List pipelines, get details, list jobs, get job details, read job logs.
-- manage_pipeline: Create (trigger), retry, cancel pipelines.
-- manage_pipeline_job: Play manual jobs, retry, cancel individual jobs.
+- manage_pipeline: Create (trigger), retry, cancel pipelines; play_job, retry_job, cancel_job for individual jobs.
 
 ## CI/CD (Variables)
 - browse_variables: List and get CI/CD variables for projects/groups.

--- a/docs/tools/ci-cd.md
+++ b/docs/tools/ci-cd.md
@@ -16,8 +16,7 @@ Pipeline management, job control, logs, and CI/CD variable configuration.
 | Tool | Type | Purpose |
 |------|------|---------|
 | `browse_pipelines` | Query | List pipelines, jobs, view logs |
-| `manage_pipeline` | Command | Trigger, retry, cancel pipelines |
-| `manage_pipeline_job` | Command | Play, retry, cancel individual jobs |
+| `manage_pipeline` | Command | Trigger/retry/cancel pipelines; play/retry/cancel individual jobs |
 | `browse_variables` | Query | List and get CI/CD variables |
 | `manage_variable` | Command | Create, update, delete variables |
 | `browse_environments` | Query | List environments and deployments |
@@ -104,6 +103,9 @@ Trigger and control pipeline execution.
 | `create` | Trigger a new pipeline on branch/tag |
 | `retry` | Re-run a failed/canceled pipeline |
 | `cancel` | Stop a running pipeline |
+| `play_job` | Trigger a manual job |
+| `retry_job` | Re-run a failed/canceled job |
+| `cancel_job` | Stop a running job |
 <!-- @autogen:end -->
 
 ### Examples
@@ -150,6 +152,33 @@ Trigger and control pipeline execution.
 }
 ```
 
+```json [Play manual job]
+{
+  "action": "play_job",
+  "project_id": "my-org/api",
+  "job_id": "5678",
+  "job_variables_attributes": [
+    { "key": "TARGET", "value": "production" }
+  ]
+}
+```
+
+```json [Retry job]
+{
+  "action": "retry_job",
+  "project_id": "my-org/api",
+  "job_id": "5678"
+}
+```
+
+```json [Cancel job]
+{
+  "action": "cancel_job",
+  "project_id": "my-org/api",
+  "job_id": "5678"
+}
+```
+
 :::
 
 ### Pipeline Inputs (GitLab 15.5+)
@@ -191,53 +220,6 @@ Trigger with inputs:
 - **`inputs`**: Typed parameters with schema validation (requires GitLab 15.5+)
 
 You can use both in the same request if needed.
-:::
-
-## manage_pipeline_job
-
-Control individual jobs within a pipeline.
-
-### Actions
-
-<!-- @autogen:tool manage_pipeline_job -->
-| Action | Description |
-|--------|-------------|
-| `play` | Trigger a manual job |
-| `retry` | Re-run a failed/canceled job |
-| `cancel` | Stop a running job |
-<!-- @autogen:end -->
-
-### Examples
-
-::: code-group
-
-```json [Play manual job]
-{
-  "action": "play",
-  "project_id": "my-org/api",
-  "job_id": "5678",
-  "job_variables_attributes": [
-    { "key": "TARGET", "value": "production" }
-  ]
-}
-```
-
-```json [Retry job]
-{
-  "action": "retry",
-  "project_id": "my-org/api",
-  "job_id": "5678"
-}
-```
-
-```json [Cancel job]
-{
-  "action": "cancel",
-  "project_id": "my-org/api",
-  "job_id": "5678"
-}
-```
-
 :::
 
 ## browse_variables / manage_variable

--- a/docs/tools/index.md.in
+++ b/docs/tools/index.md.in
@@ -147,8 +147,7 @@ Each tool accepts an `action` parameter selecting the specific operation.
 | Tool | Type | Description |
 |------|------|-------------|
 | `browse_pipelines` | Query | List pipelines, jobs, logs |
-| `manage_pipeline` | Command | Create, retry, cancel pipelines |
-| `manage_pipeline_job` | Command | Play, retry, cancel jobs |
+| `manage_pipeline` | Command | Create, retry, cancel pipelines; play, retry, cancel jobs |
 
 ## Tools by Use-Case
 
@@ -170,7 +169,6 @@ Which tools matter most for each role:
 | `manage_mr_discussion` | ★★★ | — | ★★★ | — |
 | `browse_pipelines` | ★★ | ★★★ | ★ | — |
 | `manage_pipeline` | ★ | ★★★ | — | — |
-| `manage_pipeline_job` | ★ | ★★★ | — | — |
 | `browse_variables` | ★ | ★★★ | — | — |
 | `manage_variable` | — | ★★★ | — | — |
 | `browse_files` | ★★★ | ★ | ★ | — |
@@ -205,7 +203,7 @@ See [role-based prompts](/prompts/by-role/developer) for workflows tailored to e
 | **Merge Requests** | `browse_merge_requests` (list, get, diffs, compare) | `manage_merge_request` (create, update, merge, approve) |
 | **Discussions** | `browse_mr_discussions` (list, drafts, draft) | `manage_mr_discussion` (comment, thread, suggest, resolve) |
 | **Pipelines** | `browse_pipelines` (list, get, jobs, logs) | `manage_pipeline` (create, retry, cancel) |
-| **Jobs** | — (via browse_pipelines) | `manage_pipeline_job` (play, retry, cancel) |
+| **Jobs** | — (via browse_pipelines) | `manage_pipeline` (play_job, retry_job, cancel_job) |
 | **Variables** | `browse_variables` (list, get) | `manage_variable` (create, update, delete) |
 | **Files** | `browse_files` (tree, content, download_attachment) | `manage_files` (single, batch, upload) |
 | **Work Items** | `browse_work_items` (list, get) | `manage_work_item` (create, update, delete) |

--- a/src/cli/list-tools.ts
+++ b/src/cli/list-tools.ts
@@ -381,13 +381,7 @@ const ENTITY_TOOLS: Record<string, string[]> = {
     'manage_label',
     'browse_iterations',
   ],
-  'CI/CD': [
-    'browse_pipelines',
-    'manage_pipeline',
-    'manage_pipeline_job',
-    'browse_variables',
-    'manage_variable',
-  ],
+  'CI/CD': ['browse_pipelines', 'manage_pipeline', 'browse_variables', 'manage_variable'],
   'Integrations & Content': [
     'browse_wiki',
     'manage_wiki',
@@ -1023,7 +1017,7 @@ function printEnvGatesMarkdown(
 const FEATURE_TO_TOOLS: Record<string, string[]> = {
   wiki: ['browse_wiki', 'manage_wiki'],
   milestones: ['browse_milestones', 'manage_milestone'],
-  pipelines: ['browse_pipelines', 'manage_pipeline', 'manage_pipeline_job'],
+  pipelines: ['browse_pipelines', 'manage_pipeline'],
   labels: ['browse_labels', 'manage_label'],
   mrs: [
     'browse_merge_requests',

--- a/src/cli/setup/presets.ts
+++ b/src/cli/setup/presets.ts
@@ -46,7 +46,7 @@ export const TOOL_CATEGORIES: ToolCategory[] = [
     id: 'pipelines',
     name: 'Pipelines & CI/CD',
     description: 'Pipeline browsing, job management, triggers',
-    tools: ['browse_pipelines', 'manage_pipeline', 'manage_pipeline_job'],
+    tools: ['browse_pipelines', 'manage_pipeline'],
     defaultEnabled: true,
   },
   {

--- a/src/entities/pipelines/registry.ts
+++ b/src/entities/pipelines/registry.ts
@@ -1,6 +1,6 @@
 import * as z from 'zod';
 import { BrowsePipelinesSchema } from './schema-readonly';
-import { ManagePipelineSchema, ManagePipelineJobSchema } from './schema';
+import { ManagePipelineSchema } from './schema';
 import { gitlab, toQuery } from '../../utils/gitlab-api';
 import { normalizeProjectId } from '../../utils/projectIdentifier';
 import { enhancedFetch } from '../../utils/fetch';
@@ -9,11 +9,10 @@ import { ToolRegistry, EnhancedToolDefinition } from '../../types';
 import { assertActionAllowed } from '../utils';
 
 /**
- * Pipelines tools registry - 3 CQRS tools replacing 12 individual tools
+ * Pipelines tools registry - 2 CQRS tools replacing 12 individual tools
  *
  * browse_pipelines (Query): list, get, jobs, triggers, job, logs
- * manage_pipeline (Command): create, retry, cancel
- * manage_pipeline_job (Command): play, retry, cancel
+ * manage_pipeline (Command): create, retry, cancel, play_job, retry_job, cancel_job
  */
 export const pipelinesToolRegistry: ToolRegistry = new Map<string, EnhancedToolDefinition>([
   // ============================================================================
@@ -25,7 +24,7 @@ export const pipelinesToolRegistry: ToolRegistry = new Map<string, EnhancedToolD
     {
       name: 'browse_pipelines',
       description:
-        'Monitor CI/CD pipelines and read job logs. Actions: list (filter by status/ref/source/username), get (pipeline details), jobs (list pipeline jobs), triggers (bridge/trigger jobs), job (single job details), logs (job console output). Related: manage_pipeline to trigger/retry/cancel, manage_pipeline_job for individual jobs.',
+        'Monitor CI/CD pipelines and read job logs. Actions: list (filter by status/ref/source/username), get (pipeline details), jobs (list pipeline jobs), triggers (bridge/trigger jobs), job (single job details), logs (job console output). Related: manage_pipeline to trigger/retry/cancel pipelines and play/retry/cancel individual jobs.',
       inputSchema: z.toJSONSchema(BrowsePipelinesSchema),
       requirements: { default: { tier: 'free', minVersion: '9.0' } },
       gate: { envVar: 'USE_PIPELINE', defaultValue: true },
@@ -190,7 +189,7 @@ export const pipelinesToolRegistry: ToolRegistry = new Map<string, EnhancedToolD
     {
       name: 'manage_pipeline',
       description:
-        'Trigger, retry, or cancel CI/CD pipelines. Actions: create (run pipeline on ref with variables or typed inputs), retry (re-run failed jobs), cancel (stop running pipeline). Related: browse_pipelines for monitoring.',
+        "Trigger, retry, or cancel CI/CD pipelines and individual jobs. Pipeline actions: create (run pipeline on ref with variables or typed inputs), retry (re-run failed jobs), cancel (stop running pipeline). Job actions: play_job (trigger a manual/delayed job with variables), retry_job (re-run a single job), cancel_job (stop a running job). Related: browse_pipelines actions 'job'/'logs' for job details.",
       inputSchema: z.toJSONSchema(ManagePipelineSchema),
       requirements: { default: { tier: 'free', minVersion: '9.0' } },
       gate: { envVar: 'USE_PIPELINE', defaultValue: true },
@@ -297,34 +296,7 @@ export const pipelinesToolRegistry: ToolRegistry = new Map<string, EnhancedToolD
             );
           }
 
-          /* istanbul ignore next -- unreachable with Zod discriminatedUnion */
-          default:
-            throw new Error(`Unknown action: ${(input as { action: string }).action}`);
-        }
-      },
-    },
-  ],
-
-  // ============================================================================
-  // manage_pipeline_job - CQRS Command Tool (discriminated union schema)
-  // TypeScript automatically narrows types in each switch case
-  // ============================================================================
-  [
-    'manage_pipeline_job',
-    {
-      name: 'manage_pipeline_job',
-      description:
-        "Control individual CI/CD jobs within a pipeline. Actions: play (trigger manual/delayed job with variables), retry (re-run single job), cancel (stop running job). Related: browse_pipelines actions 'job'/'logs' for job details.",
-      inputSchema: z.toJSONSchema(ManagePipelineJobSchema),
-      requirements: { default: { tier: 'free', minVersion: '9.0' } },
-      gate: { envVar: 'USE_PIPELINE', defaultValue: true },
-      handler: async (args: unknown): Promise<unknown> => {
-        const input = ManagePipelineJobSchema.parse(args);
-
-        assertActionAllowed('manage_pipeline_job', input.action);
-
-        switch (input.action) {
-          case 'play': {
+          case 'play_job': {
             // TypeScript knows: input has job_id (required), job_variables_attributes (optional)
             const { project_id, job_id, job_variables_attributes } = input;
             const body: Record<string, unknown> = {};
@@ -337,13 +309,13 @@ export const pipelinesToolRegistry: ToolRegistry = new Map<string, EnhancedToolD
             });
           }
 
-          case 'retry': {
+          case 'retry_job': {
             // TypeScript knows: input has job_id (required)
             const { project_id, job_id } = input;
             return gitlab.post(`projects/${normalizeProjectId(project_id)}/jobs/${job_id}/retry`);
           }
 
-          case 'cancel': {
+          case 'cancel_job': {
             // TypeScript knows: input has job_id (required), force (optional)
             const { project_id, job_id, force } = input;
             const query = force ? { force: 'true' } : undefined;

--- a/src/entities/pipelines/schema.ts
+++ b/src/entities/pipelines/schema.ts
@@ -21,7 +21,9 @@ const PipelineInputValueSchema = z
 
 // ============================================================================
 // manage_pipeline - CQRS Command Tool (discriminated union schema)
-// Actions: create, retry, cancel
+// Pipeline-level actions: create, retry, cancel
+// Job-level actions: play_job, retry_job, cancel_job (folded in; the _job suffix
+// avoids colliding with the pipeline-level retry/cancel).
 // Uses z.discriminatedUnion() for type-safe action handling.
 // Schema pipeline flattens to flat JSON Schema for AI clients that don't support oneOf.
 // ============================================================================
@@ -29,6 +31,7 @@ const PipelineInputValueSchema = z
 // --- Shared fields ---
 const projectIdField = requiredId.describe('Project ID or URL-encoded path');
 const pipelineIdField = requiredId.describe('The ID of the pipeline');
+const jobIdField = requiredId.describe('The ID of the job');
 
 // --- Action: create ---
 const CreatePipelineSchema = z.object({
@@ -61,26 +64,9 @@ const CancelPipelineSchema = z.object({
   pipeline_id: pipelineIdField,
 });
 
-// --- Discriminated union combining all actions ---
-export const ManagePipelineSchema = z.discriminatedUnion('action', [
-  CreatePipelineSchema,
-  RetryPipelineSchema,
-  CancelPipelineSchema,
-]);
-
-// ============================================================================
-// manage_pipeline_job - CQRS Command Tool (discriminated union schema)
-// Actions: play, retry, cancel
-// Uses z.discriminatedUnion() for type-safe action handling.
-// Schema pipeline flattens to flat JSON Schema for AI clients that don't support oneOf.
-// ============================================================================
-
-// --- Shared fields ---
-const jobIdField = requiredId.describe('The ID of the job');
-
-// --- Action: play ---
+// --- Action: play_job ---
 const PlayJobSchema = z.object({
-  action: z.literal('play').describe('Trigger a manual job'),
+  action: z.literal('play_job').describe('Trigger a manual job'),
   project_id: projectIdField,
   job_id: jobIdField,
   job_variables_attributes: z
@@ -89,23 +75,26 @@ const PlayJobSchema = z.object({
     .describe('Variables to pass to the job'),
 });
 
-// --- Action: retry ---
+// --- Action: retry_job ---
 const RetryJobSchema = z.object({
-  action: z.literal('retry').describe('Re-run a failed/canceled job'),
+  action: z.literal('retry_job').describe('Re-run a failed/canceled job'),
   project_id: projectIdField,
   job_id: jobIdField,
 });
 
-// --- Action: cancel ---
+// --- Action: cancel_job ---
 const CancelJobSchema = z.object({
-  action: z.literal('cancel').describe('Stop a running job'),
+  action: z.literal('cancel_job').describe('Stop a running job'),
   project_id: projectIdField,
   job_id: jobIdField,
   force: z.boolean().optional().describe('Force cancellation of the job'),
 });
 
-// --- Discriminated union combining all actions ---
-export const ManagePipelineJobSchema = z.discriminatedUnion('action', [
+// --- Discriminated union combining all pipeline + job actions ---
+export const ManagePipelineSchema = z.discriminatedUnion('action', [
+  CreatePipelineSchema,
+  RetryPipelineSchema,
+  CancelPipelineSchema,
   PlayJobSchema,
   RetryJobSchema,
   CancelJobSchema,
@@ -116,4 +105,3 @@ export const ManagePipelineJobSchema = z.discriminatedUnion('action', [
 // ============================================================================
 
 export type ManagePipelineInput = z.infer<typeof ManagePipelineSchema>;
-export type ManagePipelineJobInput = z.infer<typeof ManagePipelineJobSchema>;

--- a/src/services/TokenScopeDetector.ts
+++ b/src/services/TokenScopeDetector.ts
@@ -125,7 +125,6 @@ const TOOL_SCOPE_REQUIREMENTS: Record<string, GitLabScope[]> = {
   // Pipelines
   browse_pipelines: ['api', 'read_api'],
   manage_pipeline: ['api'],
-  manage_pipeline_job: ['api'],
 
   // Variables
   browse_variables: ['api', 'read_api'],

--- a/tests/unit/entities/pipelines/registry.test.ts
+++ b/tests/unit/entities/pipelines/registry.test.ts
@@ -40,13 +40,13 @@ describe('Pipelines Registry - CQRS Tools', () => {
       expect(pipelinesToolRegistry instanceof Map).toBe(true);
     });
 
-    it('should contain exactly 3 CQRS tools', () => {
+    it('should contain exactly 2 CQRS tools', () => {
       const toolNames = Array.from(pipelinesToolRegistry.keys());
 
       expect(toolNames).toContain('browse_pipelines');
       expect(toolNames).toContain('manage_pipeline');
-      expect(toolNames).toContain('manage_pipeline_job');
-      expect(pipelinesToolRegistry.size).toBe(3);
+      expect(toolNames).not.toContain('manage_pipeline_job');
+      expect(pipelinesToolRegistry.size).toBe(2);
     });
 
     it('should have tools with valid structure', () => {
@@ -84,7 +84,7 @@ describe('Pipelines Registry - CQRS Tools', () => {
       expect(tool?.inputSchema).toBeDefined();
     });
 
-    it('should have proper manage_pipeline tool', () => {
+    it('should have proper manage_pipeline tool with pipeline + job actions', () => {
       const tool = pipelinesToolRegistry.get('manage_pipeline');
 
       expect(tool).toBeDefined();
@@ -93,19 +93,15 @@ describe('Pipelines Registry - CQRS Tools', () => {
       expect(tool?.description).toContain('create');
       expect(tool?.description).toContain('retry');
       expect(tool?.description).toContain('cancel');
+      // Job-level actions folded in (the _job suffix avoids colliding with retry/cancel)
+      expect(tool?.description).toContain('play_job');
+      expect(tool?.description).toContain('retry_job');
+      expect(tool?.description).toContain('cancel_job');
       expect(tool?.inputSchema).toBeDefined();
     });
 
-    it('should have proper manage_pipeline_job tool', () => {
-      const tool = pipelinesToolRegistry.get('manage_pipeline_job');
-
-      expect(tool).toBeDefined();
-      expect(tool?.name).toBe('manage_pipeline_job');
-      expect(tool?.description).toContain('individual CI/CD jobs');
-      expect(tool?.description).toContain('play');
-      expect(tool?.description).toContain('retry');
-      expect(tool?.description).toContain('cancel');
-      expect(tool?.inputSchema).toBeDefined();
+    it('should not register a separate manage_pipeline_job tool', () => {
+      expect(pipelinesToolRegistry.get('manage_pipeline_job')).toBeUndefined();
     });
   });
 
@@ -128,7 +124,6 @@ describe('Pipelines Registry - CQRS Tools', () => {
       const readOnlyTools = getPipelinesReadOnlyToolNames();
 
       expect(readOnlyTools).not.toContain('manage_pipeline');
-      expect(readOnlyTools).not.toContain('manage_pipeline_job');
     });
 
     it('should return exactly 1 read-only tool', () => {
@@ -155,10 +150,10 @@ describe('Pipelines Registry - CQRS Tools', () => {
       expect(definitions.length).toBe(pipelinesToolRegistry.size);
     });
 
-    it('should return all 3 CQRS tools from registry', () => {
+    it('should return all 2 CQRS tools from registry', () => {
       const definitions = getPipelinesToolDefinitions();
 
-      expect(definitions.length).toBe(3);
+      expect(definitions.length).toBe(2);
     });
 
     it('should return tool definitions with proper structure', () => {
@@ -179,7 +174,7 @@ describe('Pipelines Registry - CQRS Tools', () => {
       const allDefinitions = getPipelinesToolDefinitions();
 
       expect(allTools.length).toBe(allDefinitions.length);
-      expect(allTools.length).toBe(3);
+      expect(allTools.length).toBe(2);
     });
 
     it('should return only read-only tools in read-only mode', () => {
@@ -204,7 +199,6 @@ describe('Pipelines Registry - CQRS Tools', () => {
 
       for (const tool of readOnlyTools) {
         expect(tool.name).not.toBe('manage_pipeline');
-        expect(tool.name).not.toBe('manage_pipeline_job');
       }
     });
   });
@@ -225,7 +219,7 @@ describe('Pipelines Registry - CQRS Tools', () => {
 
   describe('Registry Consistency', () => {
     it('should have all expected CQRS tools', () => {
-      const expectedTools = ['browse_pipelines', 'manage_pipeline', 'manage_pipeline_job'];
+      const expectedTools = ['browse_pipelines', 'manage_pipeline'];
 
       for (const toolName of expectedTools) {
         expect(pipelinesToolRegistry.has(toolName)).toBe(true);
@@ -247,7 +241,7 @@ describe('Pipelines Registry - CQRS Tools', () => {
       const readOnlyCount = getPipelinesReadOnlyToolNames().length;
 
       expect(totalTools).toBeGreaterThan(readOnlyCount);
-      expect(totalTools).toBe(3);
+      expect(totalTools).toBe(2);
       expect(readOnlyCount).toBe(1);
     });
   });
@@ -1207,7 +1201,7 @@ describe('Pipelines Registry - CQRS Tools', () => {
       });
     });
 
-    describe('manage_pipeline_job handler - play action', () => {
+    describe('manage_pipeline handler - play_job action', () => {
       it('should play manual job', async () => {
         const mockJob = {
           id: 1,
@@ -1216,9 +1210,9 @@ describe('Pipelines Registry - CQRS Tools', () => {
         };
         mockEnhancedFetch.mockResolvedValueOnce(mockResponse(mockJob) as never);
 
-        const tool = pipelinesToolRegistry.get('manage_pipeline_job')!;
+        const tool = pipelinesToolRegistry.get('manage_pipeline')!;
         const result = await tool.handler({
-          action: 'play',
+          action: 'play_job',
           project_id: 'test/project',
           job_id: '1',
         });
@@ -1240,9 +1234,9 @@ describe('Pipelines Registry - CQRS Tools', () => {
         const mockJob = { id: 1, name: 'deploy', status: 'running' };
         mockEnhancedFetch.mockResolvedValueOnce(mockResponse(mockJob) as never);
 
-        const tool = pipelinesToolRegistry.get('manage_pipeline_job')!;
+        const tool = pipelinesToolRegistry.get('manage_pipeline')!;
         await tool.handler({
-          action: 'play',
+          action: 'play_job',
           project_id: 'test/project',
           job_id: '1',
           job_variables_attributes: [{ key: 'ENVIRONMENT', value: 'production' }],
@@ -1256,7 +1250,7 @@ describe('Pipelines Registry - CQRS Tools', () => {
       });
     });
 
-    describe('manage_pipeline_job handler - retry action', () => {
+    describe('manage_pipeline handler - retry_job action', () => {
       it('should retry failed job', async () => {
         const mockJob = {
           id: 1,
@@ -1265,9 +1259,9 @@ describe('Pipelines Registry - CQRS Tools', () => {
         };
         mockEnhancedFetch.mockResolvedValueOnce(mockResponse(mockJob) as never);
 
-        const tool = pipelinesToolRegistry.get('manage_pipeline_job')!;
+        const tool = pipelinesToolRegistry.get('manage_pipeline')!;
         const result = await tool.handler({
-          action: 'retry',
+          action: 'retry_job',
           project_id: 'test/project',
           job_id: '1',
         });
@@ -1282,7 +1276,7 @@ describe('Pipelines Registry - CQRS Tools', () => {
       });
     });
 
-    describe('manage_pipeline_job handler - cancel action', () => {
+    describe('manage_pipeline handler - cancel_job action', () => {
       it('should cancel running job', async () => {
         const mockJob = {
           id: 1,
@@ -1291,9 +1285,9 @@ describe('Pipelines Registry - CQRS Tools', () => {
         };
         mockEnhancedFetch.mockResolvedValueOnce(mockResponse(mockJob) as never);
 
-        const tool = pipelinesToolRegistry.get('manage_pipeline_job')!;
+        const tool = pipelinesToolRegistry.get('manage_pipeline')!;
         const result = await tool.handler({
-          action: 'cancel',
+          action: 'cancel_job',
           project_id: 'test/project',
           job_id: '1',
         });
@@ -1311,9 +1305,9 @@ describe('Pipelines Registry - CQRS Tools', () => {
         const mockJob = { id: 1, name: 'build', status: 'canceled' };
         mockEnhancedFetch.mockResolvedValueOnce(mockResponse(mockJob) as never);
 
-        const tool = pipelinesToolRegistry.get('manage_pipeline_job')!;
+        const tool = pipelinesToolRegistry.get('manage_pipeline')!;
         await tool.handler({
-          action: 'cancel',
+          action: 'cancel_job',
           project_id: 'test/project',
           job_id: '1',
           force: true,
@@ -1364,17 +1358,14 @@ describe('Pipelines Registry - CQRS Tools', () => {
         await expect(tool.handler({ action: 'retry', project_id: 'test' })).rejects.toThrow();
       });
 
-      it('should handle schema validation errors for manage_pipeline_job', async () => {
-        const tool = pipelinesToolRegistry.get('manage_pipeline_job')!;
-
-        // Missing required action
-        await expect(tool.handler({})).rejects.toThrow();
+      it('should handle schema validation errors for manage_pipeline job actions', async () => {
+        const tool = pipelinesToolRegistry.get('manage_pipeline')!;
 
         // Invalid action
         await expect(tool.handler({ action: 'invalid', job_id: '1' })).rejects.toThrow();
 
-        // Missing job_id for play
-        await expect(tool.handler({ action: 'play', project_id: 'test' })).rejects.toThrow();
+        // Missing job_id for play_job
+        await expect(tool.handler({ action: 'play_job', project_id: 'test' })).rejects.toThrow();
       });
 
       it('should handle network errors', async () => {

--- a/tests/unit/entities/pipelines/registry.test.ts
+++ b/tests/unit/entities/pipelines/registry.test.ts
@@ -1250,57 +1250,28 @@ describe('Pipelines Registry - CQRS Tools', () => {
       });
     });
 
-    describe('manage_pipeline handler - retry_job action', () => {
-      it('should retry failed job', async () => {
-        const mockJob = {
-          id: 1,
-          name: 'test',
-          status: 'running',
-        };
+    // retry_job and cancel_job share the same shape: POST jobs/:id/<verb>, no body,
+    // returns the job. Parametrized so the identical assertion block lives once.
+    describe('manage_pipeline handler - simple job actions', () => {
+      it.each([
+        { action: 'retry_job', verb: 'retry' },
+        { action: 'cancel_job', verb: 'cancel' },
+      ])('$action POSTs to jobs/:id/$verb and returns the job', async ({ action, verb }) => {
+        const mockJob = { id: 1, name: 'test', status: 'running' };
         mockEnhancedFetch.mockResolvedValueOnce(mockResponse(mockJob) as never);
 
         const tool = pipelinesToolRegistry.get('manage_pipeline')!;
-        const result = await tool.handler({
-          action: 'retry_job',
-          project_id: 'test/project',
-          job_id: '1',
-        });
+        const result = await tool.handler({ action, project_id: 'test/project', job_id: '1' });
 
         expect(mockEnhancedFetch).toHaveBeenCalledWith(
-          'https://gitlab.example.com/api/v4/projects/test%2Fproject/jobs/1/retry',
-          {
-            method: 'POST',
-          },
+          `https://gitlab.example.com/api/v4/projects/test%2Fproject/jobs/1/${verb}`,
+          { method: 'POST' },
         );
         expect(result).toEqual(mockJob);
       });
     });
 
-    describe('manage_pipeline handler - cancel_job action', () => {
-      it('should cancel running job', async () => {
-        const mockJob = {
-          id: 1,
-          name: 'build',
-          status: 'canceled',
-        };
-        mockEnhancedFetch.mockResolvedValueOnce(mockResponse(mockJob) as never);
-
-        const tool = pipelinesToolRegistry.get('manage_pipeline')!;
-        const result = await tool.handler({
-          action: 'cancel_job',
-          project_id: 'test/project',
-          job_id: '1',
-        });
-
-        expect(mockEnhancedFetch).toHaveBeenCalledWith(
-          'https://gitlab.example.com/api/v4/projects/test%2Fproject/jobs/1/cancel',
-          {
-            method: 'POST',
-          },
-        );
-        expect(result).toEqual(mockJob);
-      });
-
+    describe('manage_pipeline handler - cancel_job force option', () => {
       it('should cancel job with force option', async () => {
         const mockJob = { id: 1, name: 'build', status: 'canceled' };
         mockEnhancedFetch.mockResolvedValueOnce(mockResponse(mockJob) as never);


### PR DESCRIPTION
## Summary

Folds the three job-level write actions into `manage_pipeline` and removes the separate `manage_pipeline_job` tool, mirroring the single `browse_pipelines` reader (which already has 6 actions). This is the one clean tool-count reduction in the catalog.

`manage_pipeline` now exposes: `create`, `retry`, `cancel`, `play_job`, `retry_job`, `cancel_job`.

Job actions are renamed with a `_job` suffix so they don't collide with the pipeline-level `retry` / `cancel`.

## Changes

- **schema**: job branches folded into `ManagePipelineSchema`; `ManagePipelineJobSchema` removed.
- **registry**: the three job handler cases merged into `manage_pipeline`; `manage_pipeline_job` no longer registered; descriptions updated.
- dropped `manage_pipeline_job` from the `TokenScopeDetector` scope map, the CLI tool/category lists, and the setup preset.
- docs updated (`docs/tools/index.md.in`, `docs/tools/ci-cd.md`, `docs/public/llms.txt.in`, the CI debug-failure prompt) to the new action names.
- unit tests updated; tool count **59 -> 58**, `browse_pipelines`(6) and `manage_pipeline`(6) symmetric.

## Breaking change

The `manage_pipeline_job` tool is removed. Callers must switch to `manage_pipeline` with `play_job` / `retry_job` / `cancel_job` (previously `manage_pipeline_job` with `play` / `retry` / `cancel`).

BREAKING CHANGE: the manage_pipeline_job tool is removed; use manage_pipeline with the play_job / retry_job / cancel_job actions instead.

## Testing

- Full suite green: 5135 unit tests, 443 integration tests, clean build and lint.
- Read-only mode still blocks all `manage_pipeline` actions; `USE_PIPELINE=false` hides the merged tool; `yarn list-tools` reports 58.

## Out of scope

The `mcp.tools` manifest in `package.json` is independently stale (missing ~15 previously-merged tools and never auto-regenerated). Tracked separately in #484 to keep this PR scoped to the consolidation rather than bundling unrelated manifest additions.

Closes #475