### PR TITLE
fix(release): sync monorepo root package.json version

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -396,6 +396,13 @@ jobs:
       - name: Sync root package.json version
         run: |
           VERSION="$(jq -r .version packages/gitlab-mcp/package.json)"
+          # jq -r prints the literal "null" (exit 0) when .version is absent, which
+          # set -e does not catch -- guard so a missing version fails loud instead
+          # of committing "version": "null" into the root package.json.
+          if [ -z "$VERSION" ] || [ "$VERSION" = "null" ]; then
+            echo "Error: no version in packages/gitlab-mcp/package.json" >&2
+            exit 1
+          fi
           jq --arg v "$VERSION" '.version = $v' package.json > package.json.tmp
           mv package.json.tmp package.json
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -388,14 +388,26 @@ jobs:
         run: ./scripts/prepare-release.sh "$(jq -r .version package.json)"
         working-directory: packages/gitlab-mcp
 
+      # release-please does not manage the monorepo root package.json (the root
+      # "." component was removed in #519 because it broke lockstep, #518), so its
+      # version field would otherwise drift behind the packages. Mirror the locked
+      # release version into it here, on the same PR branch, so the merged root
+      # version always matches the published packages.
+      - name: Sync root package.json version
+        run: |
+          VERSION="$(jq -r .version packages/gitlab-mcp/package.json)"
+          jq --arg v "$VERSION" '.version = $v' package.json > package.json.tmp
+          mv package.json.tmp package.json
+
       - name: Commit regenerated metadata to the release PR
         working-directory: packages/gitlab-mcp
         run: |
           git config user.name "structured-world-releaser[bot]"
           git config user.email "structured-world-releaser[bot]@users.noreply.github.com"
           # Only the committed dynamic artifacts. .semantic-release-version is a
-          # release-time-only file and must not be committed.
-          git add package.json README.md server.json
+          # release-time-only file and must not be committed. The root
+          # package.json (../../) carries the mirrored release version.
+          git add package.json README.md server.json ../../package.json
           if git diff --cached --quiet; then
             echo "No metadata drift; nothing to commit."
           else


### PR DESCRIPTION
## Summary

The monorepo root `package.json` version drifted to `9.0.2` while the workspace packages (`packages/gitlab-mcp`, `packages/gitlab-mcp-db`) are at `9.1.0`.

Root cause: #519 (closes #518) removed the root `.` component from release-please because, as a managed component, it captured every commit (including CI/config-only changes), bumping the anchor while `linked-versions` left unchanged packages behind, desyncing the manifest and producing phantom versions. That fixed lockstep but left the root `version` field unmanaged, so it lags behind every package release.

## Change

Extend the existing `sync-release-pr` job in `.github/workflows/release-please.yml` to mirror the locked release version into the root `package.json`, and include the root file in the commit it already pushes to the release branch.

- Keeps the root out of release-please core components (lockstep preserved, no `extra-files` path-traversal outside the package).
- Uses the job that already runs on every push to main while a release is pending, so the merged root version always matches the published packages.

## Effect

This is a `fix(release):` change, so merging it triggers a release. The next release's sync run writes the locked version into the root `package.json`, ending the drift on merge.

## Testing

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release-please.yml'))"` passes.
- Logic mirrors the existing metadata-sync steps (plain `jq` + `git add`), which already run in this job.

Closes #525
