### PR TITLE
ci: add weekly upstream monitor + expand CodeRabbit config

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,5 +1,47 @@
 # yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+language: 'en-US'
 reviews:
+  profile: 'assertive'
+  request_changes_workflow: false
+  high_level_summary: true
+  review_status: true
+  collapse_walkthrough: true
+  assess_linked_issues: true
+  related_issues: true
+  related_prs: true
+  suggested_labels: true
+  auto_review:
+    enabled: true
+    auto_incremental_review: true
+    drafts: false
+    base_branches: ['main']
+    ignore_title_keywords: ['WIP', 'DO NOT MERGE']
+  path_instructions:
+    - path: 'src/**/*.ts'
+      instructions: |
+        TypeScript strict mode is on. No `any` — define proper interfaces.
+        No eslint-disable comments — fix the underlying issue with typing.
+        Validate external data (API responses, user input, config) with Zod at boundaries.
+        MCP agentic design: one tool call = one complete task; hide API limitations from the agent.
+    - path: 'src/entities/**/registry.ts'
+      instructions: |
+        Entity registries are the CQRS tool implementations (browse_*/manage_* pairs).
+        Verify Zod discriminated-union schema validation on every action.
+        Tool descriptions must be agent-focused (WHAT not HOW) — no GraphQL/REST internals.
+        Typed GraphQL responses (TypedDocumentNode) are trusted; Zod is for input + untyped REST.
+    - path: 'tests/unit/**'
+      instructions: |
+        Tests must validate real behavior, not just pass. No weakened assertions.
+        No fixed dynamic values (IDs, IIDs, timestamps) — assert structure/types or store created IDs.
+    - path: 'tests/integration/**'
+      instructions: |
+        Integration tests follow the data-lifecycle pattern: create in dependency order,
+        clean up in reverse (best-effort try/catch). Use the test/ root group only.
+        Tier-gated suites use describeIfTier(...). No destructive ops against real data.
+    - path: 'docs/**'
+      instructions: |
+        Check documentation accuracy against current code. Edit the .in templates,
+        not the generated outputs. Verify code examples are valid.
   tools:
     # Disabled: CodeRabbit cannot install ESLint in its sandbox for this repo
     # (engines.node >=24, ESLint 10, and Yarn 4 without a package-lock), which
@@ -7,3 +49,44 @@ reviews:
     # locally (yarn lint) and in CI before merge, so nothing is lost here.
     eslint:
       enabled: false
+    markdownlint:
+      enabled: true
+    github-checks:
+      enabled: true
+      timeout_ms: 120000
+chat:
+  auto_reply: true
+knowledge_base:
+  learnings:
+    scope: auto
+  issues:
+    scope: auto
+  pull_requests:
+    scope: auto
+  code_guidelines:
+    enabled: true
+    filePatterns:
+      - '.github/copilot-instructions.md'
+      - 'CONTRIBUTING.md'
+issue_enrichment:
+  labeling:
+    auto_apply_labels: true
+    labeling_instructions:
+      - label: 'bug'
+        instructions: 'Code defect, incorrect behavior'
+      - label: 'enhancement'
+        instructions: 'New feature, new MCP tool, new capability'
+      - label: 'performance'
+        instructions: 'Optimization, caching, reduced latency'
+      - label: 'refactor'
+        instructions: 'Code restructuring without behavior change'
+      - label: 'test'
+        instructions: 'New tests, test infrastructure, coverage'
+      - label: 'ci'
+        instructions: 'CI/CD workflows, Docker, release automation'
+      - label: 'upstream-sync'
+        instructions: 'Upstream synchronization and cherry-picks'
+      - label: 'upstream-candidate'
+        instructions: 'Can be contributed back to zereight upstream'
+      - label: 'fork-only'
+        instructions: 'Structured World specific, not for upstream'

