### PR TITLE
ci(release): set GH_REPO so PR steps work without a checkout

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -65,6 +65,9 @@ jobs:
         id: relpr
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          # This job has no checkout; without GH_REPO, gh falls back to local git
+          # detection and fails with "not a git repository".
+          GH_REPO: ${{ github.repository }}
         run: |
           BRANCH="release-please--branches--${{ github.ref_name }}"
           NUMBER="$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number // empty')"
@@ -84,6 +87,8 @@ jobs:
         if: steps.relpr.outputs.number != ''
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          # Same as above: no checkout in this job, so gh needs the repo explicitly.
+          GH_REPO: ${{ github.repository }}
           PR_NUMBER: ${{ steps.relpr.outputs.number }}
           PR_BRANCH: ${{ steps.relpr.outputs.branch }}
         run: |


### PR DESCRIPTION
## Summary

Follow-up to #521. The new `Resolve the open release PR` step failed on the next release run ([27106500343](https://github.com/structured-world/gitlab-mcp/actions/runs/27106500343)):

```
failed to run git: fatal: not a git repository (or any of the parent directories): .git
```

The `release-please` job runs no `actions/checkout`, so `gh pr list` (and `gh pr edit` in the title step) fell back to local git detection and failed.

## Fix

Set `GH_REPO: ${{ github.repository }}` on both the resolver and the title step so gh targets the repository explicitly through the API, no local clone needed. (The `gh api repos/<owner>/<repo>/...` call already used an explicit repo and was unaffected.)

## Testing

- `yaml.safe_load` parses; `actionlint` clean in the changed block (only pre-existing info-level SC2086 elsewhere).
- After merge: the release-please job resolves the open release PR by branch and retitles it without needing a checkout.

Closes #520

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release automation reliability by resolving repository context issues in the release workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->