### PR TITLE
fix(release): restore db package.json after publish

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -140,6 +140,10 @@ jobs:
           # Resolve any Yarn workspace: specifier to the real (lockstep) version.
           # Plain `npm publish` (used for OIDC provenance) does not understand the
           # workspace: protocol, so it would otherwise ship an invalid range.
+          # Restore package.json afterwards so the resolved range does not leak into
+          # later steps (the Docker build runs `yarn install --immutable` over the
+          # same tree, and a workspace:^ -> ^x.y.z drift fails the immutable check).
+          cp package.json package.json.orig
           jq --arg v "^${VERSION}" '
             def resolve_ws: with_entries(
               if (.value | type == "string") and (.value | startswith("workspace:"))
@@ -149,6 +153,7 @@ jobs:
             | (if (.peerDependencies | type) == "object" then .peerDependencies |= resolve_ws else . end)
           ' package.json > package.json.tmp && mv package.json.tmp package.json
           npm publish --provenance --access public
+          mv package.json.orig package.json
 
       # Build and upload both MCPB bundles (lightweight core + full with db)
       - name: Build MCPB bundles


### PR DESCRIPTION
## Problem

The db publish step resolves the `workspace:` specifier by rewriting `package.json` in place, but never restores it. The modified file persists in the working tree, so the subsequent **core Docker build** runs `yarn install --immutable` against a tree where db's `package.json` says `^<version>` while `yarn.lock` still says `workspace:^`:

```
YN0028: The lockfile would have been modified by this install, which is explicitly forbidden.
```

On the 9.0.1 release this published core npm, db npm (correctly resolved to `^9.0.1`), and both MCPB bundles — but failed both Docker images and the MCP Registry publish.

## Fix

Back up `package.json` before the jq rewrite and restore it right after `npm publish`, so the resolved range is used only for publishing and later steps see the original (workspace-locked) tree.

## Note

The 9.0.1 docker/registry publish is being completed by re-running the post-release job (db npm already published → its step skips → no rewrite → clean Docker build). This PR prevents the recurrence on future releases.

Closes #513

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated npm package publishing workflow to improve how package configuration is managed during dependency resolution steps. Enhanced process ensures downstream build validation and installation operations execute correctly without conflicts from resolved workspace dependencies in the release pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->