### PR TITLE
fix(release): resolve workspace: deps before publishing db to npm

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -137,6 +137,18 @@ jobs:
             echo "Db ${VERSION} already published to npm; skipping."
             exit 0
           fi
+          # Resolve any Yarn workspace: specifier to the real (lockstep) version.
+          # Plain `npm publish` (used for OIDC provenance) does not understand the
+          # workspace: protocol, so it would otherwise ship an invalid range.
+          jq --arg v "^${VERSION}" '
+            def resolve_ws:
+              if . then with_entries(
+                if (.value | type == "string") and (.value | startswith("workspace:"))
+                then .value = $v else . end) else . end;
+            .dependencies |= resolve_ws
+            | .devDependencies |= resolve_ws
+            | .peerDependencies |= resolve_ws
+          ' package.json > package.json.tmp && mv package.json.tmp package.json
           npm publish --provenance --access public
 
       # Build and upload both MCPB bundles (lightweight core + full with db)

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -141,13 +141,12 @@ jobs:
           # Plain `npm publish` (used for OIDC provenance) does not understand the
           # workspace: protocol, so it would otherwise ship an invalid range.
           jq --arg v "^${VERSION}" '
-            def resolve_ws:
-              if . then with_entries(
-                if (.value | type == "string") and (.value | startswith("workspace:"))
-                then .value = $v else . end) else . end;
-            .dependencies |= resolve_ws
-            | .devDependencies |= resolve_ws
-            | .peerDependencies |= resolve_ws
+            def resolve_ws: with_entries(
+              if (.value | type == "string") and (.value | startswith("workspace:"))
+              then .value = $v else . end);
+            (if (.dependencies | type) == "object" then .dependencies |= resolve_ws else . end)
+            | (if (.devDependencies | type) == "object" then .devDependencies |= resolve_ws else . end)
+            | (if (.peerDependencies | type) == "object" then .peerDependencies |= resolve_ws else . end)
           ' package.json > package.json.tmp && mv package.json.tmp package.json
           npm publish --provenance --access public
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -34,7 +34,7 @@
     },
     "packages/gitlab-mcp": {
       "component": "gitlab-mcp",
-      "changelog-path": "CHANGELOG.md",
+      "skip-changelog": true,
       "bump-minor-pre-major": false,
       "bump-patch-for-minor-pre-major": false,
       "extra-files": [
@@ -44,7 +44,7 @@
     },
     "packages/gitlab-mcp-db": {
       "component": "gitlab-mcp-db",
-      "changelog-path": "CHANGELOG.md",
+      "skip-changelog": true,
       "bump-minor-pre-major": false,
       "bump-patch-for-minor-pre-major": false
     }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -34,7 +34,7 @@
     },
     "packages/gitlab-mcp": {
       "component": "gitlab-mcp",
-      "skip-changelog": true,
+      "changelog-path": "CHANGELOG.md",
       "bump-minor-pre-major": false,
       "bump-patch-for-minor-pre-major": false,
       "extra-files": [
@@ -44,7 +44,7 @@
     },
     "packages/gitlab-mcp-db": {
       "component": "gitlab-mcp-db",
-      "skip-changelog": true,
+      "changelog-path": "CHANGELOG.md",
       "bump-minor-pre-major": false,
       "bump-patch-for-minor-pre-major": false
     }


### PR DESCRIPTION
## Problem

`release-please-action@v5`'s bundled `node-workspace` does not rewrite Yarn's `workspace:` protocol (the standalone CLI does), so the generated release branch keeps:

```json
// packages/gitlab-mcp-db/package.json
"devDependencies": { "@structured-world/gitlab-mcp": "workspace:^" }
```

The publish job uses plain `npm publish` (required for OIDC provenance), which cannot resolve the `workspace:` protocol — `gitlab-mcp-db` would publish an invalid specifier.

## Fix

In the db publish step, before `npm publish`, rewrite any `workspace:` specifier (across dependencies / devDependencies / peerDependencies) to the real version `^<version>`. The packages are version-locked, so `^<version>` is correct. This is independent of the plugin, so it works regardless of the action's node-workspace behavior.

Verified locally — the jq rewrite turns `workspace:^` into `^9.0.1` and leaves other deps untouched.

## Sequence

Merge this **before** the `chore: release 9.0.1` PR (#508), so the 9.0.1 db publish resolves the specifier.

Closes #511

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented publishing of the database package with unresolved internal references, ensuring reliable installs from npm.

* **Chores**
  * Stopped automated changelog generation for two internal packages to centralize release notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->