### PR TITLE
fix(release): stop the core MCPB glob from matching the db bundle

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -168,7 +168,7 @@ jobs:
         with:
           tag_name: ${{ needs.release-please.outputs.release-tag }}
           files: |
-            packages/gitlab-mcp/gitlab-mcp-*.mcpb
+            packages/gitlab-mcp/gitlab-mcp-[0-9]*.mcpb
             packages/gitlab-mcp/gitlab-mcp-db-*.mcpb
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Narrow the core MCPB glob to `gitlab-mcp-[0-9]*.mcpb` so it no longer also matches `gitlab-mcp-db-*.mcpb`. The overlap listed the db bundle twice, and on a re-run the upload action tried to delete the same asset twice (Not Found), blocking Docker and Registry publish.

Closes #516

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined release artifact handling to ensure only specific core MCPB bundles are attached to releases, improving precision in the release process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->