### PR TITLE
ci(release): auto-sync generated MCP manifest into the release PR

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -35,6 +35,7 @@ jobs:
       release-tag: ${{ steps.release.outputs.tag_name }}
       release-sha: ${{ steps.release.outputs.sha }}
       pr-number: ${{ steps.release.outputs.pr != '' && fromJSON(steps.release.outputs.pr).number || '' }}
+      pr-branch: ${{ steps.release.outputs.pr != '' && fromJSON(steps.release.outputs.pr).headBranchName || '' }}
 
     steps:
       - name: Generate release token
@@ -216,7 +217,82 @@ jobs:
       - name: Publish to MCP Registry
         run: ./mcp-publisher publish
 
-  # Job 3: Summary
+  # Job 3: Sync generated metadata into the open release PR
+  # When release-please updates (not merges) the release PR, regenerate the
+  # dynamic artifacts (package.json MCP manifest + tool counts, README counts,
+  # server.json description) and commit them onto the PR branch so the committed
+  # state always matches what will be published — alongside the version bump and
+  # CHANGELOG that already live on that branch.
+  #
+  # Loop-safe: this pushes to the release PR branch, and the workflow only triggers
+  # on push to main, so the commit never re-triggers the workflow. release-please
+  # may rebuild its PR branch on the next push to main; this job re-runs then and
+  # re-applies the metadata, so the PR is current whenever it is merged.
+  sync-release-pr:
+    name: Sync generated metadata into release PR
+    runs-on: ubuntu-latest
+    needs: release-please
+    if: needs.release-please.outputs.pr-number != '' && needs.release-please.outputs.release-created != 'true'
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Generate release token
+        uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          app-id: ${{ secrets.RELEASER_APP_ID }}
+          private-key: ${{ secrets.RELEASER_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+
+      - name: Checkout release PR branch
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.release-please.outputs.pr-branch }}
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Install Yarn
+        run: corepack prepare yarn@4.12.0 --activate
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Generate Prisma client
+        run: yarn prisma generate
+
+      - name: Build project
+        run: yarn build
+
+      # release-please already bumped package.json version on the PR branch;
+      # use it so README/server.json counts carry the pending release version.
+      - name: Regenerate dynamic metadata
+        run: ./scripts/prepare-release.sh "$(jq -r .version package.json)"
+
+      - name: Commit regenerated metadata to the release PR
+        run: |
+          git config user.name "structured-world-releaser[bot]"
+          git config user.email "structured-world-releaser[bot]@users.noreply.github.com"
+          # Only the committed dynamic artifacts. .semantic-release-version is a
+          # release-time-only file and must not be committed.
+          git add package.json README.md server.json
+          if git diff --cached --quiet; then
+            echo "No metadata drift; nothing to commit."
+          else
+            git commit -m "chore: sync generated tool metadata"
+            git push origin "HEAD:${{ needs.release-please.outputs.pr-branch }}"
+          fi
+
+  # Job 4: Summary
   summary:
     name: Release Summary
     runs-on: ubuntu-latest

--- a/scripts/update-mcp-manifest.js
+++ b/scripts/update-mcp-manifest.js
@@ -13,8 +13,8 @@
  * The script also updates mcp.description with the current tool count.
  */
 
