### PR TITLE
fix(release): one lockstep release PR titled with the version, no root anchor

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -30,10 +30,14 @@ jobs:
       pull-requests: write
 
     outputs:
-      release-created: ${{ steps.release.outputs.release_created }}
-      release-version: ${{ steps.release.outputs.version }}
-      release-tag: ${{ steps.release.outputs.tag_name }}
-      release-sha: ${{ steps.release.outputs.sha }}
+      # No root (".") component, so there are no bare release_created/version/tag
+      # outputs. Trigger on releases_created (any component) and take the
+      # version/tag from the core gitlab-mcp package (the two packages are
+      # version-locked, so its tag is the release reference for checkout + assets).
+      release-created: ${{ steps.release.outputs.releases_created }}
+      release-version: ${{ steps.release.outputs['packages/gitlab-mcp--version'] }}
+      release-tag: ${{ steps.release.outputs['packages/gitlab-mcp--tag_name'] }}
+      release-sha: ${{ steps.release.outputs['packages/gitlab-mcp--sha'] }}
       pr-number: ${{ steps.release.outputs.pr != '' && fromJSON(steps.release.outputs.pr).number || '' }}
       pr-branch: ${{ steps.release.outputs.pr != '' && fromJSON(steps.release.outputs.pr).headBranchName || '' }}
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -56,6 +56,20 @@ jobs:
         with:
           token: ${{ steps.app-token.outputs.token }}
 
+      # release-please cannot put the version in a combined multi-package PR title
+      # without a root "." component, and that component breaks lockstep on
+      # root-only changes. Set the title from the gitlab-mcp version instead -- the
+      # packages are version-locked, so it is the single release version.
+      - name: Put the release version in the combined PR title
+        if: steps.release.outputs.pr != ''
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_NUMBER: ${{ fromJSON(steps.release.outputs.pr).number }}
+          PR_BRANCH: ${{ fromJSON(steps.release.outputs.pr).headBranchName }}
+        run: |
+          VERSION="$(gh api "repos/${{ github.repository }}/contents/packages/gitlab-mcp/package.json?ref=${PR_BRANCH}" --jq '.content' | base64 -d | jq -r .version)"
+          gh pr edit "$PR_NUMBER" --title "chore: release ${VERSION}"
+
   # Job 2: Post-release — update artifacts, publish everywhere
   post-release:
     name: Post-Release Publish

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,4 @@
 {
-  ".": "9.0.2",
   "packages/gitlab-mcp": "9.0.1",
   "packages/gitlab-mcp-db": "9.0.1"
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,7 +2,6 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "node",
   "separate-pull-requests": false,
-  "group-pull-request-title-pattern": "chore: release ${version}",
   "plugins": [
     {
       "type": "node-workspace"
@@ -10,7 +9,7 @@
     {
       "type": "linked-versions",
       "groupName": "gitlab-mcp",
-      "components": ["gitlab-mcp-monorepo", "gitlab-mcp", "gitlab-mcp-db"]
+      "components": ["gitlab-mcp", "gitlab-mcp-db"]
     }
   ],
   "changelog-sections": [
@@ -27,11 +26,6 @@
     { "type": "chore", "section": "Chores", "hidden": true }
   ],
   "packages": {
-    ".": {
-      "component": "gitlab-mcp-monorepo",
-      "include-component-in-tag": false,
-      "changelog-path": "CHANGELOG.md"
-    },
     "packages/gitlab-mcp": {
       "component": "gitlab-mcp",
       "changelog-path": "CHANGELOG.md",


### PR DESCRIPTION
## Problem

The root `.` release-please component captured every commit, so a release triggered by root-only changes (CI/workflow/config) bumped only the anchor and left the packages behind — a desynced manifest and a phantom version with no tag/publish (`.` reached 9.0.2 while both packages stayed 9.0.1).

## Fix

- **Remove the root `.` anchor.** No component captures root-only commits anymore; the two packages release in lockstep via `linked-versions` (which force-syncs the group to the highest version) when a package changes.
- **Keep a single combined release PR** (`separate-pull-requests: false`).
- **Title the combined PR with the version.** release-please can't inject `${version}` into a combined PR title without a root component, so a workflow step reads the (version-locked) `gitlab-mcp` version from the PR branch and sets the title to `chore: release <version>`.
- **Publish workflow** now triggers on `releases_created` and reads the version/tag from the `gitlab-mcp` component outputs instead of the (now absent) bare root outputs.

## Verified

`release-please --dry-run` against this branch: the pending root-only/CI changes produce **0 release PRs** (no more phantom). A package change will produce one combined lockstep PR for both packages.

The desynced manifest is corrected here (both packages at 9.0.1, the real published version); the next package change releases cleanly.

Closes #518

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release automation configuration for improved multi-package release handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->