--- a/.github/workflows/upstream-monitor.yml
+++ b/.github/workflows/upstream-monitor.yml
@@ -1,0 +1,70 @@
+# Upstream Monitor — weekly intelligence on zereight/gitlab-mcp
+#
+# This fork is heavily diverged (different version scheme, different feature set,
+# published as @structured-world/gitlab-mcp). It is NEVER auto-merged. This
+# workflow only WATCHES upstream and opens a digest issue when there is new
+# activity, so a human can decide what to cherry-pick / port.
+
+name: Upstream Monitor
+
+on:
+  schedule:
+    - cron: '0 8 * * 1' # weekly, Monday 08:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: upstream-monitor
+  cancel-in-progress: false
+
+jobs:
+  digest:
+    name: Upstream digest
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+
+      - name: Fetch upstream
+        run: |
+          git remote add upstream https://github.com/zereight/gitlab-mcp.git
+          git fetch --no-tags upstream main
+          git fetch upstream 'refs/tags/*:refs/tags/upstream-*' || true
+
+      - name: Generate digest
+        id: digest
+        run: |
+          node scripts/upstream-digest.mjs 7 > digest.json
+          echo "has_activity=$(node -e 'process.stdout.write(String(require("./digest.json").hasActivity))')" >> "$GITHUB_OUTPUT"
+          node -e 'process.stdout.write(require("./digest.json").title)' > digest-title.txt
+          node -e 'process.stdout.write(require("./digest.json").body)' > digest-body.md
+
+      - name: Open digest issue
+        if: steps.digest.outputs.has_activity == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh label create upstream-digest --color 0e8a16 \
+            --description "Weekly upstream activity digest (monitor-only)" 2>/dev/null || true
+          gh issue create \
+            --title "$(cat digest-title.txt)" \
+            --body-file digest-body.md \
+            --label upstream-digest
+
+      - name: No activity
+        if: steps.digest.outputs.has_activity != 'true'
+        run: echo "No new upstream commits in the last 7 days; no digest issue created."

