### PR TITLE
ci(release): rewrite db's workspace dependency so the published package resolves

### DIFF
--- a/packages/gitlab-mcp-db/package.json
+++ b/packages/gitlab-mcp-db/package.json
@@ -21,14 +21,12 @@
     "prisma": "^7.8.0"
   },
   "devDependencies": {
+    "@structured-world/gitlab-mcp": "workspace:^",
     "@types/jest": "^30.0.0",
     "@types/node": "^25.9.2",
     "jest": "^30.4.2",
     "ts-jest": "^29.4.11",
     "typescript": "^6.0.0"
-  },
-  "peerDependencies": {
-    "@structured-world/gitlab-mcp": "workspace:^"
   },
   "publishConfig": {
     "access": "public"

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,6 +8,10 @@
       "type": "linked-versions",
       "groupName": "gitlab-mcp",
       "components": ["gitlab-mcp-monorepo", "gitlab-mcp", "gitlab-mcp-db"]
+    },
+    {
+      "type": "node-workspace",
+      "updatePeerDependencies": true
     }
   ],
   "changelog-sections": [

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,12 +5,12 @@
   "group-pull-request-title-pattern": "chore: release ${version}",
   "plugins": [
     {
+      "type": "node-workspace"
+    },
+    {
       "type": "linked-versions",
       "groupName": "gitlab-mcp",
       "components": ["gitlab-mcp-monorepo", "gitlab-mcp", "gitlab-mcp-db"]
-    },
-    {
-      "type": "node-workspace"
     }
   ],
   "changelog-sections": [

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -10,8 +10,7 @@
       "components": ["gitlab-mcp-monorepo", "gitlab-mcp", "gitlab-mcp-db"]
     },
     {
-      "type": "node-workspace",
-      "updatePeerDependencies": true
+      "type": "node-workspace"
     }
   ],
   "changelog-sections": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -2110,18 +2110,17 @@ __metadata:
   resolution: "@structured-world/gitlab-mcp-db@workspace:packages/gitlab-mcp-db"
   dependencies:
     "@prisma/client": "npm:^7.8.0"
+    "@structured-world/gitlab-mcp": "workspace:^"
     "@types/jest": "npm:^30.0.0"
     "@types/node": "npm:^25.9.2"
     jest: "npm:^30.4.2"
     prisma: "npm:^7.8.0"
     ts-jest: "npm:^29.4.11"
     typescript: "npm:^6.0.0"
-  peerDependencies:
-    "@structured-world/gitlab-mcp": "workspace:^"
   languageName: unknown
   linkType: soft
 
-"@structured-world/gitlab-mcp@workspace:packages/gitlab-mcp":
+"@structured-world/gitlab-mcp@workspace:^, @structured-world/gitlab-mcp@workspace:packages/gitlab-mcp":
   version: 0.0.0-use.local
   resolution: "@structured-world/gitlab-mcp@workspace:packages/gitlab-mcp"
   dependencies:


### PR DESCRIPTION
## Problem

`packages/gitlab-mcp-db` declared its core dependency as `peerDependencies['@structured-world/gitlab-mcp'] = "workspace:^"`. The release publish job uses plain `npm publish` (required for OIDC provenance), which does **not** resolve Yarn's `workspace:` protocol — the published manifest would ship the literal `workspace:^` range, which consumers cannot resolve.

## Fix

- **Move the core dependency to `devDependencies`.** It is a build-time, type-only dependency (db imports core's storage contract type; core lazy-loads db at runtime, not the reverse), so `devDependencies` is the correct place, and it gives the `node-workspace` plugin a graph edge to process.
- **Add the `node-workspace` plugin**, ordered **before** `linked-versions`. `linked-versions` merges the per-component releases into one group; if it ran first, `node-workspace` found no individual releases to process and the merged PR was dropped (verified: it produced 0 PRs). Running `node-workspace` first rewrites the `workspace:` range before grouping.

## Verified with a real dry-run

`release-please release-pr --dry-run` against this branch:

```
running plugin: NodeWorkspace
✔ Found 3 in-scope releases → Merging 3 in-scope candidates → Post-processing 1
running plugin: LinkedVersions
running plugin: Merge
Would open 1 pull requests
title: chore: release 9.0.0

gitlab-mcp-db: 9.0.0
  * devDependencies
    * @structured-world/gitlab-mcp bumped to 9.0.0
```

- One combined PR, title `chore: release 9.0.0`, all components lockstep.
- db's `@structured-world/gitlab-mcp` dependency is rewritten from `workspace:^` to `9.0.0` in the release commit, so the published package is valid.

`yarn workspace @structured-world/gitlab-mcp-db build` passes with core as a devDependency.

## Still required (one-time, your action)

npm OIDC trusted publishing must be configured for the new `@structured-world/gitlab-mcp-db` package on npmjs.com, or its first publish will fail on auth.

Closes #504

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development dependencies and release automation configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->