### PR TITLE
fix(db): add repository field for npm provenance

### DIFF
--- a/packages/gitlab-mcp-db/package.json
+++ b/packages/gitlab-mcp-db/package.json
@@ -3,6 +3,11 @@
   "version": "9.0.0",
   "description": "Optional PostgreSQL/Prisma OAuth-storage backend for @structured-world/gitlab-mcp",
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/structured-world/gitlab-mcp",
+    "directory": "packages/gitlab-mcp-db"
+  },
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",


### PR DESCRIPTION
## Problem

The 9.0.0 `post-release` job published **core** to npm but **failed on `@structured-world/gitlab-mcp-db`**:

```
npm error 422 — Error verifying sigstore provenance bundle:
package.json: "repository.url" is "", expected "https://github.com/structured-world/gitlab-mcp" from provenance
```

`npm publish --provenance` requires a `repository` field. Core has one; db did not. The sequential job then **skipped** both Docker images, both MCPB bundles, and the MCP Registry publish.

## Fix

Add `repository` to `packages/gitlab-mcp-db/package.json` (matching core, with the monorepo `directory`).

## Release impact

This is the only blocker to db getting npm provenance. Merging it lets the next release publish db with provenance. See the PR discussion for completing the partial 9.0.0 publish.

Closes #506

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package metadata for improved project documentation and organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->