### PR TITLE
ci(release): lock gitlab-mcp-db to the gitlab-mcp version

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,4 @@
 {
   "packages/gitlab-mcp": "8.0.0",
-  "packages/gitlab-mcp-db": "0.0.0"
+  "packages/gitlab-mcp-db": "8.0.0"
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,6 +2,14 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "node",
   "separate-pull-requests": false,
+  "group-pull-request-title-pattern": "chore: release ${version}",
+  "plugins": [
+    {
+      "type": "linked-versions",
+      "groupName": "gitlab-mcp",
+      "components": ["gitlab-mcp", "gitlab-mcp-db"]
+    }
+  ],
   "changelog-sections": [
     { "type": "feat", "section": "Features" },
     { "type": "fix", "section": "Bug Fixes" },
@@ -29,8 +37,8 @@
     "packages/gitlab-mcp-db": {
       "component": "gitlab-mcp-db",
       "changelog-path": "CHANGELOG.md",
-      "bump-minor-pre-major": true,
-      "bump-patch-for-minor-pre-major": true
+      "bump-minor-pre-major": false,
+      "bump-patch-for-minor-pre-major": false
     }
   }
 }


### PR DESCRIPTION
## Summary

`gitlab-mcp-db` is the same product as `gitlab-mcp` with the PostgreSQL backend split into an optional package — the two must always ship the **same** version. The release-please setup let them drift; this enforces lockstep.

## Changes

- **Manifest:** `packages/gitlab-mcp-db` was tracked at `0.0.0` (its `package.json` is already `8.0.0`). Set to `8.0.0` so it releases on the `8.x` line instead of a separate `0.0.x` one.
- **`linked-versions` plugin:** groups `gitlab-mcp` + `gitlab-mcp-db` so they always bump together to the same next version.
- **Bump rules:** aligned the db package with core (`bump-minor-pre-major` / `bump-patch-for-minor-pre-major` -> `false`).
- **Title:** `group-pull-request-title-pattern: "chore: release ${version}"` so the combined release PR shows the shared version instead of the generic `chore: release main`.

## Effect

After merge, release-please regenerates the open release PR with both packages on the same version and the version in its title. Component tags (`gitlab-mcp-v*`, `gitlab-mcp-db-v*`) share the same number.

Closes #500

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package version alignment across components.
  * Enhanced release configuration to streamline the release process with grouped pull requests and synchronized versioning across related packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->