--- a/scripts/upstream-digest.mjs
+++ b/scripts/upstream-digest.mjs
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+/**
+ * Upstream digest generator (monitor-only).
+ *
+ * Summarizes new commits on the upstream `zereight/gitlab-mcp` main branch within
+ * a time window and categorizes them so a human can decide what to cherry-pick.
+ * This fork is heavily diverged and is NEVER auto-merged — this is intelligence
+ * only.
+ *
+ * Prereq: an `upstream` remote pointing at zereight/gitlab-mcp must be fetched
+ * (`git remote add upstream ...; git fetch upstream main --tags`).
+ *
+ * Usage: node scripts/upstream-digest.mjs <sinceDays>
+ * Output: a single JSON object on stdout: { hasActivity, title, body }.
+ *   - hasActivity=false when no new upstream commits in the window (caller skips
+ *     creating a digest issue to avoid alert fatigue).
+ */
+
+import { execSync } from 'node:child_process';
+
+const UPSTREAM_SLUG = 'zereight/gitlab-mcp';
+const sinceDays = Number.parseInt(process.argv[2] ?? '7', 10) || 7;
+const since = `${sinceDays} days ago`;
+
+function git(args) {
+  try {
+    return execSync(`git ${args}`, {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+  } catch {
+    return '';
+  }
+}
+
+/** Parse `<sha>\t<subject>` lines into commit records (short sha + subject). */
+function parseCommits(raw) {
+  if (!raw) return [];
+  return raw.split('\n').map((line) => {
+    const tab = line.indexOf('\t');
+    return { sha: line.slice(0, tab).slice(0, 7), subject: line.slice(tab + 1) };
+  });
+}
+
+/** Turn a trailing PR ref like "(#382)" into an upstream-qualified link. */
+function linkSubject(subject) {
+  return subject.replace(/\(#(\d+)\)/g, (_m, n) => `(${UPSTREAM_SLUG}#${n})`);
+}
+
+const SECURITY_RE = /security|CVE-|vuln|sanitiz|injection|XSS|SSRF|RCE|auth bypass/i;
+
+/** Bucket a commit by conventional-commit type + security heuristics. */
+function categorize({ subject }) {
+  if (SECURITY_RE.test(subject)) return 'security';
+  if (/^feat(\(|!|:)/i.test(subject)) return 'feat';
+  if (/^fix(\(|!|:)/i.test(subject)) return 'fix';
+  if (/^docs(\(|:)/i.test(subject)) return 'docs';
+  return 'other';
+}
+
+const commits = parseCommits(
+  git(`log upstream/main --no-merges --since="${since}" --pretty=format:%H%x09%s`),
+);
+
+if (commits.length === 0) {
+  process.stdout.write(JSON.stringify({ hasActivity: false, title: '', body: '' }));
+  process.exit(0);
+}
+
+const buckets = { security: [], feat: [], fix: [], docs: [], other: [] };
+for (const c of commits) buckets[categorize(c)].push(c);
+
+// Latest upstream tag reachable from upstream/main (release intelligence).
+// Upstream tags are fetched under an `upstream-` namespace to avoid clobbering
+// this fork's own release tags; strip it for display.
+const latestTag = git('describe --tags --abbrev=0 upstream/main').replace(/^upstream-/, '');
+
+const today = git('log -1 --format=%cs upstream/main') || new Date().toISOString().slice(0, 10);
+
+const section = (emoji, heading, list, note) => {
+  if (list.length === 0) return '';
+  const lines = list.map((c) => `- \`${c.sha}\` ${linkSubject(c.subject)}`).join('\n');
+  return `\n### ${emoji} ${heading}${note ? ` ${note}` : ''}\n${lines}\n`;
+};
+
+const body =
+  `## Upstream digest — last ${sinceDays} days (as of ${today})\n\n` +
+  `Upstream: [\`${UPSTREAM_SLUG}\`](https://github.com/${UPSTREAM_SLUG})` +
+  (latestTag ? ` · latest tag \`${latestTag}\`` : '') +
+  `\nNew commits on \`upstream/main\`: **${commits.length}**\n` +
+  section('🔒', 'Security (cherry-pick recommended)', buckets.security) +
+  section('✨', 'New features / tools (evaluate)', buckets.feat) +
+  section('🐛', 'Bug fixes (cherry-pick candidates)', buckets.fix) +
+  section('📝', 'Docs', buckets.docs) +
+  section('📦', 'Other', buckets.other) +
+  `\n### Action needed\n` +
+  `- [ ] Review security fixes for cherry-pick\n` +
+  `- [ ] Evaluate new features/tools — do we already have equivalents?\n` +
+  `- [ ] Cherry-pick relevant bug fixes (paths differ from this fork — port, don't merge)\n` +
+  `- [ ] Close this issue when reviewed\n\n` +
+  `> Monitor-only: this fork is heavily diverged and is never auto-merged.\n`;
+
+const title = `Upstream digest: ${commits.length} new commit${commits.length === 1 ? '' : 's'}${latestTag ? ` (latest ${latestTag})` : ''} — ${today}`;
+
+process.stdout.write(JSON.stringify({ hasActivity: true, title, body }));


### PR DESCRIPTION
## Summary

Adds upstream-change intelligence for this heavily-diverged fork and expands the CodeRabbit configuration.

### Upstream monitor (monitor-only)

This fork is hundreds of commits diverged from `zereight/gitlab-mcp`, published separately, and is **never** auto-merged. So this is intelligence only — no auto-merge PRs.

- **`.github/workflows/upstream-monitor.yml`** — runs **weekly (Mon 08:00 UTC)** + manual `workflow_dispatch`. Fetches upstream read-only (`persist-credentials: false`), runs the digest generator, and opens a single issue labelled `upstream-digest` **only when there is new upstream activity** (avoids alert fatigue).
- **`scripts/upstream-digest.mjs`** — categorizes new `upstream/main` commits into security / features / bug fixes / docs / other, links `(#NNN)` PR refs to the upstream repo, reports the latest upstream tag, and frames security/fixes as cherry-pick candidates (paths differ across the fork — port, don't merge). Dependency-free; verified locally against the live upstream.

Loop-safety / scope: the workflow only reads upstream and writes a digest issue; it never pushes or merges.

### CodeRabbit config

Extended `.coderabbit.yaml`:
- **kept `eslint: enabled: false`** (CodeRabbit can't install ESLint in its sandbox for this repo; ESLint still runs in `yarn lint` + CI) — preserves the prior decision rather than re-enabling it as the issue draft suggested.
- added `path_instructions` for `src/**`, entity registries, unit/integration tests, and docs — adapted to this repo's actual layout (`tests/`, `registry.ts`), not the draft's `src/__tests__/` / `handler*.ts`.
- added issue-labeling instructions and knowledge-base guideline files (`.github/copilot-instructions.md`, `CONTRIBUTING.md`).
- did **not** enable the biome tool (repo uses eslint+prettier, no biome config).

## Testing

- Both YAML files validated.
- `upstream-digest.mjs` run locally against fetched `zereight/gitlab-mcp`: correct categorization, PR links, and latest-tag detection; `hasActivity=false` path returns cleanly with no commits in window.
- Workflow itself runs on schedule/dispatch (not locally executable); logic and YAML verified.

Closes #357