-const fs = require("fs");
-const path = require("path");
+const fs = require('fs');
+const path = require('path');
 
 /**
  * Read all input from stdin
@@ -22,16 +22,16 @@ const path = require("path");
  */
 function readStdin() {
   return new Promise((resolve, reject) => {
-    let data = "";
-    process.stdin.setEncoding("utf8");
-    process.stdin.on("readable", () => {
+    let data = '';
+    process.stdin.setEncoding('utf8');
+    process.stdin.on('readable', () => {
       let chunk;
       while ((chunk = process.stdin.read()) !== null) {
         data += chunk;
       }
     });
-    process.stdin.on("end", () => resolve(data));
-    process.stdin.on("error", reject);
+    process.stdin.on('end', () => resolve(data));
+    process.stdin.on('error', reject);
   });
 }
 
@@ -43,53 +43,68 @@ function readStdin() {
 function extractCategory(toolName) {
   // Map tool prefixes/patterns to categories
   const categoryMap = {
-    browse_projects: "Projects",
-    manage_project: "Projects",
-    browse_namespaces: "Projects",
-    manage_namespace: "Projects",
-    browse_commits: "Repository",
-    browse_events: "Activity",
-    browse_users: "Users",
-    browse_todos: "Activity",
-    manage_todos: "Activity",
-    browse_merge_requests: "Merge Requests",
-    browse_mr_discussions: "Merge Requests",
-    manage_merge_request: "Merge Requests",
-    manage_mr_discussion: "Merge Requests",
-    manage_draft_notes: "Merge Requests",
-    browse_files: "Repository",
-    manage_files: "Repository",
-    browse_milestones: "Planning",
-    manage_milestone: "Planning",
-    browse_pipelines: "CI/CD",
-    manage_pipeline: "CI/CD",
-    manage_pipeline_job: "CI/CD",
-    browse_variables: "CI/CD",
-    manage_variable: "CI/CD",
-    browse_wiki: "Content",
-    manage_wiki: "Content",
-    browse_work_items: "Planning",
-    manage_work_item: "Planning",
-    browse_labels: "Planning",
-    manage_label: "Planning",
-    browse_snippets: "Content",
-    manage_snippet: "Content",
-    browse_webhooks: "Integrations",
-    manage_webhook: "Integrations",
-    browse_integrations: "Integrations",
-    manage_integration: "Integrations",
-    browse_releases: "Releases",
-    manage_release: "Releases",
-    browse_refs: "Repository",
-    manage_ref: "Repository",
-    browse_members: "Access",
-    manage_member: "Access",
-    browse_search: "Discovery",
-    browse_iterations: "Planning",
-    manage_context: "Session",
+    browse_projects: 'Projects',
+    manage_project: 'Projects',
+    browse_namespaces: 'Projects',
+    manage_namespace: 'Projects',
+    browse_commits: 'Repository',
+    browse_events: 'Activity',
+    browse_users: 'Users',
+    browse_todos: 'Activity',
+    manage_todos: 'Activity',
+    browse_merge_requests: 'Merge Requests',
+    browse_mr_discussions: 'Merge Requests',
+    manage_merge_request: 'Merge Requests',
+    manage_mr_discussion: 'Merge Requests',
+    manage_draft_notes: 'Merge Requests',
+    browse_files: 'Repository',
+    manage_files: 'Repository',
+    browse_milestones: 'Planning',
+    manage_milestone: 'Planning',
+    browse_pipelines: 'CI/CD',
+    manage_pipeline: 'CI/CD',
+    manage_pipeline_job: 'CI/CD',
+    browse_variables: 'CI/CD',
+    manage_variable: 'CI/CD',
+    browse_job_token_scope: 'CI/CD',
+    manage_job_token_scope: 'CI/CD',
+    browse_deploy_keys: 'CI/CD',
+    manage_deploy_key: 'CI/CD',
+    browse_environments: 'CI/CD',
+    manage_environment: 'CI/CD',
+    browse_runners: 'CI/CD',
+    manage_runner: 'CI/CD',
+    browse_registry: 'CI/CD',
+    manage_registry: 'CI/CD',
+    browse_access_tokens: 'Access',
+    manage_access_token: 'Access',
+    browse_audit_events: 'Security',
+    browse_vulnerabilities: 'Security',
+    manage_vulnerability: 'Security',
+    browse_wiki: 'Content',
+    manage_wiki: 'Content',
+    browse_work_items: 'Planning',
+    manage_work_item: 'Planning',
+    browse_labels: 'Planning',
+    manage_label: 'Planning',
+    browse_snippets: 'Content',
+    manage_snippet: 'Content',
+    browse_webhooks: 'Integrations',
+    manage_webhook: 'Integrations',
+    browse_integrations: 'Integrations',
+    manage_integration: 'Integrations',
+    browse_releases: 'Releases',
+    manage_release: 'Releases',
+    browse_refs: 'Repository',
+    manage_ref: 'Repository',
+    browse_members: 'Access',
+    manage_member: 'Access',
+    browse_search: 'Discovery',
+    browse_iterations: 'Planning',
+    manage_context: 'Session',
   };
 
-  return categoryMap[toolName] || "General";
+  return categoryMap[toolName] || 'General';
 }
 
 /**
@@ -98,7 +113,7 @@ function extractCategory(toolName) {
  * @returns {boolean}
  */
 function isReadOnly(toolName) {
-  return toolName.startsWith("browse_") || toolName === "manage_context";
+  return toolName.startsWith('browse_') || toolName === 'manage_context';
 }
 
 /**
@@ -108,7 +123,7 @@ function isReadOnly(toolName) {
  */
 function transformTool(tool) {
   // Normalize tier: "unknown" means tool has no tier requirement, treat as "free"
-  const tier = tool.tier && tool.tier !== "unknown" ? tool.tier : "free";
+  const tier = tool.tier && tool.tier !== 'unknown' ? tool.tier : 'free';
 
   return {
     name: tool.name,
@@ -125,10 +140,10 @@ function transformTool(tool) {
  * @returns {string} - First sentence or truncated description
  */
 function truncateDescription(description) {
-  if (!description) return "";
+  if (!description) return '';
 
   // Remove "Related:" section
-  const relatedIndex = description.indexOf("Related:");
+  const relatedIndex = description.indexOf('Related:');
   let clean = relatedIndex > 0 ? description.substring(0, relatedIndex).trim() : description;
 
   // Take first sentence
@@ -139,14 +154,14 @@ function truncateDescription(description) {
 
   // Truncate if too long
   if (clean.length > 200) {
-    return clean.substring(0, 197) + "...";
+    return clean.substring(0, 197) + '...';
   }
 
   return clean;
 }
 
 async function main() {
-  const packageJsonPath = path.resolve(process.cwd(), "package.json");
+  const packageJsonPath = path.resolve(process.cwd(), 'package.json');
 
   // Read tools from stdin
   let toolsJson;
@@ -154,27 +169,27 @@ async function main() {
     const input = await readStdin();
     if (!input.trim()) {
       console.error(
-        "Error: No input received. Usage: yarn list-tools --json | node scripts/update-mcp-manifest.js"
+        'Error: No input received. Usage: yarn list-tools --json | node scripts/update-mcp-manifest.js',
       );
       process.exit(1);
     }
     toolsJson = JSON.parse(input);
   } catch (error) {
-    console.error("Error parsing tools JSON:", error.message);
+    console.error('Error parsing tools JSON:', error.message);
     process.exit(1);
   }
 
   if (!Array.isArray(toolsJson)) {
-    console.error("Error: Expected array of tools");
+    console.error('Error: Expected array of tools');
     process.exit(1);
   }
 
   // Read package.json
   let pkg;
   try {
-    pkg = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
+    pkg = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
   } catch (error) {
-    console.error("Error reading package.json:", error.message);
+    console.error('Error reading package.json:', error.message);
     process.exit(1);
   }
 
@@ -204,24 +219,24 @@ async function main() {
 
   // Write updated package.json
   try {
-    fs.writeFileSync(packageJsonPath, JSON.stringify(pkg, null, 2) + "\n");
+    fs.writeFileSync(packageJsonPath, JSON.stringify(pkg, null, 2) + '\n');
   } catch (error) {
-    console.error("Error writing package.json:", error.message);
+    console.error('Error writing package.json:', error.message);
     process.exit(1);
   }
 
   console.log(
-    `MCP manifest updated: ${transformedTools.length} tools (${readOnlyCount} read-only), ${entityCount} categories`
+    `MCP manifest updated: ${transformedTools.length} tools (${readOnlyCount} read-only), ${entityCount} categories`,
   );
   console.log(
-    "Categories:",
+    'Categories:',
     Object.entries(categoryCounts)
       .map(([k, v]) => `${k}(${v})`)
-      .join(", ")
+      .join(', '),
   );
 }
 
 main().catch((error) => {
-  console.error("Fatal error:", error);
+  console.error('Fatal error:', error);
   process.exit(1);
 });


### PR DESCRIPTION
## Summary

Makes the generated dynamic metadata self-maintaining and committed in sync with each release, and fixes tool categorization.

The MCP tool manifest in `package.json` (`mcp.tools` + `mcp.description` count), the README counts, and the `server.json` description are all generated from the registry. They were regenerated only in the post-release job for the published tarball and never committed back, so the committed copies drifted (listed 43 vs 58 real tools) and recently-added tools were categorized as `General`.

## Changes

1. **`sync-release-pr` job** in `release-please.yml`: when release-please creates/updates the release PR (not on merge/release), it checks out the PR branch, rebuilds the dynamic artifacts via `prepare-release.sh` (using the pending version release-please already bumped), and commits `package.json` / `README.md` / `server.json` onto that branch — next to the version bump and CHANGELOG. The committed state now always matches what gets published.
2. **categoryMap completion** in `scripts/update-mcp-manifest.js`: runners, registry, deploy-keys, job-token-scope, environments -> `CI/CD`; access-tokens -> `Access`; audit-events, vulnerabilities -> `Security`. Verified by a local dry-run: `CI/CD(14), Access(4), Security(3)`, zero `General`.

## Why this shape (not commit-back-on-merge or a CI drift check)

The changelog + version bump already live committed on the release-please PR branch; the generated json belongs on the same branch so the repo state is consistent at merge. A merge-time-only regeneration leaves git stale between releases; a drift check just nags for a manual regen. This keeps it automatic and correct, tied to the release.

**Loop-safe:** the job pushes to the release PR branch; the workflow only triggers on `push: main`, so it never re-triggers itself. If release-please rebuilds its PR branch on a later push to main, this job re-runs and re-applies the metadata, so the PR is current whenever merged.

## Testing

- Workflow YAML validated; `yarn lint` clean; `yarn build` clean.
- Manifest regeneration dry-run produces correct categories and 58-tool count.
- The release-flow job itself cannot be exercised locally; it runs on the next release-please PR after merge (self-bootstrapping).
- No `src/` changes -> unit/integration suites unaffected.

Closes #484