### PR TITLE
ci: auto-sync generated metadata to main on drift

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -91,6 +91,84 @@ jobs:
           path: dist/
           retention-days: 1
 
+  # Job: keep generated metadata (README counts, server.json description,
+  # package.json MCP manifest) in sync on main. README.md is a committed file
+  # GitHub renders from the repo, so it must physically hold current counts —
+  # unlike the docs site, which regenerates an ephemeral Pages artifact on every
+  # deploy. Counts come from the built registry via prepare-release.sh.
+  #
+  # Runs ONLY on push to main (never on PRs). Reconciles against the actual
+  # post-merge state, so it self-heals regardless of merge order. Pushes ONLY
+  # when there is real drift (git diff guard) — empty/no-op pushes never happen.
+  # The commit carries [skip ci], so the sync push never re-triggers this
+  # workflow or release-please: no loop.
+  sync-metadata:
+    name: Sync generated metadata
+    runs-on: ubuntu-latest
+    needs: [quality-checks]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+
+    permissions:
+      contents: write
+
+    steps:
+      # App token (not GITHUB_TOKEN) so the push can bypass branch protection on
+      # main. Same releaser app used by release-please.yml.
+      - name: Generate release token
+        uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          app-id: ${{ secrets.RELEASER_APP_ID }}
+          private-key: ${{ secrets.RELEASER_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+
+      - name: Checkout main
+        uses: actions/checkout@v6
+        with:
+          ref: main
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Install Yarn
+        run: corepack prepare yarn@4.12.0 --activate
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Generate Prisma client
+        run: yarn prisma generate
+
+      - name: Build project
+        run: yarn build
+
+      # Use the currently released version from package.json (release-please bumps
+      # it only inside the release PR), so server.json version does not spuriously
+      # drift here — only the tool/action/entity counts can change.
+      - name: Regenerate metadata
+        run: ./scripts/prepare-release.sh "$(jq -r .version package.json)"
+
+      # Push ONLY on real drift. .semantic-release-version is release-time-only
+      # (gitignored) and never staged.
+      - name: Commit and push on drift
+        run: |
+          git config user.name "structured-world-releaser[bot]"
+          git config user.email "structured-world-releaser[bot]@users.noreply.github.com"
+          git add README.md server.json package.json
+          if git diff --cached --quiet; then
+            echo "No metadata drift; nothing to push."
+            exit 0
+          fi
+          git commit -m "chore: sync generated metadata [skip ci]"
+          git push origin HEAD:main
+
   # Legacy required status check - reports quality-checks result for branch protection
   # Added to support migration from old "Lint, Test & Build" ruleset requirement
   expected-status:

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 [![npm version](https://img.shields.io/npm/v/@structured-world/gitlab-mcp)](https://www.npmjs.com/package/@structured-world/gitlab-mcp) [![npm downloads](https://img.shields.io/npm/dm/@structured-world/gitlab-mcp)](https://www.npmjs.com/package/@structured-world/gitlab-mcp) [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE) [![Release](https://github.com/structured-world/gitlab-mcp/workflows/Release/badge.svg)](https://github.com/structured-world/gitlab-mcp/actions) [![Coverage](https://codecov.io/gh/structured-world/gitlab-mcp/graph/badge.svg)](https://codecov.io/gh/structured-world/gitlab-mcp) [![Coverage Report](https://img.shields.io/badge/Coverage-Live%20Report-brightgreen?logo=github)](https://gitlab-mcp.sw.foundation/coverage/)
 
-Advanced GitLab MCP server — 50 CQRS tools exposing 193 GitLab operations across 21 entity types. The tool catalog and parameters are filtered to each instance's GitLab version, tier, and token scopes, so the agent sees only what the connected instance actually supports.
+Advanced GitLab MCP server — 58 CQRS tools exposing 230 GitLab operations across 26 entity types. The tool catalog and parameters are filtered to each instance's GitLab version, tier, and token scopes, so the agent sees only what the connected instance actually supports.
 
-[![Install in Claude Desktop](https://img.shields.io/badge/Claude_Desktop-Install_Extension-F97316?style=for-the-badge)](https://gitlab-mcp.sw.foundation/downloads/gitlab-mcp-7.6.0.mcpb)
+[![Install in Claude Desktop](https://img.shields.io/badge/Claude_Desktop-Install_Extension-F97316?style=for-the-badge)](https://gitlab-mcp.sw.foundation/downloads/gitlab-mcp-8.0.0.mcpb)
 [![Install in VS Code](https://img.shields.io/badge/VS_Code-Install_MCP_Server-007ACC?style=for-the-badge&logo=visualstudiocode&logoColor=white)](vscode:mcp/install?%7B%22name%22%3A%22gitlab-mcp%22%2C%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22%40structured-world%2Fgitlab-mcp%22%5D%7D)
 [![Install in VS Code Insiders](https://img.shields.io/badge/VS_Code_Insiders-Install_MCP_Server-24bfa5?style=for-the-badge&logo=visualstudiocode&logoColor=white)](vscode-insiders:mcp/install?%7B%22name%22%3A%22gitlab-mcp%22%2C%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22%40structured-world%2Fgitlab-mcp%22%5D%7D)
 
@@ -29,7 +29,7 @@ Advanced GitLab MCP server — 50 CQRS tools exposing 193 GitLab operations acro
 
 ## Highlights
 
-- **50 tools** across 21 entity types — projects, merge requests, pipelines, work items, wiki, and more
+- **58 tools** across 26 entity types — projects, merge requests, pipelines, work items, wiki, and more
 - **CQRS architecture** — `browse_*` for queries, `manage_*` for commands
 - **Connection resilience** — Bounded startup, auto-reconnect with exponential backoff, disconnected mode when GitLab is unreachable
 - **Multi-instance support** — Connect to GitLab.com, self-managed, and self-hosted instances with per-instance OAuth and rate limiting
@@ -44,8 +44,8 @@ Advanced GitLab MCP server — 50 CQRS tools exposing 193 GitLab operations acro
 
 GitLab exposes hundreds of API operations. Giving each its own MCP tool floods an
 agent's context; a thin API wrapper pushes that complexity back onto the agent. This
-server takes a third path: 50 CQRS tools, each holding several typed
-actions, expose 193 operations across 21 entity types.
+server takes a third path: 58 CQRS tools, each holding several typed
+actions, expose 230 operations across 26 entity types.
 
 - `browse_*` tools are read-only queries; `manage_*` tools are writes.
 - Sub-resources fold into actions rather than new tools — `browse_pipelines` covers
@@ -70,7 +70,7 @@ Full documentation is available at **[gitlab-mcp.sw.foundation](https://gitlab-m
 | [Installation](https://gitlab-mcp.sw.foundation/guide/installation/npm) | npm, Docker, VS Code, Codex |
 | [Configuration](https://gitlab-mcp.sw.foundation/guide/configuration) | Environment variables, feature flags |
 | [Multi-Instance](https://gitlab-mcp.sw.foundation/guide/multi-instance) | Connect to multiple GitLab instances |
-| [Tool Reference](https://gitlab-mcp.sw.foundation/tools/) | All 50 tools with parameters |
+| [Tool Reference](https://gitlab-mcp.sw.foundation/tools/) | All 58 tools with parameters |
 | [OAuth Setup](https://gitlab-mcp.sw.foundation/security/oauth) | Team authentication with Claude |
 | [TLS/HTTPS](https://gitlab-mcp.sw.foundation/advanced/tls) | Production deployment with SSL |
 | [Customization](https://gitlab-mcp.sw.foundation/advanced/customization) | Tool descriptions, action filtering |

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "description": "Advanced GitLab MCP server",
   "mcp": {
     "name": "GitLab MCP Server",
-    "description": "Advanced GitLab MCP server - 44 tools across 13 entity types with CQRS architecture, OAuth 2.1, and multiple transport modes",
+    "description": "Advanced GitLab MCP server - 58 tools across 14 entity types with CQRS architecture, OAuth 2.1, and multiple transport modes",
     "repository": "https://github.com/structured-world/gitlab-mcp",
     "homepage": "https://gitlab-mcp.sw.foundation",
     "author": "Dmitry Prudnikov",
@@ -230,14 +230,7 @@
       },
       {
         "name": "manage_pipeline",
-        "description": "Trigger, retry, or cancel CI/CD pipelines.",
-        "category": "CI/CD",
-        "tier": "free",
-        "readOnly": false
-      },
-      {
-        "name": "manage_pipeline_job",
-        "description": "Control individual CI/CD jobs within a pipeline.",
+        "description": "Trigger, retry, or cancel CI/CD pipelines and individual jobs.",
         "category": "CI/CD",
         "tier": "free",
         "readOnly": false
@@ -381,6 +374,111 @@
         "category": "Planning",
         "tier": "free",
         "readOnly": true
+      },
+      {
+        "name": "browse_job_token_scope",
+        "description": "Inspect a project CI/CD job token inbound access scope.",
+        "category": "CI/CD",
+        "tier": "free",
+        "readOnly": true
+      },
+      {
+        "name": "manage_job_token_scope",
+        "description": "Manage a project CI/CD job token inbound allowlist.",
+        "category": "CI/CD",
+        "tier": "free",
+        "readOnly": false
+      },
+      {
+        "name": "browse_deploy_keys",
+        "description": "List and inspect deploy keys (SSH keys granting repo access to CI/automation).",
+        "category": "CI/CD",
+        "tier": "free",
+        "readOnly": true
+      },
+      {
+        "name": "manage_deploy_key",
+        "description": "Add, enable, update, or remove project deploy keys.",
+        "category": "CI/CD",
+        "tier": "free",
+        "readOnly": false
+      },
+      {
+        "name": "browse_environments",
+        "description": "Inspect project environments and their deployments.",
+        "category": "CI/CD",
+        "tier": "free",
+        "readOnly": true
+      },
+      {
+        "name": "manage_environment",
+        "description": "Create and control project environments and deployment status.",
+        "category": "CI/CD",
+        "tier": "free",
+        "readOnly": false
+      },
+      {
+        "name": "browse_registry",
+        "description": "Inspect the GitLab Container Registry.",
+        "category": "CI/CD",
+        "tier": "free",
+        "readOnly": true
+      },
+      {
+        "name": "manage_registry",
+        "description": "Delete GitLab Container Registry repositories and tags.",
+        "category": "CI/CD",
+        "tier": "free",
+        "readOnly": false
+      },
+      {
+        "name": "browse_access_tokens",
+        "description": "Inspect access tokens (CI/automation credentials).",
+        "category": "Access",
+        "tier": "free",
+        "readOnly": true
+      },
+      {
+        "name": "manage_access_token",
+        "description": "Create, rotate, or revoke access tokens.",
+        "category": "Access",
+        "tier": "free",
+        "readOnly": false
+      },
+      {
+        "name": "browse_runners",
+        "description": "Inspect CI runners.",
+        "category": "CI/CD",
+        "tier": "free",
+        "readOnly": true
+      },
+      {
+        "name": "manage_runner",
+        "description": "Register and control CI runners.",
+        "category": "CI/CD",
+        "tier": "free",
+        "readOnly": false
+      },
+      {
+        "name": "browse_audit_events",
+        "description": "Inspect audit events: the immutable record of who did what, when.",
+        "category": "Security",
+        "tier": "free",
+        "readOnly": true
+      },
+      {
+        "name": "browse_vulnerabilities",
+        "description": "Inspect security vulnerabilities (Ultimate).",
+        "category": "Security",
+        "tier": "free",
+        "readOnly": true
+      },
+      {
+        "name": "manage_vulnerability",
+        "description": "Drive the vulnerability state machine (Ultimate).",
+        "category": "Security",
+        "tier": "free",
+        "readOnly": false
       }
     ]
   },

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "$comment": "Schema version 2025-12-11 is the current MCP Registry standard. Only essential env vars are exposed here; USE_* feature flags are documented at websiteUrl and available via MCPB toggles.",
   "name": "io.github.structured-world/gitlab-mcp",
   "title": "Advanced GitLab MCP server",
-  "description": "GitLab MCP server with 44 tools for projects, MRs, pipelines, and more",
+  "description": "GitLab MCP server with 58 tools for projects, MRs, pipelines, and more",
   "websiteUrl": "https://gitlab-mcp.sw.foundation",
   "repository": {
     "url": "https://github.com/structured-world/gitlab-mcp",


### PR DESCRIPTION
## Summary

`README.md`, `server.json` description, and the `package.json` MCP manifest are generated from the built registry (tool/action/entity counts). They were regenerated post-release for the npm tarball but never committed back, so the copies on `main` drifted: npm 8.0.0 README says **58 tools / 230 operations / 26 entities**, while `main` (and the v8.0.0 tag) still said **50 / 193 / 21**.

The docs site never drifts because `docs.yml` regenerates an ephemeral Pages artifact on every deploy. `README.md` is different: GitHub renders it from the committed file, so it must physically hold the current numbers.

## Changes

1. **New `sync-metadata` job** in `ci-cd.yml`, runs **only on push to `main`**:
   - rebuilds the registry, runs `prepare-release.sh "$(jq -r .version package.json)"` (current released version, so server.json version does not spuriously drift)
   - pushes to `main` **ONLY when there is real drift** (`git diff --cached --quiet` guard) — no empty/no-op pushes
   - commit subject carries `[skip ci]`, so the sync push never re-triggers CI or release-please: no loop
   - reconciles against the actual post-merge state of `main`, so it self-heals regardless of merge order
2. **Regenerate current stale metadata** so `main` is correct immediately: 50 -> 58 tools, 193 -> 230 operations, 21 -> 26 entities, and the MCPB download badge 7.6.0 -> 8.0.0.

## Prerequisite

The releaser GitHub App (`RELEASER_APP_ID`) must be allowed to push directly to protected `main` (bypass) — the same token release-please already uses. If the app lacks bypass, the push step fails loudly (no silent drift).

## Why not a per-PR drift guard

A per-PR check races on the global tool count: a PR opened against an older main passes its own check, then merges stale. Post-merge reconciliation against actual main state avoids this entirely.

## Testing

- `yarn build` + `prepare-release.sh` produce 58 / 230 / 26; only README/server.json/package.json change
- workflow YAML validated (`yaml.safe_load`)
- `yarn lint` clean
- `sync-release-pr` in release-please.yml left intact as a no-op safety net

Closes #489