### PR TITLE
ci(release): resolve release PR by branch, not the absent pr output

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -38,8 +38,8 @@ jobs:
       release-version: ${{ steps.release.outputs['packages/gitlab-mcp--version'] }}
       release-tag: ${{ steps.release.outputs['packages/gitlab-mcp--tag_name'] }}
       release-sha: ${{ steps.release.outputs['packages/gitlab-mcp--sha'] }}
-      pr-number: ${{ steps.release.outputs.pr != '' && fromJSON(steps.release.outputs.pr).number || '' }}
-      pr-branch: ${{ steps.release.outputs.pr != '' && fromJSON(steps.release.outputs.pr).headBranchName || '' }}
+      pr-number: ${{ steps.relpr.outputs.number }}
+      pr-branch: ${{ steps.relpr.outputs.branch }}
 
     steps:
       - name: Generate release token
@@ -56,16 +56,36 @@ jobs:
         with:
           token: ${{ steps.app-token.outputs.token }}
 
-      # release-please cannot put the version in a combined multi-package PR title
-      # without a root "." component, and that component breaks lockstep on
+      # Without a root (".") component, release-please-action does not populate the
+      # aggregate `pr` output -- only per-package ones -- so the release PR must be
+      # resolved by its deterministic branch instead. The branch is empty when no
+      # release PR is open (e.g. right after a release merges, or a commit that
+      # produces no release), which downstream steps treat as "nothing to do".
+      - name: Resolve the open release PR
+        id: relpr
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          BRANCH="release-please--branches--${{ github.ref_name }}"
+          NUMBER="$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number // empty')"
+          if [ -n "$NUMBER" ]; then
+            echo "number=$NUMBER" >> "$GITHUB_OUTPUT"
+            echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+          else
+            echo "number=" >> "$GITHUB_OUTPUT"
+            echo "branch=" >> "$GITHUB_OUTPUT"
+          fi
+
+      # release-please cannot inject the version into a combined multi-package PR
+      # title without a root "." component, and that component breaks lockstep on
       # root-only changes. Set the title from the gitlab-mcp version instead -- the
       # packages are version-locked, so it is the single release version.
       - name: Put the release version in the combined PR title
-        if: steps.release.outputs.pr != ''
+        if: steps.relpr.outputs.number != ''
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          PR_NUMBER: ${{ fromJSON(steps.release.outputs.pr).number }}
-          PR_BRANCH: ${{ fromJSON(steps.release.outputs.pr).headBranchName }}
+          PR_NUMBER: ${{ steps.relpr.outputs.number }}
+          PR_BRANCH: ${{ steps.relpr.outputs.branch }}
         run: |
           VERSION="$(gh api "repos/${{ github.repository }}/contents/packages/gitlab-mcp/package.json?ref=${PR_BRANCH}" --jq '.content' | base64 -d | jq -r .version)"
           gh pr edit "$PR_NUMBER" --title "chore: release ${VERSION}"


### PR DESCRIPTION
## Summary

The release workflow failed on the merge of #491 ([run 27106198639](https://github.com/structured-world/gitlab-mcp/actions/runs/27106198639)). Root cause: after the root (`.`) component was removed to fix lockstep, `release-please-action@v5` stopped populating the aggregate `pr` output, but the workflow still depended on it in two places.

- **Title step** evaluated `fromJSON(steps.release.outputs.pr).number` in `env:`; with an empty `pr`, `fromJSON('')` threw `Error reading JToken from JsonReader` and failed the job. The step `if:` guard does not cover `env:` evaluation.
- **`pr-number` / `pr-branch` job outputs** resolved to empty, so the "Sync generated metadata into release PR" job was skipped and the PR title was never set.

## Fix

Resolve the release PR by its deterministic branch (`release-please--branches--<target>`) in a dedicated `Resolve the open release PR` step, and feed its outputs to the job outputs and the title step. No `fromJSON`, no dependency on the missing aggregate output.

- `gh pr list --head release-please--branches--${{ github.ref_name }} --state open` writes `number` / `branch` to `$GITHUB_OUTPUT` (empty when no PR is open).
- Title step gated on `steps.relpr.outputs.number != ''`.

## Testing

- `yaml.safe_load` parses; `actionlint` reports only pre-existing info-level SC2086 warnings in unrelated steps, none in the changed block.
- Behaviour: a merge that opens/updates a release PR retitles it `chore: release <version>` and runs metadata-sync; a merge with no release PR keeps the workflow green and skips the title/sync steps cleanly.

Closes #520

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release workflow to better detect and manage release PR title updates across different repository configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->