### PR TITLE
ci(release): add root version anchor so post-release publishes and the PR title shows the version

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,5 @@
 {
+  ".": "8.0.0",
   "packages/gitlab-mcp": "8.0.0",
   "packages/gitlab-mcp-db": "8.0.0"
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,7 +7,7 @@
     {
       "type": "linked-versions",
       "groupName": "gitlab-mcp",
-      "components": ["gitlab-mcp", "gitlab-mcp-db"]
+      "components": ["gitlab-mcp-monorepo", "gitlab-mcp", "gitlab-mcp-db"]
     }
   ],
   "changelog-sections": [
@@ -24,6 +24,11 @@
     { "type": "chore", "section": "Chores", "hidden": true }
   ],
   "packages": {
+    ".": {
+      "component": "gitlab-mcp-monorepo",
+      "include-component-in-tag": false,
+      "changelog-path": "CHANGELOG.md"
+    },
     "packages/gitlab-mcp": {
       "component": "gitlab-mcp",
       "changelog-path": "CHANGELOG.md",


### PR DESCRIPTION
## Problem

`release-please.yml`'s `post-release` job (npm / Docker / MCPB / MCP Registry) is gated on the **bare** action outputs (`release-created`, `release-version`, `release-tag`). Per the release-please-action docs, those are emitted **only when a root (`.`) component exists** — with only nested packages they are empty, so on the first monorepo release `if: '' == 'true'` is false and **nothing would publish**. This is latent (no release merged yet).

## Fix

Add a root version anchor:

- `.release-please-manifest.json`: `".": "8.0.0"`.
- Config `.` package: `component: gitlab-mcp-monorepo`, `include-component-in-tag: false` (clean `v<version>` umbrella tag), root `CHANGELOG.md`.
- Include the root component in `linked-versions` so all three stay in lockstep.

This populates the bare outputs (post-release runs, checks out the umbrella tag, uploads the MCPB bundles), and supplies `${version}` to the combined release-PR title.

## Verified with a real dry-run

`release-please release-pr --dry-run` against this branch:

```
✔ Building candidate release pull request for path: .
✔ Building candidate release pull request for path: packages/gitlab-mcp
✔ Building candidate release pull request for path: packages/gitlab-mcp-db
✔ Merging 3 pull requests → Would open 1 pull requests
title: chore: release 9.0.0
```

- One combined PR, title `chore: release 9.0.0` (version in the title).
- All three components lockstep at the same version.
- 9.0.0 (major) because of the breaking changes since 8.0.0 (nx split, OAuth env rename).

## Side effects (intended)

- A root `CHANGELOG.md` (umbrella product changelog).
- The root `package.json` (private orchestrator) version bumps with the product.
- An umbrella `v<version>` tag/release that hosts the MCPB bundles; per-package tags (`gitlab-mcp-v*`, `gitlab-mcp-db-v*`) still drive npm/Docker.

Closes #502

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release management configuration to coordinate versioning across repository components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->